### PR TITLE
fix(web): make queue and job rows fully clickable

### DIFF
--- a/apps/web/e2e/pages.spec.ts
+++ b/apps/web/e2e/pages.spec.ts
@@ -6,6 +6,7 @@ import {
   findJobByStatus,
   getDefaultConnectionId,
   getJob,
+  getJobs,
   getTestQueueName,
   getScheduledJobs,
   TEST_ORG_SLUG,
@@ -30,7 +31,7 @@ test.describe("Pages", () => {
 
     const queueRow = page.getByTestId(`queue-row-${queueName}`);
     await expect(queueRow).toBeVisible();
-    await queueRow.getByRole("link").first().click();
+    await queueRow.locator("td").nth(1).click();
 
     await page.waitForURL(
       new RegExp(`/${TEST_ORG_SLUG}/c/${connectionId}/queues/${queueName}`)
@@ -83,7 +84,7 @@ test.describe("Pages", () => {
     const queueRow = page.getByTestId(`queue-row-${queueName}`);
     await expect(queueRow).toBeVisible();
 
-    await queueRow.getByRole("link").first().click();
+    await queueRow.locator("td").nth(1).click();
     await page.waitForURL(
       new RegExp(`/${TEST_ORG_SLUG}/c/${connectionId}/queues/${queueName}`)
     );
@@ -172,9 +173,22 @@ test.describe("Pages", () => {
 
   test("queue jobs tab status filter and scheduled tab", async ({ page }) => {
     const { connectionId, queueName } = await getConnectionAndQueue(page);
+    const jobs = await getJobs(page, connectionId, queueName, { page: 1, pageSize: 1 });
+    const firstJobId = jobs.jobs.length > 0 ? String(jobs.jobs[0].id) : null;
 
     await page.goto(`/${TEST_ORG_SLUG}/c/${connectionId}/queues/${queueName}`);
     await expect(page.getByRole("button", { name: "Jobs", exact: true })).toBeVisible();
+    if (firstJobId) {
+      const jobRow = page.getByTestId(`job-row-${firstJobId}`);
+      await expect(jobRow).toBeVisible();
+      await jobRow.locator("td").nth(2).click();
+      await page.waitForURL(
+        new RegExp(`/${TEST_ORG_SLUG}/c/${connectionId}/queues/${queueName}/jobs/${firstJobId}`)
+      );
+      await page.goBack();
+      await expect(jobRow).toBeVisible();
+    }
+
     const hideScheduledJobs = page.getByLabel("Hide scheduled jobs");
     await expect(hideScheduledJobs).toBeVisible();
     await expect(hideScheduledJobs).not.toBeChecked();

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -1,7 +1,7 @@
 import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
-import { Link, useParams } from '@tanstack/react-router'
+import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import { AlertCircle, ExternalLink, Eye, EyeOff, MoreHorizontal, Pause, Play } from 'lucide-react'
-import { memo, useCallback, useMemo, useState } from 'react'
+import { type KeyboardEvent, memo, type MouseEvent, useCallback, useMemo, useState } from 'react'
 import { useConnection } from '@/components/connection-provider'
 import { QueueNameTag } from '@/components/queue-name-tag'
 import { StatusIndicator } from '@/components/status-badge'
@@ -139,6 +139,18 @@ interface QueueTableRowProps {
   queue: QueueSummary
 }
 
+function shouldSkipRowNavigation(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  return Boolean(
+    target.closest(
+      'a,button,input,select,textarea,[role="menuitem"],[role="checkbox"],[data-row-nav-ignore="true"]'
+    )
+  )
+}
+
 /**
  * Memoized table row for a single queue
  * Prevents unnecessary re-renders when other queues change
@@ -146,6 +158,7 @@ interface QueueTableRowProps {
 const QueueTableRow = memo(function QueueTableRow({ queue }: QueueTableRowProps) {
   const { currentConnection } = useConnection()
   const connectionId = currentConnection?.id ?? ''
+  const navigate = useNavigate()
   // Get orgSlug from route params for org-scoped navigation
   const params = useParams({ strict: false })
   const orgSlug = (params as { orgSlug?: string }).orgSlug ?? ''
@@ -161,10 +174,49 @@ const QueueTableRow = memo(function QueueTableRow({ queue }: QueueTableRowProps)
     }
   }, [queue.isPaused, queue.name, pauseMutation, resumeMutation])
 
+  const navigateToQueue = useCallback(() => {
+    void navigate({
+      to: '/$orgSlug/c/$connectionId/queues/$queueName',
+      params: { orgSlug, connectionId, queueName: queue.name },
+      search: {},
+    })
+  }, [connectionId, navigate, orgSlug, queue.name])
+
+  const handleRowClick = useCallback(
+    (event: MouseEvent<HTMLTableRowElement>) => {
+      if (shouldSkipRowNavigation(event.target)) {
+        return
+      }
+
+      navigateToQueue()
+    },
+    [navigateToQueue]
+  )
+
+  const handleRowKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTableRowElement>) => {
+      if (event.key !== 'Enter' || shouldSkipRowNavigation(event.target)) {
+        return
+      }
+
+      event.preventDefault()
+      navigateToQueue()
+    },
+    [navigateToQueue]
+  )
+
   const status = queue.isPaused ? QUEUE_STATUS.PAUSED : QUEUE_STATUS.ACTIVE
 
   return (
-    <TableRow className="group" data-testid={`queue-row-${queue.name}`}>
+    <TableRow
+      className="group cursor-pointer focus-visible:bg-muted/50 focus-visible:outline-none"
+      aria-label={`Open queue ${queue.name}`}
+      data-testid={`queue-row-${queue.name}`}
+      onClick={handleRowClick}
+      onKeyDown={handleRowKeyDown}
+      role="link"
+      tabIndex={0}
+    >
       {/* Queue Name */}
       <TableCell>
         <Tooltip>

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
@@ -26,7 +26,7 @@ import {
   Trash2,
   Zap,
 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { type KeyboardEvent, type MouseEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { z } from 'zod'
 import { useAppTopBar } from '@/components/app-top-bar'
@@ -1775,6 +1775,18 @@ function MetricRow({ label, value }: { label: string; value: string | number }) 
 
 type JobStatus = 'waiting' | 'active' | 'delayed' | 'completed' | 'failed'
 
+function shouldSkipRowNavigation(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  return Boolean(
+    target.closest(
+      'a,button,input,select,textarea,[role="menuitem"],[role="checkbox"],[data-row-nav-ignore="true"]'
+    )
+  )
+}
+
 // Job summary type - matches API response
 interface JobSummary {
   id: string
@@ -1808,6 +1820,7 @@ function JobRow({
   onToggleSelect: () => void
 }) {
   const [copied, setCopied] = useState(false)
+  const navigate = useNavigate()
   const statusMap: Record<string, JobStatus> = {
     waiting: 'waiting',
     active: 'active',
@@ -1821,7 +1834,7 @@ function JobRow({
   const status = statusMap[job.status] || 'waiting'
   const isTruncated = job.id.length > 16
 
-  const handleCopy = async (e: React.MouseEvent) => {
+  const handleCopy = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
     e.stopPropagation()
     try {
@@ -1833,8 +1846,47 @@ function JobRow({
     }
   }
 
+  const navigateToJob = useCallback(() => {
+    void navigate({
+      to: '/$orgSlug/c/$connectionId/queues/$queueName/jobs/$jobId',
+      params: { orgSlug, connectionId, queueName, jobId: job.id },
+      search: {},
+    })
+  }, [connectionId, job.id, navigate, orgSlug, queueName])
+
+  const handleRowClick = useCallback(
+    (event: MouseEvent<HTMLTableRowElement>) => {
+      if (shouldSkipRowNavigation(event.target)) {
+        return
+      }
+
+      navigateToJob()
+    },
+    [navigateToJob]
+  )
+
+  const handleRowKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTableRowElement>) => {
+      if (event.key !== 'Enter' || shouldSkipRowNavigation(event.target)) {
+        return
+      }
+
+      event.preventDefault()
+      navigateToJob()
+    },
+    [navigateToJob]
+  )
+
   return (
-    <TableRow>
+    <TableRow
+      className="group cursor-pointer focus-visible:bg-muted/50 focus-visible:outline-none"
+      aria-label={`Open job ${job.id}`}
+      data-testid={`job-row-${job.id}`}
+      onClick={handleRowClick}
+      onKeyDown={handleRowKeyDown}
+      role="link"
+      tabIndex={0}
+    >
       <TableCell>
         <input
           type="checkbox"


### PR DESCRIPTION
## What
- make queue rows on the dashboard table navigate when any non-interactive part of the row is clicked
- make queue job rows navigate the same way from the queue detail Jobs table
- preserve existing behavior for interactive controls (links, action buttons, checkboxes, menu items) so they do not trigger row navigation
- add keyboard support (`Enter`) for row navigation on both tables
- add/update e2e assertions to validate clicking non-link table cells navigates correctly

## Why
Users were confused because only the ID/queue link looked actionable. This change makes table interactions consistent and predictable by allowing the full row to open details.

## How
- add shared row click guards (`shouldSkipRowNavigation`) to ignore clicks originating from interactive descendants
- use `useNavigate` row handlers in:
  - `apps/web/src/components/queue-table.tsx`
  - `apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx`
- add `data-testid` for job rows to make row-level navigation testable
- update `apps/web/e2e/pages.spec.ts` to click non-link cells for queue and job row navigation coverage

## Testing
- ✅ `cd apps/web && bun run typecheck`
- ✅ `cd apps/web && bun run test:e2e --list`
- ⚠️ attempted targeted e2e run failed in this environment due API config: `Failed to decrypt Redis connection URL. Verify DURABULL_REDIS_URL_ENCRYPTION_KEY.`
