### PR TITLE
Improve Redis failure UX and add E2E coverage

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { cors } from 'hono/cors'
+import { HTTPException } from 'hono/http-exception'
 import { logger } from 'hono/logger'
 import { secureHeaders } from 'hono/secure-headers'
 
@@ -26,6 +27,8 @@ import workersRoutes from './routes/workers'
 
 const DEFAULT_POSTHOG_API_HOST = 'https://us.i.posthog.com'
 const DEFAULT_POSTHOG_UI_HOST = 'https://us.posthog.com'
+const REDIS_CONNECTION_ERROR_MESSAGE =
+  'Unable to connect to Redis for this connection. Verify Redis URL, credentials, TLS settings, and IP allowlist, then retry.'
 
 function getPosthogApiHost(): string {
   const rawHost = env.POSTHOG_HOST?.trim()
@@ -61,6 +64,39 @@ function getPosthogApiHost(): string {
     )
     return DEFAULT_POSTHOG_API_HOST
   }
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === 'string') return error
+  return String(error)
+}
+
+function redactSensitiveErrorData(message: string): string {
+  return message
+    .replace(/(redis(?:s)?:\/\/)([^@/\s]+)@/gi, '$1[REDACTED]@')
+    .replace(/(args:\s*\[[^\]]*?"[^"]*?",\s*")[^"]*(")/gi, '$1[REDACTED]$2')
+}
+
+function isRedisConnectionError(error: unknown): boolean {
+  const message = normalizeErrorMessage(error).toLowerCase()
+  if (message.includes('failed to decrypt redis connection url')) {
+    return false
+  }
+
+  return [
+    'failed to connect to redis',
+    'unable to connect to redis',
+    'redis connection failed recently',
+    'client ip address is not in the allowlist',
+    'invalid username-password pair',
+    'authentication failed',
+    'wrongpass',
+    'noauth',
+    'econnrefused',
+    'enotfound',
+    'etimedout',
+  ].some((indicator) => message.includes(indicator))
 }
 
 /**
@@ -184,6 +220,34 @@ export async function createApiApp(options: CreateApiAppOptions = {}) {
   const { enableLogging = true, corsOrigins = getDefaultCorsOrigins() } = options
 
   const app = new Hono()
+
+  app.onError((error, c) => {
+    if (error instanceof HTTPException) {
+      return error.getResponse()
+    }
+
+    if (isRedisConnectionError(error)) {
+      const detail = redactSensitiveErrorData(normalizeErrorMessage(error))
+      console.error(`[redis] ${detail}`)
+      return c.json(
+        {
+          error: 'Redis connection unavailable',
+          message: REDIS_CONNECTION_ERROR_MESSAGE,
+          detail: env.NODE_ENV === 'production' ? undefined : detail,
+        },
+        503
+      )
+    }
+
+    console.error('[api] Unhandled error:', error)
+    return c.json(
+      {
+        error: 'Internal server error',
+        message: 'An unexpected error occurred while processing this request.',
+      },
+      500
+    )
+  })
 
   // Middleware
   if (enableLogging) {

--- a/apps/api/src/lib/redis.ts
+++ b/apps/api/src/lib/redis.ts
@@ -3,8 +3,23 @@ import { Redis } from 'ioredis'
 
 // Cache for Redis connections keyed by connection ID
 const redisConnections = new Map<string, Redis>()
+// Cache in-flight connection attempts to prevent creating duplicate clients concurrently
+const redisConnectionPromises = new Map<string, Promise<Redis>>()
+// Cache recent failures to avoid hot-looping permanent connection/auth issues
+const recentRedisConnectionFailures = new Map<
+  string,
+  { message: string; at: number; permanent: boolean }
+>()
+// Cache recent log lines to dedupe noisy repeated errors
+const recentRedisErrorLogs = new Map<string, { message: string; at: number }>()
 // Cache for queues keyed by "connectionId:queueName"
 const queues = new Map<string, Queue>()
+
+const REDIS_RECONNECT_BASE_DELAY_MS = 200
+const REDIS_RECONNECT_MAX_DELAY_MS = 2000
+const REDIS_MAX_RECONNECT_ATTEMPTS = 3
+const REDIS_FAILURE_COOLDOWN_MS = 30_000
+const REDIS_ERROR_LOG_DEDUPE_WINDOW_MS = 10_000
 
 function extractQueueNameFromMetaKey(key: string): string | null {
   // BullMQ meta keys end with ":meta". Queue names cannot contain ":".
@@ -19,6 +34,92 @@ function extractQueueNameFromMetaKey(key: string): string | null {
   return queueName
 }
 
+function normalizeRedisErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === 'string') return error
+  if (error === null || error === undefined) return 'Unknown Redis error'
+  return String(error)
+}
+
+function redactRedisSensitiveData(message: string): string {
+  return message
+    .replace(/(redis(?:s)?:\/\/)([^@/\s]+)@/gi, '$1[REDACTED]@')
+    .replace(/(args:\s*\[[^\]]*?"[^"]*?",\s*")[^"]*(")/gi, '$1[REDACTED]$2')
+}
+
+function getSafeRedisErrorMessage(error: unknown): string {
+  return redactRedisSensitiveData(normalizeRedisErrorMessage(error))
+}
+
+function isPermanentRedisConnectionError(message: string): boolean {
+  const normalized = message.toLowerCase()
+
+  return (
+    normalized.includes('allowlist') ||
+    normalized.includes('invalid username-password pair') ||
+    normalized.includes('wrongpass') ||
+    normalized.includes('authentication failed') ||
+    normalized.includes('noauth') ||
+    normalized.includes('acl')
+  )
+}
+
+function shouldLogRedisError(connectionId: string, message: string): boolean {
+  const now = Date.now()
+  const existing = recentRedisErrorLogs.get(connectionId)
+
+  if (
+    existing &&
+    existing.message === message &&
+    now - existing.at < REDIS_ERROR_LOG_DEDUPE_WINDOW_MS
+  ) {
+    return false
+  }
+
+  recentRedisErrorLogs.set(connectionId, { message, at: now })
+  return true
+}
+
+function buildRedisClient(
+  connectionId: string,
+  connectionUrl: string,
+  connectionName?: string
+): Redis {
+  const redis = new Redis(connectionUrl, {
+    maxRetriesPerRequest: null,
+    lazyConnect: true,
+    retryStrategy: (attempts) => {
+      if (attempts > REDIS_MAX_RECONNECT_ATTEMPTS) return null
+      return Math.min(attempts * REDIS_RECONNECT_BASE_DELAY_MS, REDIS_RECONNECT_MAX_DELAY_MS)
+    },
+  })
+
+  const label = connectionName ?? connectionId
+
+  redis.on('error', (error) => {
+    const message = getSafeRedisErrorMessage(error)
+
+    if (shouldLogRedisError(connectionId, message)) {
+      console.error(`❌ Redis error (${label}): ${message}`)
+    }
+
+    if (isPermanentRedisConnectionError(message)) {
+      recentRedisConnectionFailures.set(connectionId, {
+        message,
+        at: Date.now(),
+        permanent: true,
+      })
+      redis.disconnect(false)
+    }
+  })
+
+  redis.on('end', () => {
+    redisConnections.delete(connectionId)
+  })
+
+  return redis
+}
+
 /**
  * Get or create a Redis connection for the given connection ID and URL.
  * The connection ID is used for caching, the URL is the actual Redis connection string.
@@ -28,23 +129,54 @@ export async function getRedis(
   connectionUrl: string,
   connectionName?: string
 ): Promise<Redis> {
-  if (!redisConnections.has(connectionId)) {
-    const redis = new Redis(connectionUrl, {
-      maxRetriesPerRequest: null,
-      lazyConnect: true,
-    })
-
-    redis.on('error', (err) =>
-      console.error(`❌ Redis error (${connectionName ?? connectionId}):`, err)
-    )
-
-    await redis.connect()
-    console.log(`✅ Connected to Redis: ${connectionName ?? connectionId}`)
-
-    redisConnections.set(connectionId, redis)
+  const existingConnection = redisConnections.get(connectionId)
+  if (existingConnection) {
+    if (existingConnection.status !== 'end') {
+      return existingConnection
+    }
+    redisConnections.delete(connectionId)
   }
 
-  return redisConnections.get(connectionId)!
+  const recentFailure = recentRedisConnectionFailures.get(connectionId)
+  if (recentFailure) {
+    const elapsed = Date.now() - recentFailure.at
+    if (recentFailure.permanent && elapsed < REDIS_FAILURE_COOLDOWN_MS) {
+      throw new Error(`Redis connection failed recently: ${recentFailure.message}`)
+    }
+    recentRedisConnectionFailures.delete(connectionId)
+  }
+
+  const inFlightConnection = redisConnectionPromises.get(connectionId)
+  if (inFlightConnection) {
+    return inFlightConnection
+  }
+
+  const connectPromise = (async () => {
+    const redis = buildRedisClient(connectionId, connectionUrl, connectionName)
+
+    try {
+      await redis.connect()
+      redisConnections.set(connectionId, redis)
+      recentRedisConnectionFailures.delete(connectionId)
+      console.log(`✅ Connected to Redis: ${connectionName ?? connectionId}`)
+      return redis
+    } catch (error) {
+      const message = getSafeRedisErrorMessage(error)
+      const existingFailure = recentRedisConnectionFailures.get(connectionId)
+      const permanent = existingFailure?.permanent ?? isPermanentRedisConnectionError(message)
+      const failureMessage = existingFailure?.permanent ? existingFailure.message : message
+      recentRedisConnectionFailures.set(connectionId, { message: failureMessage, at: Date.now(), permanent })
+      redis.disconnect(false)
+      throw new Error(
+        `Failed to connect to Redis (${connectionName ?? connectionId}): ${failureMessage}`
+      )
+    } finally {
+      redisConnectionPromises.delete(connectionId)
+    }
+  })()
+
+  redisConnectionPromises.set(connectionId, connectPromise)
+  return connectPromise
 }
 
 /**

--- a/apps/web/e2e/fixtures/test.ts
+++ b/apps/web/e2e/fixtures/test.ts
@@ -14,6 +14,13 @@ type Connection = {
   environment: string
 }
 
+type CreateConnectionInput = {
+  name: string
+  url: string
+  environment?: 'development' | 'staging' | 'production'
+  isDefault?: boolean
+}
+
 type QueueSummary = {
   name: string
 }
@@ -79,6 +86,28 @@ export async function getConnections(page: Page): Promise<Connection[]> {
     throw new Error('No connections found. Ensure the seed script ran successfully.')
   }
   return data.connections
+}
+
+export async function createConnection(
+  page: Page,
+  input: CreateConnectionInput
+): Promise<Connection> {
+  const response = await page.request.post('/api/connections', {
+    data: {
+      name: input.name,
+      url: input.url,
+      environment: input.environment ?? 'development',
+      isDefault: input.isDefault ?? false,
+    },
+  })
+
+  const data = await apiJson<{ connection: Connection }>(response, 'POST /api/connections')
+  return data.connection
+}
+
+export async function deleteConnection(page: Page, connectionId: string): Promise<void> {
+  const response = await page.request.delete(`/api/connections/${connectionId}`)
+  await apiJson<{ success: boolean }>(response, `DELETE /api/connections/${connectionId}`)
 }
 
 export async function getDefaultConnectionId(page: Page): Promise<string> {

--- a/apps/web/e2e/pages.spec.ts
+++ b/apps/web/e2e/pages.spec.ts
@@ -1,4 +1,6 @@
 import {
+  createConnection,
+  deleteConnection,
   expect,
   ensureActiveOrg,
   findJobByStatus,
@@ -36,6 +38,34 @@ test.describe("Pages", () => {
     await expect(
       page.getByRole("heading", { name: queueName, exact: true, level: 1 })
     ).toBeVisible();
+  });
+
+  test("shows a clear Redis connection failure message for unreachable connections", async ({
+    page,
+  }) => {
+    await ensureActiveOrg(page);
+
+    const connection = await createConnection(page, {
+      name: `Broken Redis ${Date.now()}`,
+      url: "redis://does-not-exist.invalid:6379",
+      environment: "development",
+    });
+
+    try {
+      await page.goto(`/${TEST_ORG_SLUG}/c/${connection.id}`);
+
+      await expect(
+        page.getByRole("heading", { name: "Failed to load queues", exact: true, level: 2 })
+      ).toBeVisible({ timeout: 25000 });
+
+      await expect(
+        page.getByText(
+          "Unable to connect to Redis for this connection. Verify Redis URL, credentials, TLS settings, and IP allowlist, then retry."
+        )
+      ).toBeVisible();
+    } finally {
+      await deleteConnection(page, connection.id);
+    }
   });
 
   test("queues page buttons and links", async ({ page }) => {

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -5,6 +5,7 @@
 
 import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useParams } from '@tanstack/react-router'
 import { useConnection } from '@/components/connection-provider'
 import { ApiError, api, fetchApi, handleRes, type InferResponseType } from '@/lib/api'
 import { PAGINATION } from '@/lib/constants'
@@ -216,10 +217,15 @@ export const queryKeys = {
   allWorkers: (connectionId: string) => ['workers', connectionId] as const,
 }
 
+function useConnectionIdFromContextOrRoute(): string | undefined {
+  const { currentConnection } = useConnection()
+  const { connectionId } = useParams({ strict: false }) as { connectionId?: string }
+  return currentConnection?.id ?? connectionId
+}
+
 // Queue Queries
 export function useQueues() {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.queues(connectionId ?? ''),
@@ -234,8 +240,7 @@ export function useQueues() {
 }
 
 export function useQueue(queueName: string) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.queue(connectionId ?? '', queueName),
@@ -250,8 +255,7 @@ export function useQueue(queueName: string) {
 }
 
 export function useQueueMetrics(queueName: string, options?: QueueMetricsOptions) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.queueMetrics(connectionId ?? '', queueName, options),
@@ -293,8 +297,7 @@ export function useJobs(
   queueName: string,
   filters?: { status?: string; name?: string; jobId?: string; page?: number; pageSize?: number }
 ) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.jobs(connectionId ?? '', queueName, filters),
@@ -335,8 +338,7 @@ export function useJobs(
 }
 
 export function useJob(queueName: string, jobId: string) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.job(connectionId ?? '', queueName, jobId),
@@ -351,8 +353,7 @@ export function useJob(queueName: string, jobId: string) {
 }
 
 export function useJobLogs(queueName: string, jobId: string) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useInfiniteQuery({
     queryKey: queryKeys.jobLogs(connectionId ?? '', queueName, jobId),
@@ -378,8 +379,7 @@ export function useJobLogs(queueName: string, jobId: string) {
 }
 
 export function useJobStacktraces(queueName: string, jobId: string, enabled = true) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useInfiniteQuery({
     queryKey: queryKeys.jobStacktraces(connectionId ?? '', queueName, jobId),
@@ -406,8 +406,7 @@ export function useJobStacktraces(queueName: string, jobId: string, enabled = tr
 
 // Scheduled Jobs Queries
 export function useScheduledJobs() {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.scheduledJobs(connectionId ?? ''),
@@ -422,8 +421,7 @@ export function useScheduledJobs() {
 }
 
 export function useQueueScheduledJobs(queueName: string) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.queueScheduledJobs(connectionId ?? '', queueName),
@@ -439,8 +437,7 @@ export function useQueueScheduledJobs(queueName: string) {
 
 // Metrics Query
 export function useAllMetrics() {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.allMetrics(connectionId ?? ''),
@@ -457,8 +454,7 @@ export function useAllMetrics() {
 
 // Workers Query
 export function useAllWorkers() {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: queryKeys.allWorkers(connectionId ?? ''),
@@ -475,8 +471,7 @@ export function useAllWorkers() {
 // Queue Mutations
 export function usePauseQueue() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async (queueName: string) => {
@@ -504,8 +499,7 @@ export function usePauseQueue() {
 
 export function useResumeQueue() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async (queueName: string) => {
@@ -533,8 +527,7 @@ export function useResumeQueue() {
 
 export function useCleanQueue() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({
@@ -577,8 +570,7 @@ export function useCleanQueue() {
 
 export function usePurgeQueue() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({
@@ -620,8 +612,7 @@ export function usePurgeQueue() {
 
 export function useObliterateQueue() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async (queueName: string) => {
@@ -651,8 +642,7 @@ export function useObliterateQueue() {
 // Job Mutations
 export function useRetryJobs() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async (
@@ -702,8 +692,7 @@ export function useRetryJobs() {
 
 export function useRemoveJobs() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({
@@ -755,8 +744,7 @@ export function useRemoveJobs() {
 
 export function useClearJobLogs() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({
@@ -800,8 +788,7 @@ export function useClearJobLogs() {
 
 export function useClearJobStacktraces() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({
@@ -834,8 +821,7 @@ export function useClearJobStacktraces() {
 
 export function useInvokeJobs() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({
@@ -880,8 +866,7 @@ export function useInvokeJobs() {
 
 export function useAddJob() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({
@@ -923,8 +908,7 @@ export function useAddJob() {
 // Scheduled Job Mutations
 export function useRemoveScheduledJob() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({ queueName, schedulerId }: { queueName: string; schedulerId: string }) => {
@@ -959,8 +943,7 @@ export function useRemoveScheduledJob() {
 
 // Check if queue can be deleted
 export function useCanDeleteQueue(queueName: string) {
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
     queryKey: ['canDeleteQueue', connectionId, queueName],
@@ -977,8 +960,7 @@ export function useCanDeleteQueue(queueName: string) {
 // Delete queue mutation
 export function useDeleteQueue() {
   const queryClient = useQueryClient()
-  const { currentConnection } = useConnection()
-  const connectionId = currentConnection?.id
+  const connectionId = useConnectionIdFromContextOrRoute()
 
   return useMutation({
     mutationFn: async ({ queueName, confirmName }: { queueName: string; confirmName: string }) => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -11,6 +11,10 @@ import { toast } from 'sonner'
 export type { ApiType, InferRequestType, InferResponseType } from '@durabull/api-client'
 export { api } from '@durabull/api-client'
 
+const API_REQUEST_TIMEOUT_MS = 15_000
+const REDIS_CONNECTION_ERROR_MESSAGE =
+  'Unable to connect to Redis for this connection. Verify Redis URL, credentials, TLS settings, and IP allowlist, then retry.'
+
 /**
  * Custom error class for API errors with status code
  * Provides better error handling and type safety
@@ -71,6 +75,53 @@ export async function handleResponse<T>(res: Response): Promise<T> {
  */
 export const handleRes = handleResponse
 
+function isConnectionScopedPath(path: string): boolean {
+  return path.includes('/api/c/')
+}
+
+async function fetchWithTimeout(path: string, options: RequestInit): Promise<Response> {
+  const timeoutController = new AbortController()
+  const timeout = setTimeout(() => timeoutController.abort(), API_REQUEST_TIMEOUT_MS)
+
+  const callerSignal = options.signal
+  const abortFromCaller = () => timeoutController.abort()
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      clearTimeout(timeout)
+      throw new ApiError('Request was aborted before it started.', 0)
+    }
+    callerSignal.addEventListener('abort', abortFromCaller, { once: true })
+  }
+
+  try {
+    return await fetch(path, {
+      ...options,
+      signal: timeoutController.signal,
+    })
+  } catch (error) {
+    if (timeoutController.signal.aborted && !callerSignal?.aborted) {
+      const seconds = Math.floor(API_REQUEST_TIMEOUT_MS / 1000)
+      const message = isConnectionScopedPath(path)
+        ? `Request timed out after ${seconds}s. ${REDIS_CONNECTION_ERROR_MESSAGE}`
+        : `Request timed out after ${seconds}s. The server did not respond in time.`
+      throw new ApiError(message, 504)
+    }
+
+    if (error instanceof ApiError) {
+      throw error
+    }
+
+    if (error instanceof Error) {
+      throw new ApiError(error.message, 0)
+    }
+
+    throw new ApiError('Network request failed', 0)
+  } finally {
+    clearTimeout(timeout)
+    callerSignal?.removeEventListener('abort', abortFromCaller)
+  }
+}
+
 /**
  * Generic fetch function for API requests
  * Used for routes that don't have full RPC type support
@@ -81,7 +132,7 @@ export async function fetchApi<T>(path: string, options?: RequestInit): Promise<
     headers.set('Content-Type', 'application/json')
   }
 
-  const res = await fetch(path, {
+  const res = await fetchWithTimeout(path, {
     ...options,
     headers,
     credentials: 'include',

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -7,6 +7,26 @@ function isUnauthorizedError(error: unknown): boolean {
   return error instanceof Error && 'status' in error && (error as { status: number }).status === 401
 }
 
+function isRedisConnectivityError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+
+  const message = error.message.toLowerCase()
+  const status =
+    'status' in error && typeof (error as { status?: unknown }).status === 'number'
+      ? (error as { status: number }).status
+      : null
+
+  return (
+    status === 503 ||
+    status === 504 ||
+    message.includes('unable to connect to redis') ||
+    message.includes('redis connection unavailable') ||
+    message.includes('failed to connect to redis') ||
+    message.includes('allowlist') ||
+    message.includes('request timed out')
+  )
+}
+
 // Global handler for 401 responses
 function handleUnauthorized() {
   // Clear any cached auth state and redirect to login
@@ -27,6 +47,12 @@ export function getRouter() {
             handleUnauthorized()
             return false
           }
+
+          // Surface Redis connectivity issues immediately so the UI shows clear feedback quickly.
+          if (isRedisConnectivityError(error)) {
+            return false
+          }
+
           // Default retry behavior for other errors
           return failureCount < 3
         },

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -6,10 +6,57 @@
 import type { ApiType as ServerApiType } from '@durabull/api/app'
 import { hc } from 'hono/client'
 
+const API_REQUEST_TIMEOUT_MS = 15_000
+
 /**
  * Re-export the API type for consumers who need it
  */
 export type ApiType = ServerApiType
+
+function getRequestPath(input: string | URL | Request): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.pathname
+  return input.url
+}
+
+function isRedisScopedApiRequest(input: string | URL | Request): boolean {
+  const path = getRequestPath(input)
+  return path.includes('/api/c/')
+}
+
+async function fetchWithTimeout(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  const timeoutController = new AbortController()
+  const timeout = setTimeout(() => timeoutController.abort(), API_REQUEST_TIMEOUT_MS)
+
+  const callerSignal = init?.signal
+  const abortFromCaller = () => timeoutController.abort()
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      clearTimeout(timeout)
+      throw new Error('Request was aborted before it started.')
+    }
+    callerSignal.addEventListener('abort', abortFromCaller, { once: true })
+  }
+
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: timeoutController.signal,
+    })
+  } catch (error) {
+    if (timeoutController.signal.aborted && !callerSignal?.aborted) {
+      const seconds = Math.floor(API_REQUEST_TIMEOUT_MS / 1000)
+      const timeoutMessage = isRedisScopedApiRequest(input)
+        ? `Request timed out after ${seconds}s. Unable to connect to Redis for this connection. Check Redis URL, credentials, TLS settings, and IP allowlist, then retry.`
+        : `Request timed out after ${seconds}s. The server did not respond in time.`
+      throw new Error(timeoutMessage)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+    callerSignal?.removeEventListener('abort', abortFromCaller)
+  }
+}
 
 /**
  * Type-safe API client
@@ -25,6 +72,7 @@ export type ApiType = ServerApiType
  *   })
  */
 export const api = hc<ApiType>('/api', {
+  fetch: fetchWithTimeout,
   init: {
     credentials: 'include', // Required for Better Auth session cookies
   },

--- a/tooling/scripts/seed/database.ts
+++ b/tooling/scripts/seed/database.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  and,
   authSchema,
   encryptRedisUrl,
   eq,
@@ -230,11 +231,26 @@ async function seedConnections(db: Awaited<ReturnType<typeof getDb>>): Promise<v
       const existingByName = await db
         .select({ id: redisConnection.id })
         .from(redisConnection)
-        .where(eq(redisConnection.name, conn.name))
+        .where(
+          and(
+            eq(redisConnection.name, conn.name),
+            eq(redisConnection.organizationId, actualOrgId)
+          )
+        )
         .limit(1)
 
       if (existingByName.length > 0) {
-        logWarning(`Connection ${conn.name} already exists`)
+        logItem(`Updating connection by name: ${conn.name}...`)
+        await db
+          .update(redisConnection)
+          .set({
+            url: encryptRedisUrl(REDIS_URL),
+            environment: conn.environment,
+            isDefault: conn.isDefault,
+            updatedAt: now,
+          })
+          .where(eq(redisConnection.id, existingByName[0].id))
+        logSuccess(`Updated existing connection: ${conn.name}`)
         continue
       }
 


### PR DESCRIPTION
<img width="1240" height="575" alt="Screenshot 2026-03-02 at 5 44 50 PM" src="https://github.com/user-attachments/assets/5c7c7089-edc5-4198-8fd6-82ad6ed2efc9" />

## Summary
- map Redis connectivity/auth failures to clear API 503 responses with sanitized error details
- add client-side request timeouts and disable retries for Redis connectivity errors so the UI fails fast
- make queue hooks fall back to route connectionId so `/c/:connectionId` pages still surface queue errors when `/api/connections` fails
- add E2E coverage that creates an unreachable Redis connection and verifies the user sees a clear failure message
- harden seed updates to refresh existing named connections (org-scoped) with current encrypted URLs

## Validation
- `bun run --filter @durabull/web typecheck`
- `cd apps/web && bun run test:e2e -- e2e/pages.spec.ts --grep "shows a clear Redis connection failure message for unreachable connections"`
