### PR TITLE
Rename sidebar to KV Explorer

### DIFF
--- a/apps/web/e2e/authless.spec.ts
+++ b/apps/web/e2e/authless.spec.ts
@@ -94,7 +94,7 @@ test.describe('Authless Mode', () => {
       page.getByRole('heading', { name: 'Scheduled Jobs', exact: true, level: 1 })
     ).toBeVisible()
 
-    await page.getByRole('link', { name: 'Redis Explorer' }).click()
+    await page.getByRole('link', { name: 'KV Explorer' }).click()
     await expect(
       page.getByRole('heading', { name: 'Redis Explorer', exact: true, level: 1 })
     ).toBeVisible()

--- a/apps/web/e2e/pages.spec.ts
+++ b/apps/web/e2e/pages.spec.ts
@@ -125,7 +125,7 @@ test.describe("Pages", () => {
       page.getByRole("heading", { name: "Scheduled Jobs", exact: true, level: 1 })
     ).toBeVisible();
 
-    await page.getByRole("link", { name: "Redis Explorer" }).click();
+    await page.getByRole("link", { name: "KV Explorer" }).click();
     await page.waitForURL(new RegExp(`/${TEST_ORG_SLUG}/c/${connectionId}/redis-keys`));
     await expect(
       page.getByRole("heading", { name: "Redis Explorer", exact: true, level: 1 })

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -294,7 +294,7 @@ function SidebarNav() {
         Scheduled Jobs
       </NavLink>
       <NavLink to={`${basePath}/redis-keys`} icon={Database}>
-        Redis Explorer
+        KV Explorer
       </NavLink>
 
       <div className="mb-2 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
@@ -340,7 +340,7 @@ function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
         Scheduled Jobs
       </MobileNavLink>
       <MobileNavLink to={`${basePath}/redis-keys`} icon={Database} onNavigate={onNavigate}>
-        Redis Explorer
+        KV Explorer
       </MobileNavLink>
 
       <div className="mb-2 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">


### PR DESCRIPTION
## Summary
- rename the sidebar navigation label from Redis Explorer to KV Explorer on desktop and mobile
- update the E2E tests that locate the sidebar link by accessible name

## Testing
- bun run --filter @durabull/web typecheck