### PR TITLE
Fix Docker image dependency installation

### DIFF
--- a/tooling/docker/Dockerfile
+++ b/tooling/docker/Dockerfile
@@ -21,14 +21,14 @@ RUN turbo prune @durabull/api @durabull/web @durabull/scripts --docker
 # -----------------------------------------------------------------------------
 FROM base AS deps
 COPY --from=prune /app/out/json/ .
-RUN rm -f bun.lock bun.lockb && bun install || true
+RUN bun install --no-save --ignore-scripts
 
 # -----------------------------------------------------------------------------
 # Prod-deps: Production dependencies only (for release)
 # -----------------------------------------------------------------------------
 FROM base AS prod-deps
 COPY --from=prune /app/out/json/ .
-RUN rm -f bun.lock bun.lockb && bun install --production || true
+RUN bun install --omit=dev --no-save --ignore-scripts
 
 # -----------------------------------------------------------------------------
 # Build: Build the web app


### PR DESCRIPTION
## Summary
- stop deleting the pruned Bun lockfile during Docker dependency installation
- stop ignoring Bun install failures in the build stages
- install dependencies with `--no-save --ignore-scripts` and `--omit=dev` so the image keeps the pruned lockfile resolution and avoids optional native install-script failures in the Bun Linux image

## Validation
- built the image successfully with `docker build -f tooling/docker/Dockerfile -t durabull:test-fix .`
- verified the built image resolves `better-auth/adapters/drizzle`
- confirmed the image now uses `better-auth 1.4.18`, matching the lockfile
- ran the container entrypoint and confirmed the previous missing module error is gone; startup now proceeds to a separate `/app/data` permission error

## Root cause
The Dockerfile deleted `bun.lock` and allowed install failures with `|| true`, which let Bun resolve newer semver versions during image builds. That drift pulled in `better-auth@1.5.3`, where the Drizzle adapter is split into `@better-auth/drizzle-adapter`, causing runtime startup failures from the built image.
