### PR TITLE
Update docs app for open-source beta launch

### DIFF
--- a/apps/docs/app/community/page.tsx
+++ b/apps/docs/app/community/page.tsx
@@ -19,7 +19,7 @@ export default function CommunityPage() {
         title="Community"
         subtitle="Join the developers improving BullMQ operations and sharing best practices."
         primaryCta={{ label: 'Follow on X', to: 'https://x.com/durabullhq' }}
-        secondaryCta={{ label: 'Contact the Team', to: '/contact' }}
+        secondaryCta={{ label: 'View on GitHub', to: 'https://github.com/durabullhq/durabull' }}
         sections={[
           {
             title: 'Office Hours',
@@ -27,7 +27,8 @@ export default function CommunityPage() {
           },
           {
             title: 'Open Source',
-            description: 'We plan to open source Durabull as the platform matures.',
+            description:
+              'Durabull is fully open source. Explore the codebase, self-host, and contribute on GitHub.',
           },
           {
             title: 'Community Stories',

--- a/apps/docs/app/pricing/page.tsx
+++ b/apps/docs/app/pricing/page.tsx
@@ -117,9 +117,9 @@ export default function PricingPage() {
                 },
                 {
                   icon: Sparkles,
-                  title: 'Open Source Intent',
+                  title: 'Open Source',
                   description:
-                    'We fully intend to open source Durabull. You can run authless mode and choose stateful (Postgres) or stateless (PGlite) persistence based on your needs.',
+                    'Durabull is fully open source and available on GitHub. You can run authless mode and choose stateful (Postgres) or stateless (PGlite) persistence based on your needs.',
                 },
               ].map((item) => (
                 <div

--- a/apps/docs/src/components/footer.tsx
+++ b/apps/docs/src/components/footer.tsx
@@ -57,12 +57,16 @@ export function Footer() {
               who demand reliability.
             </p>
             <div className="flex items-center gap-4">
-              <span
-                title="GitHub repository coming soon"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border/80 bg-secondary/70 text-muted-foreground/70"
+              <a
+                href="https://github.com/durabullhq/durabull"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Durabull on GitHub"
+                title="Durabull GitHub repository"
+                className="rounded-lg bg-secondary p-2 transition-colors duration-200 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
-                <Github className="h-5 w-5" aria-hidden="true" />
-              </span>
+                <Github className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+              </a>
               <a
                 href="https://x.com/durabullhq"
                 target="_blank"


### PR DESCRIPTION
## Summary
- add a live GitHub link in the docs footer social icons
- update Community page copy to reflect that Durabull is now fully open source
- replace open-source intent language on Pricing page with current open-source availability

## Validation
- bun run --filter @durabull/docs format
- bun run --filter @durabull/docs lint
- bun run --filter @durabull/docs typecheck