### PR TITLE
ci: trigger Render deploy after GHCR publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=tag
+            type=raw,value=latest
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -48,3 +49,54 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+
+  deploy-render:
+    name: Deploy to Render
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - name: Validate Render secrets
+        run: |
+          if [ -z "${{ secrets.RENDER_SERVICE_ID }}" ] || [ -z "${{ secrets.RENDER_API_KEY }}" ]; then
+            echo "RENDER_SERVICE_ID and RENDER_API_KEY secrets must be configured."
+            exit 1
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for image availability in GHCR
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          IMAGE_REPOSITORY="${REPOSITORY,,}"
+          IMAGE_TAG="ghcr.io/${IMAGE_REPOSITORY}:${REF_NAME}"
+          IMAGE_LATEST="ghcr.io/${IMAGE_REPOSITORY}:latest"
+
+          for image in "$IMAGE_TAG" "$IMAGE_LATEST"; do
+            echo "Checking availability for $image"
+            for attempt in {1..20}; do
+              if docker buildx imagetools inspect "$image" >/dev/null 2>&1; then
+                echo "$image is available."
+                break
+              fi
+              if [ "$attempt" -eq 20 ]; then
+                echo "Timed out waiting for $image."
+                exit 1
+              fi
+              echo "Waiting for $image to be available ($attempt/20)..."
+              sleep 15
+            done
+          done
+
+      - name: Deploy latest image on Render
+        uses: JorgeLNJunior/render-deploy@v1.5.0
+        with:
+          service_id: ${{ secrets.RENDER_SERVICE_ID }}
+          api_key: ${{ secrets.RENDER_API_KEY }}
+          wait_deploy: true


### PR DESCRIPTION
## Summary
- add `latest` tag to Docker publish metadata for release tags
- add `deploy-render` job that runs after successful image publish (`needs: docker`)
- verify image availability in GHCR before deployment trigger
- trigger Render deploy using `JorgeLNJunior/render-deploy@v1.5.0` with `wait_deploy: true`

## Notes
- requires repository secrets: `RENDER_SERVICE_ID` and `RENDER_API_KEY`
- designed to deploy the newest published image automatically after tag builds
