### PR TITLE
feat(web): add empty-org onboarding and connection fallbacks

### DIFF
--- a/apps/web/src/components/no-connection-configured.tsx
+++ b/apps/web/src/components/no-connection-configured.tsx
@@ -1,0 +1,252 @@
+import { Link } from '@tanstack/react-router'
+import { motion } from 'framer-motion'
+import type { LucideIcon } from 'lucide-react'
+import { ArrowRight, Cable, Compass, Sparkles } from 'lucide-react'
+import { useMemo } from 'react'
+import { useAppTopBar } from '@/components/app-top-bar'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { useAppMode } from '@/hooks/use-app-mode'
+import { cn } from '@/lib/utils'
+
+interface NoConnectionConfiguredProps {
+  orgSlug: string
+  area: string
+  icon: LucideIcon
+  description?: string
+}
+
+const shellTransition = { duration: 0.55, ease: [0.16, 1, 0.3, 1] as const }
+
+export function NoConnectionConfigured({
+  orgSlug,
+  area,
+  icon: AreaIcon,
+  description,
+}: NoConnectionConfiguredProps) {
+  const { envConnections } = useAppMode()
+
+  const topBarConfig = useMemo(
+    () => ({
+      left: (
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted/70 text-muted-foreground">
+            <AreaIcon className="h-4 w-4" />
+          </span>
+          <h1 className="truncate text-base font-semibold md:text-lg">{area}</h1>
+          <span className="hidden text-sm text-muted-foreground xl:inline">
+            Connection required before this workspace can load
+          </span>
+        </div>
+      ),
+      actions: (
+        <Button asChild size="xs" className="gap-2">
+          <Link
+            to="/$orgSlug/connections"
+            params={{ orgSlug }}
+            search={envConnections ? undefined : { create: 1 }}
+          >
+            {envConnections ? 'Open Setup Guide' : 'Add Connection'}
+          </Link>
+        </Button>
+      ),
+    }),
+    [area, envConnections, orgSlug]
+  )
+
+  useAppTopBar(topBarConfig)
+
+  const bodyCopy =
+    description ??
+    (envConnections
+      ? `This environment is configured for env-driven Redis connections. Add the required DURABULL_REDIS_URL_* values, restart the app, and ${area.toLowerCase()} will come online.`
+      : `Durabull needs a Redis connection before ${area.toLowerCase()} can inspect queues, workers, schedulers, or Redis data.`)
+
+  return (
+    <motion.div
+      className="relative isolate overflow-hidden rounded-[30px] border border-border/70 bg-card/85 shadow-[0_25px_90px_-55px_rgba(15,23,42,0.55)]"
+      initial={{ opacity: 0, y: 18 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={shellTransition}
+    >
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.16),transparent_30%),radial-gradient(circle_at_80%_18%,rgba(251,191,36,0.14),transparent_28%),linear-gradient(135deg,rgba(15,23,42,0.04),transparent_55%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.18),transparent_30%),radial-gradient(circle_at_80%_18%,rgba(251,191,36,0.18),transparent_28%),linear-gradient(135deg,rgba(15,23,42,0.3),transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 opacity-40 [background-image:linear-gradient(to_right,rgba(148,163,184,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(148,163,184,0.12)_1px,transparent_1px)] [background-size:32px_32px]" />
+
+      <div className="relative grid gap-8 px-6 py-8 sm:px-8 sm:py-10 xl:grid-cols-[1.15fr_0.85fr] xl:px-10">
+        <div className="space-y-6">
+          <motion.div
+            className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/75 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground shadow-sm backdrop-blur"
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...shellTransition, delay: 0.05 }}
+          >
+            <Sparkles className="h-3.5 w-3.5 text-amber-500" />
+            Connection Required
+          </motion.div>
+
+          <motion.div
+            className="space-y-3"
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...shellTransition, delay: 0.1 }}
+          >
+            <h2
+              className="max-w-3xl text-3xl font-semibold tracking-tight text-foreground sm:text-4xl"
+              style={{
+                fontFamily: '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif',
+              }}
+            >
+              No connection configured
+            </h2>
+            <p className="max-w-2xl text-base leading-7 text-muted-foreground">{bodyCopy}</p>
+          </motion.div>
+
+          <motion.div
+            className="flex flex-wrap gap-3"
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...shellTransition, delay: 0.15 }}
+          >
+            <Button asChild className="gap-2">
+              <Link
+                to="/$orgSlug/connections"
+                params={{ orgSlug }}
+                search={envConnections ? undefined : { create: 1 }}
+              >
+                {envConnections ? 'Review connection setup' : 'Add your first connection'}
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" className="gap-2">
+              <Link to="/$orgSlug" params={{ orgSlug }} search={{ onboarding: 1 }}>
+                Open onboarding
+              </Link>
+            </Button>
+          </motion.div>
+
+          <motion.div
+            className="grid gap-3 md:grid-cols-3"
+            initial={{ opacity: 0, y: 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...shellTransition, delay: 0.2 }}
+          >
+            {[
+              {
+                icon: Cable,
+                label: envConnections ? 'Wire env vars' : 'Connect Redis',
+                copy: envConnections
+                  ? 'Provide the Redis URLs Durabull should mount at boot.'
+                  : 'Attach the Redis instance that powers your BullMQ queues.',
+                gradient: 'from-sky-500/18 via-sky-500/6 to-transparent',
+              },
+              {
+                icon: AreaIcon,
+                label: `Unlock ${area}`,
+                copy: `${area} comes online automatically once a connection is available.`,
+                gradient: 'from-emerald-500/18 via-emerald-500/6 to-transparent',
+              },
+              {
+                icon: Compass,
+                label: 'Return to onboarding',
+                copy: 'Reopen the guided setup if you want the full checklist again.',
+                gradient: 'from-amber-500/18 via-amber-500/6 to-transparent',
+              },
+            ].map((item, index) => (
+              <Card
+                key={item.label}
+                className={cn(
+                  'overflow-hidden border bg-background/78 backdrop-blur',
+                  'shadow-[0_18px_55px_-42px_rgba(15,23,42,0.9)]'
+                )}
+              >
+                <CardContent className="relative p-4">
+                  <div
+                    className={cn(
+                      'absolute inset-0 bg-gradient-to-br opacity-80',
+                      item.gradient
+                    )}
+                  />
+                  <motion.div
+                    className="relative space-y-3"
+                    initial={{ opacity: 0, y: 14 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ ...shellTransition, delay: 0.24 + index * 0.06 }}
+                  >
+                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/30 bg-white/60 text-foreground shadow-sm dark:border-white/10 dark:bg-white/5">
+                      <item.icon className="h-4 w-4" />
+                    </span>
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-foreground">{item.label}</p>
+                      <p className="text-sm leading-6 text-muted-foreground">{item.copy}</p>
+                    </div>
+                  </motion.div>
+                </CardContent>
+              </Card>
+            ))}
+          </motion.div>
+        </div>
+
+        <motion.div
+          className="relative"
+          initial={{ opacity: 0, x: 18 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ ...shellTransition, delay: 0.14 }}
+        >
+          <div className="absolute inset-0 rounded-[28px] bg-gradient-to-br from-foreground/[0.08] via-transparent to-transparent blur-3xl" />
+          <Card className="relative overflow-hidden rounded-[28px] border border-border/70 bg-background/82 shadow-[0_24px_70px_-48px_rgba(15,23,42,0.95)] backdrop-blur">
+            <CardContent className="space-y-6 p-6">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                    Control Plane
+                  </p>
+                  <p className="text-xl font-semibold text-foreground">Stand up your first link</p>
+                </div>
+                <span className="rounded-full border border-border/70 bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                  {area}
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                {[
+                  'Redis credentials validated',
+                  'Queue discovery indexed',
+                  'Platform surfaces unlocked',
+                ].map((label, index) => (
+                  <div key={label} className="flex items-center gap-3">
+                    <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-border/70 bg-muted/40">
+                      <span className="text-sm font-semibold text-foreground">0{index + 1}</span>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-foreground">{label}</p>
+                      <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted/60">
+                        <motion.div
+                          className={cn(
+                            'h-full rounded-full',
+                            index === 0 && 'bg-sky-500/65',
+                            index === 1 && 'bg-emerald-500/60',
+                            index === 2 && 'bg-amber-500/65'
+                          )}
+                          initial={{ width: 0 }}
+                          animate={{ width: `${52 + index * 16}%` }}
+                          transition={{ duration: 1, delay: 0.35 + index * 0.12 }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="rounded-[24px] border border-border/70 bg-muted/35 p-4">
+                <p className="text-sm font-medium text-foreground">
+                  The moment a connection is added, Durabull can resolve queues, workers, schedules,
+                  and Redis keys without another setup step.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </div>
+    </motion.div>
+  )
+}

--- a/apps/web/src/components/organization-onboarding.tsx
+++ b/apps/web/src/components/organization-onboarding.tsx
@@ -1,0 +1,736 @@
+import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { Link } from '@tanstack/react-router'
+import { motion } from 'framer-motion'
+import type { LucideIcon } from 'lucide-react'
+import {
+  ArrowRight,
+  BadgeCheck,
+  Check,
+  ChevronRight,
+  Cloud,
+  Database,
+  Github,
+  Loader2,
+  Mail,
+  Shield,
+  Sparkles,
+  UserPlus,
+  Users,
+  WandSparkles,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useAppTopBar } from '@/components/app-top-bar'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useAppMode } from '@/hooks/use-app-mode'
+import { linkSocial, listAccounts, useAuth } from '@/hooks/use-auth'
+import {
+  type MemberRole,
+  useActiveOrganization,
+  useInviteMember,
+  useOrganizationInvitations,
+  useOrganizationMembers,
+} from '@/hooks/use-organization'
+import { cn } from '@/lib/utils'
+
+interface OrganizationOnboardingProps {
+  orgSlug: string
+  organizationName: string
+  onSkip: () => void
+}
+
+interface LinkedAccount {
+  id: string
+  accountId: string
+  providerId: string
+}
+
+type ProviderId = 'google' | 'github'
+
+const shellTransition = { duration: 0.65, ease: [0.16, 1, 0.3, 1] as const }
+
+const socialProviders: Array<{
+  id: ProviderId
+  name: string
+  icon: LucideIcon | typeof GoogleIcon
+  accent: string
+  bg: string
+  description: string
+}> = [
+  {
+    id: 'google',
+    name: 'Google',
+    icon: GoogleIcon,
+    accent: 'text-rose-600 dark:text-rose-300',
+    bg: 'bg-rose-500/12',
+    description: 'Bring Google sign-in online for less friction across the team.',
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    icon: Github,
+    accent: 'text-slate-700 dark:text-slate-200',
+    bg: 'bg-slate-500/12',
+    description: 'Keep engineering access one click away with GitHub auth.',
+  },
+]
+
+export function OrganizationOnboarding({
+  orgSlug,
+  organizationName,
+  onSkip,
+}: OrganizationOnboardingProps) {
+  const { envConnections, isAuthless } = useAppMode()
+  const { user } = useAuth()
+  const { data: activeOrg } = useActiveOrganization()
+  const { data: members = [], isLoading: membersLoading } = useOrganizationMembers()
+  const { data: invitations = [], isLoading: invitationsLoading } = useOrganizationInvitations()
+  const inviteMember = useInviteMember()
+
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteRole, setInviteRole] = useState<MemberRole>('member')
+  const [inviteSuccess, setInviteSuccess] = useState<string | null>(null)
+  const [accounts, setAccounts] = useState<LinkedAccount[]>([])
+  const [accountsLoading, setAccountsLoading] = useState(!isAuthless)
+  const [linkingProvider, setLinkingProvider] = useState<ProviderId | null>(null)
+
+  const currentMembership = members.find((member) => member.userId === user?.id)
+  const canManageMembers =
+    !isAuthless && (currentMembership?.role === 'owner' || currentMembership?.role === 'admin')
+  const linkedProviders = accounts.filter(
+    (account): account is LinkedAccount & { providerId: ProviderId } =>
+      account.providerId === 'google' || account.providerId === 'github'
+  )
+  const linkedProviderIds = new Set(linkedProviders.map((account) => account.providerId))
+  const teamReady = members.length > 1 || invitations.length > 0
+  const accountsReady = linkedProviderIds.size > 0
+  const optionalProgress = Number(teamReady) + Number(accountsReady)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadAccounts() {
+      if (isAuthless || !user) {
+        setAccounts([])
+        setAccountsLoading(false)
+        return
+      }
+
+      try {
+        setAccountsLoading(true)
+        const result = await listAccounts()
+        if (!cancelled) {
+          setAccounts((result.data as LinkedAccount[] | undefined) ?? [])
+        }
+      } finally {
+        if (!cancelled) {
+          setAccountsLoading(false)
+        }
+      }
+    }
+
+    void loadAccounts()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthless, user])
+
+  const topBarConfig = useMemo(
+    () => ({
+      left: (
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted/70 text-muted-foreground">
+            <WandSparkles className="h-4 w-4" />
+          </span>
+          <h1 className="truncate text-base font-semibold md:text-lg">Getting Started</h1>
+          <span className="hidden text-sm text-muted-foreground xl:inline">
+            Bring {organizationName} online
+          </span>
+        </div>
+      ),
+      actions: (
+        <Button variant="ghost" size="xs" onClick={onSkip}>
+          Skip for now
+        </Button>
+      ),
+    }),
+    [onSkip, organizationName]
+  )
+
+  useAppTopBar(topBarConfig)
+
+  const handleInvite = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!activeOrg?.id) return
+
+    try {
+      await inviteMember.mutateAsync({
+        email: inviteEmail,
+        role: inviteRole,
+        organizationId: activeOrg.id,
+      })
+      setInviteSuccess(inviteEmail)
+      setInviteEmail('')
+      setInviteRole('member')
+    } catch {
+      setInviteSuccess(null)
+    }
+  }
+
+  const handleLinkProvider = async (provider: ProviderId) => {
+    setLinkingProvider(provider)
+    try {
+      trackEvent(AnalyticsEvents.USER_ACCOUNT_LINKED, {
+        provider,
+        success: true,
+      })
+      const result = await linkSocial({ provider })
+      if (result?.error) {
+        setLinkingProvider(null)
+      }
+    } catch {
+      setLinkingProvider(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <motion.section
+        className="relative isolate overflow-hidden rounded-[34px] border border-border/70 bg-card/90 shadow-[0_28px_120px_-68px_rgba(15,23,42,0.75)]"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={shellTransition}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.2),transparent_30%),radial-gradient(circle_at_82%_18%,rgba(251,191,36,0.15),transparent_24%),linear-gradient(140deg,rgba(14,116,144,0.12),transparent_45%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.22),transparent_30%),radial-gradient(circle_at_82%_18%,rgba(251,191,36,0.16),transparent_24%),linear-gradient(140deg,rgba(6,78,59,0.15),transparent_45%)]" />
+        <div className="pointer-events-none absolute inset-0 opacity-45 [background-image:linear-gradient(to_right,rgba(148,163,184,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(148,163,184,0.12)_1px,transparent_1px)] [background-size:34px_34px]" />
+
+        <div className="relative grid gap-8 px-6 py-8 sm:px-8 sm:py-10 xl:grid-cols-[1.2fr_0.8fr] xl:px-10">
+          <div className="space-y-7">
+            <motion.div
+              className="inline-flex items-center gap-2 rounded-full border border-white/35 bg-background/75 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] text-muted-foreground shadow-sm backdrop-blur"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ ...shellTransition, delay: 0.06 }}
+            >
+              <Sparkles className="h-3.5 w-3.5 text-sky-500" />
+              New Organization
+            </motion.div>
+
+            <motion.div
+              className="space-y-4"
+              initial={{ opacity: 0, y: 14 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ ...shellTransition, delay: 0.1 }}
+            >
+              <h2
+                className="max-w-4xl text-4xl font-semibold tracking-tight text-foreground sm:text-5xl xl:text-[3.7rem]"
+                style={{
+                  fontFamily: '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif',
+                }}
+              >
+                Turn <span className="text-sky-500">{organizationName}</span> into a live BullMQ
+                control room.
+              </h2>
+              <p className="max-w-2xl text-base leading-8 text-muted-foreground sm:text-lg">
+                Add your first Redis connection, pull teammates into the workspace, and connect the
+                sign-in providers your team already trusts. The platform is ready. It just needs a
+                signal.
+              </p>
+            </motion.div>
+
+            <motion.div
+              className="flex flex-wrap gap-3"
+              initial={{ opacity: 0, y: 18 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ ...shellTransition, delay: 0.16 }}
+            >
+              <Button asChild size="lg" className="gap-2 rounded-full px-6">
+                <Link
+                  to="/$orgSlug/connections"
+                  params={{ orgSlug }}
+                  search={envConnections ? undefined : { create: 1 }}
+                >
+                  {envConnections ? 'Configure connection source' : 'Add first connection'}
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild size="lg" variant="outline" className="rounded-full px-6">
+                <Link to="/$orgSlug/connections" params={{ orgSlug }}>
+                  View connection setup
+                </Link>
+              </Button>
+            </motion.div>
+
+            <motion.div
+              className="grid gap-3 md:grid-cols-3"
+              initial={{ opacity: 0, y: 22 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ ...shellTransition, delay: 0.22 }}
+            >
+              <HeroMetric
+                icon={Database}
+                label="Primary launch step"
+                value={envConnections ? 'Wire env vars' : 'Connect Redis'}
+                copy="The only required move before queues and analytics can boot."
+              />
+              <HeroMetric
+                icon={Users}
+                label="Optional accelerators"
+                value={`${optionalProgress}/2 complete`}
+                copy="Invite teammates and link auth providers while the workspace is still fresh."
+              />
+              <HeroMetric
+                icon={BadgeCheck}
+                label="Workspace posture"
+                value={teamReady || accountsReady ? 'Momentum started' : 'Blank slate'}
+                copy="Clean organizations onboard fastest when the first workflow is deliberate."
+              />
+            </motion.div>
+          </div>
+
+          <motion.div
+            className="relative"
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ ...shellTransition, delay: 0.2 }}
+          >
+            <div className="absolute inset-0 rounded-[30px] bg-gradient-to-br from-sky-500/10 via-transparent to-amber-500/10 blur-3xl" />
+            <Card className="relative overflow-hidden rounded-[30px] border border-border/70 bg-background/80 shadow-[0_24px_90px_-54px_rgba(15,23,42,0.92)] backdrop-blur">
+              <CardContent className="space-y-6 p-6">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                      Launch Sequence
+                    </p>
+                    <p className="mt-1 text-xl font-semibold text-foreground">
+                      The first ten minutes
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="rounded-full px-3 py-1 text-xs">
+                    Guided
+                  </Badge>
+                </div>
+
+                <div className="space-y-4">
+                  {[
+                    {
+                      step: '01',
+                      title: envConnections
+                        ? 'Point Durabull at Redis'
+                        : 'Create the first connection',
+                      copy: envConnections
+                        ? 'Add the env-backed Redis URLs Durabull should read at boot.'
+                        : 'Save a Redis endpoint and let queue discovery index the surface area.',
+                      progress: 72,
+                      tone: 'bg-sky-500/70',
+                    },
+                    {
+                      step: '02',
+                      title: 'Invite collaborators',
+                      copy: 'Loop in teammates before production alerts start landing here.',
+                      progress: teamReady ? 100 : 46,
+                      tone: 'bg-emerald-500/70',
+                    },
+                    {
+                      step: '03',
+                      title: 'Link Google or GitHub',
+                      copy: 'Reduce auth friction now, not during the first urgent incident.',
+                      progress: accountsReady ? 100 : 38,
+                      tone: 'bg-amber-500/75',
+                    },
+                  ].map((item, index) => (
+                    <div
+                      key={item.step}
+                      className="rounded-[22px] border border-border/65 bg-muted/28 p-4"
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-border/70 bg-background/80 text-sm font-semibold text-foreground">
+                          {item.step}
+                        </div>
+                        <div className="min-w-0 flex-1 space-y-2">
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <p className="text-sm font-semibold text-foreground">{item.title}</p>
+                              <p className="text-sm leading-6 text-muted-foreground">{item.copy}</p>
+                            </div>
+                            <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                          </div>
+                          <div className="h-2 overflow-hidden rounded-full bg-background/80">
+                            <motion.div
+                              className={cn('h-full rounded-full', item.tone)}
+                              initial={{ width: 0 }}
+                              animate={{ width: `${item.progress}%` }}
+                              transition={{ duration: 1, delay: 0.38 + index * 0.12 }}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+        </div>
+      </motion.section>
+
+      <div className="grid gap-5 xl:grid-cols-[1.05fr_0.95fr_0.95fr]">
+        <OnboardingCard
+          icon={Database}
+          title={envConnections ? 'Point Durabull at Redis' : 'Add your first connection'}
+          description={
+            envConnections
+              ? 'This workspace uses environment-managed connections. Wire the Redis URLs once and the whole platform wakes up on restart.'
+              : 'Create a connection, kick off queue discovery, and land directly in the queues dashboard.'
+          }
+          accent="from-sky-500/18 via-sky-500/5 to-transparent"
+        >
+          <div className="space-y-4">
+            <div className="rounded-[24px] border border-border/70 bg-background/75 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Connection path</p>
+                  <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                    {envConnections
+                      ? 'Define env-backed Redis URLs for the environments you want to expose.'
+                      : 'Store a Redis URL, set the environment, and let Durabull discover queues automatically.'}
+                  </p>
+                </div>
+                <Cloud className="h-5 w-5 shrink-0 text-sky-500" />
+              </div>
+            </div>
+
+            {envConnections ? (
+              <div className="rounded-[20px] border border-dashed border-border/70 bg-muted/25 p-4">
+                <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  Suggested variable
+                </p>
+                <code className="mt-2 block rounded-xl bg-background/80 px-3 py-2 font-mono text-sm text-foreground">
+                  DURABULL_REDIS_URL_PRODUCTION
+                </code>
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-3">
+              <Button asChild className="gap-2">
+                <Link
+                  to="/$orgSlug/connections"
+                  params={{ orgSlug }}
+                  search={envConnections ? undefined : { create: 1 }}
+                >
+                  {envConnections ? 'Open setup guide' : 'Create connection'}
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link to="/$orgSlug/connections" params={{ orgSlug }}>
+                  Review connections
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </OnboardingCard>
+
+        <OnboardingCard
+          icon={UserPlus}
+          title="Invite your team"
+          description="Shared visibility is worth more than a polished dashboard used by one person."
+          accent="from-emerald-500/18 via-emerald-500/5 to-transparent"
+        >
+          {isAuthless ? (
+            <div className="rounded-[22px] border border-border/70 bg-muted/25 p-4 text-sm leading-6 text-muted-foreground">
+              Team management is disabled in authless mode.
+            </div>
+          ) : canManageMembers ? (
+            <form onSubmit={handleInvite} className="space-y-4">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Users className="h-4 w-4 text-emerald-500" />
+                <span>
+                  {membersLoading || invitationsLoading
+                    ? 'Loading team posture...'
+                    : `${members.length} member${members.length === 1 ? '' : 's'} • ${invitations.length} pending invite${invitations.length === 1 ? '' : 's'}`}
+                </span>
+              </div>
+
+              <Input
+                type="email"
+                value={inviteEmail}
+                onChange={(event) => {
+                  setInviteEmail(event.target.value)
+                  setInviteSuccess(null)
+                }}
+                placeholder="teammate@company.com"
+                className="h-11 rounded-2xl bg-background/80"
+              />
+
+              <div className="flex flex-wrap gap-2">
+                {[
+                  { value: 'member' as const, label: 'Member', icon: Users },
+                  { value: 'admin' as const, label: 'Admin', icon: Shield },
+                ].map((roleOption) => (
+                  <button
+                    key={roleOption.value}
+                    type="button"
+                    onClick={() => setInviteRole(roleOption.value)}
+                    className={cn(
+                      'inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm transition-colors',
+                      inviteRole === roleOption.value
+                        ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+                        : 'border-border/70 bg-background/70 text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    <roleOption.icon className="h-3.5 w-3.5" />
+                    {roleOption.label}
+                  </button>
+                ))}
+              </div>
+
+              {inviteSuccess ? (
+                <div className="flex items-center gap-2 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-300">
+                  <Check className="h-4 w-4" />
+                  Invitation sent to {inviteSuccess}
+                </div>
+              ) : null}
+
+              {inviteMember.error ? (
+                <div className="rounded-2xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {inviteMember.error.message}
+                </div>
+              ) : null}
+
+              <div className="flex gap-3">
+                <Button
+                  type="submit"
+                  className="gap-2"
+                  disabled={inviteMember.isPending || !inviteEmail}
+                >
+                  {inviteMember.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Sending
+                    </>
+                  ) : (
+                    <>
+                      <Mail className="h-4 w-4" />
+                      Send invite
+                    </>
+                  )}
+                </Button>
+                <Button asChild variant="outline">
+                  <Link to="/$orgSlug/team" params={{ orgSlug }}>
+                    Open team page
+                  </Link>
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <div className="space-y-4">
+              <div className="rounded-[22px] border border-border/70 bg-muted/25 p-4 text-sm leading-6 text-muted-foreground">
+                {membersLoading
+                  ? 'Loading team permissions...'
+                  : 'You do not currently have permission to invite members from this workspace.'}
+              </div>
+              <Button asChild variant="outline">
+                <Link to="/$orgSlug/team" params={{ orgSlug }}>
+                  Open team page
+                </Link>
+              </Button>
+            </div>
+          )}
+        </OnboardingCard>
+
+        <OnboardingCard
+          icon={BadgeCheck}
+          title="Connect Google or GitHub"
+          description="Make future sign-ins boring. That is exactly the point."
+          accent="from-amber-500/18 via-amber-500/5 to-transparent"
+        >
+          {isAuthless ? (
+            <div className="rounded-[22px] border border-border/70 bg-muted/25 p-4 text-sm leading-6 text-muted-foreground">
+              External auth providers are disabled in authless mode.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {socialProviders.map((provider) => {
+                const ProviderIcon = provider.icon
+                const linked = linkedProviderIds.has(provider.id)
+
+                return (
+                  <div
+                    key={provider.id}
+                    className="rounded-[22px] border border-border/70 bg-background/76 p-4"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex min-w-0 items-start gap-3">
+                        <span
+                          className={cn(
+                            'flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl',
+                            provider.bg
+                          )}
+                        >
+                          <ProviderIcon className={cn('h-5 w-5', provider.accent)} />
+                        </span>
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-semibold text-foreground">{provider.name}</p>
+                            {linked ? (
+                              <Badge className="rounded-full bg-emerald-500/12 text-emerald-700 shadow-none dark:text-emerald-300">
+                                Connected
+                              </Badge>
+                            ) : null}
+                          </div>
+                          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                            {provider.description}
+                          </p>
+                        </div>
+                      </div>
+                      {linked ? (
+                        <Button asChild variant="ghost" size="sm">
+                          <Link to="/settings">Manage</Link>
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          className="gap-2"
+                          disabled={accountsLoading || linkingProvider !== null}
+                          onClick={() => handleLinkProvider(provider.id)}
+                        >
+                          {linkingProvider === provider.id ? (
+                            <>
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              Connecting
+                            </>
+                          ) : (
+                            'Connect'
+                          )}
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+
+              <div className="rounded-[22px] border border-dashed border-border/70 bg-muted/22 p-4 text-sm leading-6 text-muted-foreground">
+                {accountsLoading
+                  ? 'Loading linked providers...'
+                  : linkedProviders.length > 0
+                    ? `${linkedProviders.length} provider${linkedProviders.length === 1 ? '' : 's'} linked already.`
+                    : 'No external providers linked yet.'}
+              </div>
+            </div>
+          )}
+        </OnboardingCard>
+      </div>
+
+      <motion.div
+        className="flex flex-col items-start justify-between gap-3 rounded-[28px] border border-border/70 bg-card/70 px-5 py-4 sm:flex-row sm:items-center sm:px-6"
+        initial={{ opacity: 0, y: 18 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...shellTransition, delay: 0.28 }}
+      >
+        <div>
+          <p className="text-sm font-semibold text-foreground">Prefer to come back later?</p>
+          <p className="text-sm text-muted-foreground">
+            Skip the guided setup now. You can reopen it any time from the empty connection state.
+          </p>
+        </div>
+        <Button variant="ghost" onClick={onSkip}>
+          Skip for now
+        </Button>
+      </motion.div>
+    </div>
+  )
+}
+
+function HeroMetric({
+  icon: Icon,
+  label,
+  value,
+  copy,
+}: {
+  icon: LucideIcon
+  label: string
+  value: string
+  copy: string
+}) {
+  return (
+    <Card className="overflow-hidden border border-border/70 bg-background/72 backdrop-blur">
+      <CardContent className="space-y-3 p-4">
+        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-muted/60 text-muted-foreground">
+          <Icon className="h-4 w-4" />
+        </span>
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            {label}
+          </p>
+          <p className="text-lg font-semibold text-foreground">{value}</p>
+          <p className="text-sm leading-6 text-muted-foreground">{copy}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function OnboardingCard({
+  icon: Icon,
+  title,
+  description,
+  accent,
+  children,
+}: {
+  icon: LucideIcon
+  title: string
+  description: string
+  accent: string
+  children: React.ReactNode
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 18 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={shellTransition}
+    >
+      <Card className="relative isolate h-full overflow-hidden rounded-[30px] border border-border/70 bg-card/88 shadow-[0_24px_85px_-60px_rgba(15,23,42,0.85)]">
+        <div className={cn('absolute inset-0 bg-gradient-to-br opacity-90', accent)} />
+        <CardContent className="relative space-y-5 p-5 sm:p-6">
+          <div className="space-y-3">
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/20 bg-background/85 text-foreground shadow-sm">
+              <Icon className="h-5 w-5" />
+            </span>
+            <div className="space-y-2">
+              <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+              <p className="text-sm leading-7 text-muted-foreground">{description}</p>
+            </div>
+          </div>
+          {children}
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}
+
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="currentColor"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  )
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -18,8 +18,12 @@ import { Route as OrgSlugRouteImport } from './routes/$orgSlug'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OrgSlugIndexRouteImport } from './routes/$orgSlug.index'
 import { Route as InviteInvitationIdRouteImport } from './routes/invite.$invitationId'
+import { Route as OrgSlugAnalyticsRouteImport } from './routes/$orgSlug.analytics'
 import { Route as OrgSlugTeamRouteImport } from './routes/$orgSlug.team'
 import { Route as OrgSlugConnectionsRouteImport } from './routes/$orgSlug.connections'
+import { Route as OrgSlugWorkersRouteImport } from './routes/$orgSlug.workers'
+import { Route as OrgSlugScheduledJobsRouteImport } from './routes/$orgSlug.scheduled-jobs'
+import { Route as OrgSlugRedisKeysRouteImport } from './routes/$orgSlug.redis-keys'
 import { Route as OrgSlugCConnectionIdRouteImport } from './routes/$orgSlug.c.$connectionId'
 import { Route as OrgSlugCConnectionIdIndexRouteImport } from './routes/$orgSlug.c.$connectionId.index'
 import { Route as OrgSlugCConnectionIdAnalyticsRouteImport } from './routes/$orgSlug.c.$connectionId.analytics'
@@ -74,6 +78,11 @@ const InviteInvitationIdRoute = InviteInvitationIdRouteImport.update({
   path: '/invite/$invitationId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OrgSlugAnalyticsRoute = OrgSlugAnalyticsRouteImport.update({
+  id: '/analytics',
+  path: '/analytics',
+  getParentRoute: () => OrgSlugRoute,
+} as any)
 const OrgSlugTeamRoute = OrgSlugTeamRouteImport.update({
   id: '/team',
   path: '/team',
@@ -82,6 +91,21 @@ const OrgSlugTeamRoute = OrgSlugTeamRouteImport.update({
 const OrgSlugConnectionsRoute = OrgSlugConnectionsRouteImport.update({
   id: '/connections',
   path: '/connections',
+  getParentRoute: () => OrgSlugRoute,
+} as any)
+const OrgSlugWorkersRoute = OrgSlugWorkersRouteImport.update({
+  id: '/workers',
+  path: '/workers',
+  getParentRoute: () => OrgSlugRoute,
+} as any)
+const OrgSlugScheduledJobsRoute = OrgSlugScheduledJobsRouteImport.update({
+  id: '/scheduled-jobs',
+  path: '/scheduled-jobs',
+  getParentRoute: () => OrgSlugRoute,
+} as any)
+const OrgSlugRedisKeysRoute = OrgSlugRedisKeysRouteImport.update({
+  id: '/redis-keys',
+  path: '/redis-keys',
   getParentRoute: () => OrgSlugRoute,
 } as any)
 const OrgSlugCConnectionIdRoute = OrgSlugCConnectionIdRouteImport.update({
@@ -135,8 +159,12 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/setup-organization': typeof SetupOrganizationRoute
   '/signup': typeof SignupRoute
+  '/$orgSlug/analytics': typeof OrgSlugAnalyticsRoute
   '/$orgSlug/connections': typeof OrgSlugConnectionsRoute
+  '/$orgSlug/redis-keys': typeof OrgSlugRedisKeysRoute
+  '/$orgSlug/scheduled-jobs': typeof OrgSlugScheduledJobsRoute
   '/$orgSlug/team': typeof OrgSlugTeamRoute
+  '/$orgSlug/workers': typeof OrgSlugWorkersRoute
   '/invite/$invitationId': typeof InviteInvitationIdRoute
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/c/$connectionId': typeof OrgSlugCConnectionIdRouteWithChildren
@@ -155,8 +183,12 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/setup-organization': typeof SetupOrganizationRoute
   '/signup': typeof SignupRoute
+  '/$orgSlug/analytics': typeof OrgSlugAnalyticsRoute
   '/$orgSlug/connections': typeof OrgSlugConnectionsRoute
+  '/$orgSlug/redis-keys': typeof OrgSlugRedisKeysRoute
+  '/$orgSlug/scheduled-jobs': typeof OrgSlugScheduledJobsRoute
   '/$orgSlug/team': typeof OrgSlugTeamRoute
+  '/$orgSlug/workers': typeof OrgSlugWorkersRoute
   '/invite/$invitationId': typeof InviteInvitationIdRoute
   '/$orgSlug': typeof OrgSlugIndexRoute
   '/$orgSlug/c/$connectionId/analytics': typeof OrgSlugCConnectionIdAnalyticsRoute
@@ -176,8 +208,12 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/setup-organization': typeof SetupOrganizationRoute
   '/signup': typeof SignupRoute
+  '/$orgSlug/analytics': typeof OrgSlugAnalyticsRoute
   '/$orgSlug/connections': typeof OrgSlugConnectionsRoute
+  '/$orgSlug/redis-keys': typeof OrgSlugRedisKeysRoute
+  '/$orgSlug/scheduled-jobs': typeof OrgSlugScheduledJobsRoute
   '/$orgSlug/team': typeof OrgSlugTeamRoute
+  '/$orgSlug/workers': typeof OrgSlugWorkersRoute
   '/invite/$invitationId': typeof InviteInvitationIdRoute
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/c/$connectionId': typeof OrgSlugCConnectionIdRouteWithChildren
@@ -199,8 +235,12 @@ export interface FileRouteTypes {
     | '/settings'
     | '/setup-organization'
     | '/signup'
+    | '/$orgSlug/analytics'
     | '/$orgSlug/connections'
+    | '/$orgSlug/redis-keys'
+    | '/$orgSlug/scheduled-jobs'
     | '/$orgSlug/team'
+    | '/$orgSlug/workers'
     | '/invite/$invitationId'
     | '/$orgSlug/'
     | '/$orgSlug/c/$connectionId'
@@ -219,8 +259,12 @@ export interface FileRouteTypes {
     | '/settings'
     | '/setup-organization'
     | '/signup'
+    | '/$orgSlug/analytics'
     | '/$orgSlug/connections'
+    | '/$orgSlug/redis-keys'
+    | '/$orgSlug/scheduled-jobs'
     | '/$orgSlug/team'
+    | '/$orgSlug/workers'
     | '/invite/$invitationId'
     | '/$orgSlug'
     | '/$orgSlug/c/$connectionId/analytics'
@@ -239,8 +283,12 @@ export interface FileRouteTypes {
     | '/settings'
     | '/setup-organization'
     | '/signup'
+    | '/$orgSlug/analytics'
     | '/$orgSlug/connections'
+    | '/$orgSlug/redis-keys'
+    | '/$orgSlug/scheduled-jobs'
     | '/$orgSlug/team'
+    | '/$orgSlug/workers'
     | '/invite/$invitationId'
     | '/$orgSlug/'
     | '/$orgSlug/c/$connectionId'
@@ -329,6 +377,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InviteInvitationIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/$orgSlug/analytics': {
+      id: '/$orgSlug/analytics'
+      path: '/analytics'
+      fullPath: '/$orgSlug/analytics'
+      preLoaderRoute: typeof OrgSlugAnalyticsRouteImport
+      parentRoute: typeof OrgSlugRoute
+    }
     '/$orgSlug/team': {
       id: '/$orgSlug/team'
       path: '/team'
@@ -341,6 +396,27 @@ declare module '@tanstack/react-router' {
       path: '/connections'
       fullPath: '/$orgSlug/connections'
       preLoaderRoute: typeof OrgSlugConnectionsRouteImport
+      parentRoute: typeof OrgSlugRoute
+    }
+    '/$orgSlug/workers': {
+      id: '/$orgSlug/workers'
+      path: '/workers'
+      fullPath: '/$orgSlug/workers'
+      preLoaderRoute: typeof OrgSlugWorkersRouteImport
+      parentRoute: typeof OrgSlugRoute
+    }
+    '/$orgSlug/scheduled-jobs': {
+      id: '/$orgSlug/scheduled-jobs'
+      path: '/scheduled-jobs'
+      fullPath: '/$orgSlug/scheduled-jobs'
+      preLoaderRoute: typeof OrgSlugScheduledJobsRouteImport
+      parentRoute: typeof OrgSlugRoute
+    }
+    '/$orgSlug/redis-keys': {
+      id: '/$orgSlug/redis-keys'
+      path: '/redis-keys'
+      fullPath: '/$orgSlug/redis-keys'
+      preLoaderRoute: typeof OrgSlugRedisKeysRouteImport
       parentRoute: typeof OrgSlugRoute
     }
     '/$orgSlug/c/$connectionId': {
@@ -428,15 +504,23 @@ const OrgSlugCConnectionIdRouteWithChildren = OrgSlugCConnectionIdRoute._addFile
 )
 
 interface OrgSlugRouteChildren {
+  OrgSlugAnalyticsRoute: typeof OrgSlugAnalyticsRoute
   OrgSlugConnectionsRoute: typeof OrgSlugConnectionsRoute
+  OrgSlugRedisKeysRoute: typeof OrgSlugRedisKeysRoute
+  OrgSlugScheduledJobsRoute: typeof OrgSlugScheduledJobsRoute
   OrgSlugTeamRoute: typeof OrgSlugTeamRoute
+  OrgSlugWorkersRoute: typeof OrgSlugWorkersRoute
   OrgSlugIndexRoute: typeof OrgSlugIndexRoute
   OrgSlugCConnectionIdRoute: typeof OrgSlugCConnectionIdRouteWithChildren
 }
 
 const OrgSlugRouteChildren: OrgSlugRouteChildren = {
+  OrgSlugAnalyticsRoute: OrgSlugAnalyticsRoute,
   OrgSlugConnectionsRoute: OrgSlugConnectionsRoute,
+  OrgSlugRedisKeysRoute: OrgSlugRedisKeysRoute,
+  OrgSlugScheduledJobsRoute: OrgSlugScheduledJobsRoute,
   OrgSlugTeamRoute: OrgSlugTeamRoute,
+  OrgSlugWorkersRoute: OrgSlugWorkersRoute,
   OrgSlugIndexRoute: OrgSlugIndexRoute,
   OrgSlugCConnectionIdRoute: OrgSlugCConnectionIdRouteWithChildren,
 }

--- a/apps/web/src/routes/$orgSlug.analytics.tsx
+++ b/apps/web/src/routes/$orgSlug.analytics.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { BarChart3 } from 'lucide-react'
+import { NoConnectionConfigured } from '@/components/no-connection-configured'
+
+export const Route = createFileRoute('/$orgSlug/analytics')({
+  component: AnalyticsFallbackRoute,
+})
+
+function AnalyticsFallbackRoute() {
+  const { orgSlug } = Route.useParams()
+
+  return (
+    <NoConnectionConfigured
+      orgSlug={orgSlug}
+      area="Analytics"
+      icon={BarChart3}
+      description="Analytics needs a connection before Durabull can aggregate queue health, throughput, and fleet-level risk signals."
+    />
+  )
+}

--- a/apps/web/src/routes/$orgSlug.connections.tsx
+++ b/apps/web/src/routes/$orgSlug.connections.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate, useParams } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
 
 // Connection types - matches API response
 type ConnectionEnvironment = 'development' | 'staging' | 'production'
@@ -32,6 +33,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { z } from 'zod'
 import { useAppTopBar } from '@/components/app-top-bar'
 import { useConnection } from '@/components/connection-provider'
 import { Badge } from '@/components/ui/badge'
@@ -55,8 +57,8 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useAppMode } from '@/hooks/use-app-mode'
 import {
-  useConnectionQueueDiscoveryStatus,
   useConnectionDetail,
+  useConnectionQueueDiscoveryStatus,
   useCreateConnection,
   useDeleteConnection,
   useRunConnectionQueueDiscovery,
@@ -66,7 +68,15 @@ import {
 } from '@/hooks/use-connections'
 import { cn } from '@/lib/utils'
 
+const connectionsSearchSchema = z.object({
+  create: z
+    .union([z.literal(true), z.literal('true'), z.literal(1), z.literal('1')])
+    .transform(() => true)
+    .optional(),
+})
+
 export const Route = createFileRoute('/$orgSlug/connections')({
+  validateSearch: zodValidator(connectionsSearchSchema),
   component: ConnectionsPage,
 })
 
@@ -194,6 +204,7 @@ function EnvironmentSectionSkeleton({ envConfig }: { envConfig: (typeof environm
 
 function ConnectionsPage() {
   const { envConnections } = useAppMode()
+  const { create } = Route.useSearch()
   const { connections, isLoading, error } = useConnection()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [editingConnection, setEditingConnection] = useState<RedisConnection | null>(null)
@@ -237,6 +248,11 @@ function ConnectionsPage() {
   useEffect(() => {
     trackEvent(AnalyticsEvents.CONNECTIONS_VIEWED)
   }, [])
+
+  useEffect(() => {
+    if (!create || envConnections) return
+    setCreateDialogOpen(true)
+  }, [create, envConnections])
 
   if (error) {
     return (

--- a/apps/web/src/routes/$orgSlug.index.tsx
+++ b/apps/web/src/routes/$orgSlug.index.tsx
@@ -1,67 +1,121 @@
-import { useQuery } from '@tanstack/react-query'
-import { createFileRoute, Navigate } from '@tanstack/react-router'
-import { Loader2 } from 'lucide-react'
-import { connectionsQueryKey } from '@/components/connection-provider'
-import { ApiError, api, type InferResponseType } from '@/lib/api'
+import { createFileRoute, Navigate, useNavigate } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
+import { AlertCircle, Layers, Loader2 } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { z } from 'zod'
+import { useConnection } from '@/components/connection-provider'
+import { NoConnectionConfigured } from '@/components/no-connection-configured'
+import { OrganizationOnboarding } from '@/components/organization-onboarding'
+import { useOrganizations } from '@/hooks/use-organization'
+
+const onboardingSearchSchema = z.object({
+  onboarding: z
+    .union([z.literal(true), z.literal('true'), z.literal(1), z.literal('1')])
+    .transform(() => true)
+    .optional(),
+})
+
+const ONBOARDING_STORAGE_PREFIX = 'durabull:onboarding:'
 
 export const Route = createFileRoute('/$orgSlug/')({
+  validateSearch: zodValidator(onboardingSearchSchema),
   component: OrgIndexRoute,
 })
 
-// Type helpers using Hono's InferResponseType
-type ListConnectionsResponse = InferResponseType<(typeof api.connections)['$get'], 200>
-type Connection = ListConnectionsResponse['connections'][number]
-
-async function fetchConnections(): Promise<Connection[]> {
-  const res = await api.connections.$get()
-  if (!res.ok) {
-    const data = (await res.json().catch(() => ({}))) as { error?: string; message?: string }
-    throw new ApiError(data.error || data.message || `API error: ${res.status}`, res.status)
-  }
-  const data = await res.json()
-  return data.connections
+function getOnboardingStorageKey(orgSlug: string) {
+  return `${ONBOARDING_STORAGE_PREFIX}${orgSlug}`
 }
 
-/**
- * Index route for an organization.
- * Automatically redirects to the default connection's queues dashboard.
- */
+function readOnboardingState(orgSlug: string): boolean {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(getOnboardingStorageKey(orgSlug)) === 'completed'
+}
+
+function writeOnboardingState(orgSlug: string) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(getOnboardingStorageKey(orgSlug), 'completed')
+}
+
+function humanizeOrgSlug(orgSlug: string) {
+  return orgSlug
+    .split('-')
+    .filter(Boolean)
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join(' ')
+}
+
 function OrgIndexRoute() {
   const { orgSlug } = Route.useParams()
+  const { onboarding } = Route.useSearch()
+  const navigate = useNavigate()
+  const { connections, currentConnection, isLoading, error } = useConnection()
+  const { data: organizations } = useOrganizations()
+  const [onboardingCompleted, setOnboardingCompleted] = useState(() => readOnboardingState(orgSlug))
 
-  const {
-    data: connections,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: connectionsQueryKey,
-    queryFn: fetchConnections,
-    staleTime: 30_000,
-  })
+  useEffect(() => {
+    setOnboardingCompleted(readOnboardingState(orgSlug))
+  }, [orgSlug])
 
-  // Loading state
+  const completeOnboarding = useCallback(() => {
+    writeOnboardingState(orgSlug)
+    setOnboardingCompleted(true)
+    void navigate({
+      to: '/$orgSlug',
+      params: { orgSlug },
+      search: {},
+      replace: true,
+    })
+  }, [navigate, orgSlug])
+
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-background">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-4" />
-        <p className="text-muted-foreground">Loading connections...</p>
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-3">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          <p className="text-sm text-muted-foreground">Loading connections...</p>
+        </div>
       </div>
     )
   }
 
-  // Error state or no connections - redirect to connections page to set up
-  if (error || !connections || connections.length === 0) {
-    return <Navigate to="/$orgSlug/connections" params={{ orgSlug }} replace />
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16">
+        <div className="rounded-full bg-destructive/10 p-4">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+        </div>
+        <h2 className="mt-4 text-xl font-semibold text-foreground">Failed to load connections</h2>
+        <p className="mt-2 max-w-md text-center text-muted-foreground">{error.message}</p>
+      </div>
+    )
   }
 
-  // Find the default connection or use the first one
-  const defaultConnection = connections.find((c) => c.isDefault) ?? connections[0]
+  if (connections.length === 0) {
+    const organizationName =
+      organizations?.find((organization) => organization.slug === orgSlug)?.name ??
+      humanizeOrgSlug(orgSlug)
 
-  // Redirect to the default connection's queues dashboard
+    if (onboarding || !onboardingCompleted) {
+      return (
+        <OrganizationOnboarding
+          orgSlug={orgSlug}
+          organizationName={organizationName}
+          onSkip={completeOnboarding}
+        />
+      )
+    }
+
+    return <NoConnectionConfigured orgSlug={orgSlug} area="Queues" icon={Layers} />
+  }
+
+  if (!currentConnection) {
+    return <NoConnectionConfigured orgSlug={orgSlug} area="Queues" icon={Layers} />
+  }
+
   return (
     <Navigate
       to="/$orgSlug/c/$connectionId"
-      params={{ orgSlug, connectionId: defaultConnection.id }}
+      params={{ orgSlug, connectionId: currentConnection.id }}
       replace
     />
   )

--- a/apps/web/src/routes/$orgSlug.redis-keys.tsx
+++ b/apps/web/src/routes/$orgSlug.redis-keys.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Database } from 'lucide-react'
+import { NoConnectionConfigured } from '@/components/no-connection-configured'
+
+export const Route = createFileRoute('/$orgSlug/redis-keys')({
+  component: RedisKeysFallbackRoute,
+})
+
+function RedisKeysFallbackRoute() {
+  const { orgSlug } = Route.useParams()
+
+  return (
+    <NoConnectionConfigured
+      orgSlug={orgSlug}
+      area="Redis Explorer"
+      icon={Database}
+      description="Redis Explorer cannot enumerate keys until a connection is configured for this organization."
+    />
+  )
+}

--- a/apps/web/src/routes/$orgSlug.scheduled-jobs.tsx
+++ b/apps/web/src/routes/$orgSlug.scheduled-jobs.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Calendar } from 'lucide-react'
+import { NoConnectionConfigured } from '@/components/no-connection-configured'
+
+export const Route = createFileRoute('/$orgSlug/scheduled-jobs')({
+  component: ScheduledJobsFallbackRoute,
+})
+
+function ScheduledJobsFallbackRoute() {
+  const { orgSlug } = Route.useParams()
+
+  return (
+    <NoConnectionConfigured
+      orgSlug={orgSlug}
+      area="Scheduled Jobs"
+      icon={Calendar}
+      description="Scheduled jobs need a configured Redis connection before Durabull can index schedulers and surface upcoming work."
+    />
+  )
+}

--- a/apps/web/src/routes/$orgSlug.workers.tsx
+++ b/apps/web/src/routes/$orgSlug.workers.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Network } from 'lucide-react'
+import { NoConnectionConfigured } from '@/components/no-connection-configured'
+
+export const Route = createFileRoute('/$orgSlug/workers')({
+  component: WorkersFallbackRoute,
+})
+
+function WorkersFallbackRoute() {
+  const { orgSlug } = Route.useParams()
+
+  return (
+    <NoConnectionConfigured
+      orgSlug={orgSlug}
+      area="Workers"
+      icon={Network}
+      description="Workers becomes available once Durabull can inspect a Redis connection and map workers back to discovered queues."
+    />
+  )
+}


### PR DESCRIPTION

<img width="1885" height="1572" alt="Screenshot 2026-03-06 at 5 16 29 PM" src="https://github.com/user-attachments/assets/2c410511-937d-4122-b131-1f32648fbb00" />

## What?
- replace the empty-organization redirect with an animated onboarding experience
- add a shared "No connection configured" state for connection-dependent platform pages
- add org-level fallback routes for Analytics, Workers, Scheduled Jobs, and Redis Explorer when no connection is selected
- let onboarding deep-link straight into the create-connection flow

## Why?
New organizations currently land in a dead-end state: platform links under the sidebar can route to pages that only work with an active connection, and the initial experience does not actively guide users toward the first meaningful setup actions. This PR makes the first-run path intentional and keeps the app coherent even after onboarding is skipped.

## How?
- added a new onboarding surface on the org index with connection, teammate invite, and Google/GitHub linking actions
- persisted the onboarding skip/completion state per org in localStorage
- added a reusable no-connection component and org-scoped fallback routes for connection-required views
- added `?create` handling on the connections page so CTA buttons can open the create dialog directly
- updated the generated route tree for the new routes

## Testing
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build`

## Notes
- `vite build` emitted a local environment warning that Node `22.10.0` is below Vite's recommended `22.12+`, but the build completed successfully.
- Browser/E2E validation was not run in this pass.
