### PR TITLE
fix(docker): include tooling/scripts in Render image

### DIFF
--- a/tooling/docker/Dockerfile
+++ b/tooling/docker/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 FROM base AS prune
 RUN bun add -g turbo
 COPY . .
-RUN turbo prune @durabull/api @durabull/web --docker
+RUN turbo prune @durabull/api @durabull/web @durabull/scripts --docker
 
 # -----------------------------------------------------------------------------
 # Deps: Install all dependencies (for building)


### PR DESCRIPTION
## Summary
- include @durabull/scripts in the turbo prune targets used by the Docker build
- ensure tooling/scripts is present in /app/tooling in deployed Render containers

## Root cause
The Docker prune stage only targeted @durabull/api and @durabull/web, so @durabull/scripts was excluded from out/full and omitted from the final image.

## Validation
- ran: turbo prune @durabull/api @durabull/web @durabull/scripts --docker
- verified: out/full/tooling/scripts exists after prune