### PR TITLE
feat: add Redis Cluster connection support

### DIFF
--- a/apps/api/src/lib/alert-monitor.test.ts
+++ b/apps/api/src/lib/alert-monitor.test.ts
@@ -73,6 +73,7 @@ function createConnection(): RedisConnection {
     organizationId: TEST_ORG_ID,
     name: 'Primary Redis',
     url: 'redis://localhost:6379/0',
+    mode: 'standalone',
     environment: 'development',
     isDefault: true,
     prefix: 'bull',

--- a/apps/api/src/lib/queue-discovery.ts
+++ b/apps/api/src/lib/queue-discovery.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto'
-import { redisDiscoveredQueueRepository } from '@durabull/dal'
-import type { RedisConnectionOptions } from './redis'
-import { scanQueuesPage } from './redis'
+import { type ConnectionMode, redisDiscoveredQueueRepository } from '@durabull/dal'
+import { type RedisConnectionOptions, scanQueuesPage } from './redis'
 
 const DEFAULT_DISCOVERY_SCAN_COUNT = 1000
 
@@ -74,7 +73,8 @@ async function runQueueDiscovery(
   connectionUrl: string,
   scanCount: number,
   prefix = 'bull',
-  redisOptions?: RedisConnectionOptions
+  redisOptions?: RedisConnectionOptions,
+  mode: ConnectionMode = 'standalone'
 ): Promise<void> {
   const runtime = discoveryStateByConnection.get(connectionId)
   if (!runtime) return
@@ -91,7 +91,8 @@ async function runQueueDiscovery(
       cursor,
       scanCount,
       prefix,
-      redisOptions
+      redisOptions,
+      mode
     )
     cursor = page.cursor
     runtime.scannedPages += 1
@@ -132,6 +133,7 @@ export async function startQueueDiscovery(
     scanCount?: number
     prefix?: string
     allowSelfSignedCerts?: boolean
+    mode?: ConnectionMode
   }
 ): Promise<QueueDiscoveryStatus> {
   const existingRun = activeDiscoveryRuns.get(connectionId)
@@ -159,12 +161,14 @@ export async function startQueueDiscovery(
 
   discoveryStateByConnection.set(connectionId, runtime)
 
+  const mode = options?.mode ?? 'standalone'
   const runPromise = runQueueDiscovery(
     connectionId,
     connectionUrl,
     scanCount,
     prefix,
-    redisOptions
+    redisOptions,
+    mode
   )
     .catch((error) => {
       if (discoveryStateByConnection.get(connectionId) === runtime) {

--- a/apps/api/src/lib/redis.ts
+++ b/apps/api/src/lib/redis.ts
@@ -1,8 +1,10 @@
+import type { ConnectionMode } from '@durabull/dal'
 import { Queue } from 'bullmq'
-import { Redis } from 'ioredis'
+import { Cluster, Redis } from 'ioredis'
 import { buildIoRedisConnectionOptions, type RedisConnectionOptions } from './connection-options'
 
 export type { RedisConnectionOptions } from './connection-options'
+export type RedisClient = Redis | Cluster
 
 export class RedisUnavailableError extends Error {
   readonly code = 'REDIS_UNAVAILABLE'
@@ -17,10 +19,10 @@ export class RedisUnavailableError extends Error {
   }
 }
 
-// Cache for Redis connections keyed by connection ID and URL
-const redisConnections = new Map<string, Redis>()
+// Cache for Redis connections keyed by (connectionId, url, allowSelfSignedCerts, mode)
+const redisConnections = new Map<string, RedisClient>()
 // Cache in-flight connection attempts to prevent creating duplicate clients concurrently
-const redisConnectionPromises = new Map<string, Promise<Redis>>()
+const redisConnectionPromises = new Map<string, Promise<RedisClient>>()
 // Cache recent failures to avoid hot-looping permanent connection/auth issues
 const recentRedisConnectionFailures = new Map<
   string,
@@ -28,7 +30,7 @@ const recentRedisConnectionFailures = new Map<
 >()
 // Cache recent log lines to dedupe noisy repeated errors
 const recentRedisErrorLogs = new Map<string, { message: string; at: number }>()
-// Cache for queues keyed by connection ID, connection URL, prefix, and queue name
+// Cache for queues keyed by (connectionId, url, prefix, name, allowSelfSignedCerts, mode)
 const queues = new Map<string, Queue>()
 
 const REDIS_RECONNECT_BASE_DELAY_MS = 200
@@ -93,9 +95,9 @@ function toRedisUnavailableError(
   )
 }
 
-function disconnectRedisClient(redis: Redis) {
+function disconnectRedisClient(client: RedisClient) {
   try {
-    redis.disconnect(false)
+    client.disconnect(false)
   } catch {
     // Ignore cleanup failures; connection is already unhealthy.
   }
@@ -117,6 +119,58 @@ function shouldLogRedisError(connectionId: string, message: string): boolean {
   return true
 }
 
+/**
+ * Parse a Redis URL into host and port for cluster startup nodes.
+ * Returns extra ioredis options derived from the URL (auth, TLS).
+ */
+function parseRedisUrl(url: string): {
+  host: string
+  port: number
+  redisOptions: Record<string, unknown>
+} {
+  const parsed = new URL(url)
+  const host = parsed.hostname
+  const port = parsed.port ? parseInt(parsed.port, 10) : 6379
+  const redisOptions: Record<string, unknown> = {}
+
+  if (parsed.password) {
+    redisOptions.password = decodeURIComponent(parsed.password)
+  }
+  if (parsed.username && parsed.username !== 'default') {
+    redisOptions.username = decodeURIComponent(parsed.username)
+  }
+  if (parsed.protocol === 'rediss:') {
+    redisOptions.tls = {}
+  }
+
+  return { host, port, redisOptions }
+}
+
+function attachClientErrorHandlers(client: RedisClient, cacheKey: string, label: string) {
+  const modeLabel = client instanceof Cluster ? 'Redis Cluster' : 'Redis'
+
+  client.on('error', (error) => {
+    const message = getSafeRedisErrorMessage(error)
+
+    if (shouldLogRedisError(cacheKey, message)) {
+      console.error(`❌ ${modeLabel} error (${label}): ${message}`)
+    }
+
+    if (isPermanentRedisConnectionError(message)) {
+      recentRedisConnectionFailures.set(cacheKey, {
+        message,
+        at: Date.now(),
+        permanent: true,
+      })
+      disconnectRedisClient(client)
+    }
+  })
+
+  client.on('end', () => {
+    redisConnections.delete(cacheKey)
+  })
+}
+
 function buildRedisClient(
   connectionUrl: string,
   cacheKey: string,
@@ -133,44 +187,95 @@ function buildRedisClient(
     ...buildIoRedisConnectionOptions(options),
   })
 
-  redis.on('error', (error) => {
-    const message = getSafeRedisErrorMessage(error)
-
-    if (shouldLogRedisError(cacheKey, message)) {
-      console.error(`❌ Redis error (${label}): ${message}`)
-    }
-
-    if (isPermanentRedisConnectionError(message)) {
-      recentRedisConnectionFailures.set(cacheKey, {
-        message,
-        at: Date.now(),
-        permanent: true,
-      })
-      disconnectRedisClient(redis)
-    }
-  })
-
-  redis.on('end', () => {
-    redisConnections.delete(cacheKey)
-  })
-
+  attachClientErrorHandlers(redis, cacheKey, label)
   return redis
+}
+
+function buildClusterClient(
+  connectionUrl: string,
+  cacheKey: string,
+  label: string,
+  options?: RedisConnectionOptions
+): Cluster {
+  const { host, port, redisOptions: urlOptions } = parseRedisUrl(connectionUrl)
+  const tlsOptions = buildIoRedisConnectionOptions(options)
+
+  // Merge TLS settings: rediss:// gives `tls: {}`, self-signed opt-in adds
+  // `tls: { rejectUnauthorized: false }`. The opt-in takes precedence.
+  const mergedRedisOptions: Record<string, unknown> = { ...urlOptions }
+  if (tlsOptions.tls) {
+    mergedRedisOptions.tls = { ...(urlOptions.tls as object | undefined), ...tlsOptions.tls }
+  }
+
+  // When connecting through a tunnel (localhost/127.0.0.1), cluster nodes report their
+  // internal IPs in CLUSTER SLOTS which aren't reachable. Use natMap to redirect all
+  // discovered nodes back through the tunnel endpoint.
+  const isTunneled = host === 'localhost' || host === '127.0.0.1' || host === '::1'
+
+  const cluster = new Cluster([{ host, port }], {
+    lazyConnect: true,
+    redisOptions: {
+      maxRetriesPerRequest: null,
+      ...mergedRedisOptions,
+    },
+    clusterRetryStrategy: (attempts) => {
+      if (attempts > REDIS_MAX_RECONNECT_ATTEMPTS) return null
+      return Math.min(attempts * REDIS_RECONNECT_BASE_DELAY_MS, REDIS_RECONNECT_MAX_DELAY_MS)
+    },
+    ...(isTunneled
+      ? {
+          natMap: () => ({ host, port }),
+          scaleReads: 'master' as const,
+        }
+      : {}),
+  })
+
+  attachClientErrorHandlers(cluster, cacheKey, label)
+  return cluster
+}
+
+function makeConnectionCacheKey(
+  connectionId: string,
+  connectionUrl: string,
+  options: RedisConnectionOptions | undefined,
+  mode: ConnectionMode
+): string {
+  return JSON.stringify([connectionId, connectionUrl, options?.allowSelfSignedCerts ?? false, mode])
+}
+
+/**
+ * Scan all master nodes of a cluster for keys matching the pattern.
+ */
+async function scanAllClusterNodes(
+  cluster: Cluster,
+  pattern: string,
+  count: number
+): Promise<string[]> {
+  const masters = cluster.nodes('master')
+  const allKeys: string[] = []
+  for (const master of masters) {
+    let cursor = '0'
+    do {
+      const [next, keys] = await master.scan(cursor, 'MATCH', pattern, 'COUNT', count)
+      cursor = next
+      allKeys.push(...keys)
+    } while (cursor !== '0')
+  }
+  return allKeys
 }
 
 /**
  * Get or create a Redis connection for the given connection ID and URL.
+ * Pass mode='cluster' to connect via Redis Cluster.
  */
 export async function getRedis(
   connectionId: string,
   connectionUrl: string,
   connectionName?: string,
-  options?: RedisConnectionOptions
-): Promise<Redis> {
-  const cacheKey = JSON.stringify([
-    connectionId,
-    connectionUrl,
-    options?.allowSelfSignedCerts ?? false,
-  ])
+  options?: RedisConnectionOptions,
+  mode: ConnectionMode = 'standalone'
+): Promise<RedisClient> {
+  const cacheKey = makeConnectionCacheKey(connectionId, connectionUrl, options, mode)
   const existingConnection = redisConnections.get(cacheKey)
   if (existingConnection) {
     if (existingConnection.status !== 'end') {
@@ -194,14 +299,19 @@ export async function getRedis(
   }
 
   const connectPromise = (async () => {
-    const redis = buildRedisClient(connectionUrl, cacheKey, connectionName ?? connectionId, options)
+    const label = connectionName ?? connectionId
+    const client =
+      mode === 'cluster'
+        ? buildClusterClient(connectionUrl, cacheKey, label, options)
+        : buildRedisClient(connectionUrl, cacheKey, label, options)
 
     try {
-      await redis.connect()
-      redisConnections.set(cacheKey, redis)
+      await client.connect()
+      redisConnections.set(cacheKey, client)
       recentRedisConnectionFailures.delete(cacheKey)
-      console.log(`✅ Connected to Redis: ${connectionName ?? connectionId}`)
-      return redis
+      const modeLabel = mode === 'cluster' ? 'Redis Cluster' : 'Redis'
+      console.log(`✅ Connected to ${modeLabel}: ${label}`)
+      return client
     } catch (error) {
       const message = getSafeRedisErrorMessage(error)
       const existingFailure = recentRedisConnectionFailures.get(cacheKey)
@@ -212,7 +322,7 @@ export async function getRedis(
         at: Date.now(),
         permanent,
       })
-      disconnectRedisClient(redis)
+      disconnectRedisClient(client)
       throw toRedisUnavailableError(connectionId, connectionName, failureMessage)
     } finally {
       redisConnectionPromises.delete(cacheKey)
@@ -230,11 +340,33 @@ export async function discoverQueues(
   connectionId: string,
   connectionUrl: string,
   prefix = 'bull',
-  options?: RedisConnectionOptions
+  options?: RedisConnectionOptions,
+  mode: ConnectionMode = 'standalone'
 ): Promise<Array<string>> {
   const queueNames = new Set<string>()
-  let cursor = '0'
 
+  if (mode === 'cluster') {
+    const client = (await getRedis(
+      connectionId,
+      connectionUrl,
+      undefined,
+      options,
+      mode
+    )) as Cluster
+    const escapedPrefix = prefix.replace(/[\\*?[\]]/g, '\\$&')
+    const keys = await scanAllClusterNodes(
+      client,
+      `${escapedPrefix}:*:meta`,
+      DEFAULT_QUEUE_SCAN_COUNT
+    )
+    for (const key of keys) {
+      const queueName = extractQueueNameFromMetaKey(key)
+      if (queueName) queueNames.add(queueName)
+    }
+    return Array.from(queueNames)
+  }
+
+  let cursor = '0'
   do {
     const page = await scanQueuesPage(
       connectionId,
@@ -242,7 +374,8 @@ export async function discoverQueues(
       cursor,
       DEFAULT_QUEUE_SCAN_COUNT,
       prefix,
-      options
+      options,
+      mode
     )
     cursor = page.cursor
     for (const queueName of page.queueNames) {
@@ -264,11 +397,24 @@ export async function scanQueuesPage(
   cursor = '0',
   count = DEFAULT_QUEUE_SCAN_COUNT,
   prefix = 'bull',
-  options?: RedisConnectionOptions
+  options?: RedisConnectionOptions,
+  mode: ConnectionMode = 'standalone'
 ): Promise<QueueScanPage> {
-  const redisClient = await getRedis(connectionId, connectionUrl, undefined, options)
+  const redisClient = await getRedis(connectionId, connectionUrl, undefined, options, mode)
   const scanCount = Math.max(100, count)
   const escapedPrefix = prefix.replace(/[\\*?[\]]/g, '\\$&')
+
+  if (redisClient instanceof Cluster) {
+    // For cluster mode, scan all master nodes in one go
+    const keys = await scanAllClusterNodes(redisClient, `${escapedPrefix}:*:meta`, scanCount)
+    const queueNames = new Set<string>()
+    for (const key of keys) {
+      const queueName = extractQueueNameFromMetaKey(key)
+      if (queueName) queueNames.add(queueName)
+    }
+    return { cursor: '0', queueNames: Array.from(queueNames) }
+  }
+
   const [nextCursor, keys] = await redisClient.scan(
     cursor,
     'MATCH',
@@ -298,10 +444,17 @@ export async function debugGetBullKeys(
   connectionId: string,
   connectionUrl: string,
   prefix = 'bull',
-  options?: RedisConnectionOptions
+  options?: RedisConnectionOptions,
+  mode: ConnectionMode = 'standalone'
 ): Promise<string[]> {
-  const redisClient = await getRedis(connectionId, connectionUrl, undefined, options)
+  const redisClient = await getRedis(connectionId, connectionUrl, undefined, options, mode)
   const escapedPrefix = prefix.replace(/[\\*?[\]]/g, '\\$&')
+
+  if (redisClient instanceof Cluster) {
+    const keys = await scanAllClusterNodes(redisClient, `${escapedPrefix}:*`, 100)
+    return keys.sort()
+  }
+
   const keys: string[] = []
   let cursor = '0'
 
@@ -328,7 +481,8 @@ export async function getQueue(
   connectionUrl: string,
   name: string,
   prefix = 'bull',
-  options?: RedisConnectionOptions
+  options?: RedisConnectionOptions,
+  mode: ConnectionMode = 'standalone'
 ): Promise<Queue> {
   const cacheKey = JSON.stringify([
     connectionId,
@@ -336,21 +490,30 @@ export async function getQueue(
     prefix,
     name,
     options?.allowSelfSignedCerts ?? false,
+    mode,
   ])
 
   if (!queues.has(cacheKey)) {
-    const queue = new Queue(name, {
-      connection: {
-        url: connectionUrl,
-        maxRetriesPerRequest: null,
-        retryStrategy: (attempts: number) => {
-          if (attempts > REDIS_MAX_RECONNECT_ATTEMPTS) return null
-          return Math.min(attempts * REDIS_RECONNECT_BASE_DELAY_MS, REDIS_RECONNECT_MAX_DELAY_MS)
+    let queue: Queue
+
+    if (mode === 'cluster') {
+      // For cluster mode, pass the cluster client instance directly to BullMQ
+      const client = await getRedis(connectionId, connectionUrl, undefined, options, mode)
+      queue = new Queue(name, { connection: client, prefix })
+    } else {
+      queue = new Queue(name, {
+        connection: {
+          url: connectionUrl,
+          maxRetriesPerRequest: null,
+          retryStrategy: (attempts: number) => {
+            if (attempts > REDIS_MAX_RECONNECT_ATTEMPTS) return null
+            return Math.min(attempts * REDIS_RECONNECT_BASE_DELAY_MS, REDIS_RECONNECT_MAX_DELAY_MS)
+          },
+          ...buildIoRedisConnectionOptions(options),
         },
-        ...buildIoRedisConnectionOptions(options),
-      },
-      prefix,
-    })
+        prefix,
+      })
+    }
 
     queue.on('error', (error) => {
       const message = getSafeRedisErrorMessage(error)
@@ -361,7 +524,7 @@ export async function getQueue(
 
       if (isPermanentRedisConnectionError(message)) {
         recentRedisConnectionFailures.set(
-          JSON.stringify([connectionId, connectionUrl, options?.allowSelfSignedCerts ?? false]),
+          makeConnectionCacheKey(connectionId, connectionUrl, options, mode),
           {
             message,
             at: Date.now(),

--- a/apps/api/src/mcp/tools/shared.test.ts
+++ b/apps/api/src/mcp/tools/shared.test.ts
@@ -22,13 +22,14 @@ describe('resolveConnectionForPrincipal', () => {
     canDelegatedUserAccessConnection.mockImplementation(async () => true)
     findById.mockReset()
     findByIdUnsafe.mockReset()
-    findByIdUnsafe.mockImplementation(async () => ({
+    findByIdUnsafe.mockImplementation((async () => ({
       id: 'conn-1',
       organizationId: 'org-1',
       url: 'https://redis.example.com',
+      mode: 'standalone',
       prefix: 'queues',
       allowSelfSignedCerts: false,
-    }))
+    })) as never)
   })
 
   it('skips delegated access re-check when policy already verified access', async () => {

--- a/apps/api/src/middleware/connection.ts
+++ b/apps/api/src/middleware/connection.ts
@@ -1,5 +1,9 @@
 import type { Auth } from '@durabull/auth'
-import { redisConnectionRepository, shouldUseEnvConnections } from '@durabull/dal'
+import {
+  type ConnectionMode,
+  redisConnectionRepository,
+  shouldUseEnvConnections,
+} from '@durabull/dal'
 import type { Session } from 'better-auth/types'
 import { createMiddleware } from 'hono/factory'
 import { getAuthlessContext, isAuthlessMode } from '../lib/authless'
@@ -12,6 +16,7 @@ declare module 'hono' {
     connectionName: string
     connectionPrefix: string
     connectionAllowSelfSignedCerts: boolean
+    connectionMode: ConnectionMode
   }
 }
 
@@ -149,6 +154,7 @@ export function createConnectionMiddleware(auth?: Auth) {
     c.set('connectionName', connection.name)
     c.set('connectionPrefix', connection.prefix ?? 'bull')
     c.set('connectionAllowSelfSignedCerts', connection.allowSelfSignedCerts ?? false)
+    c.set('connectionMode', connection.mode ?? 'standalone')
 
     await next()
   })

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -1,5 +1,6 @@
 import {
   and,
+  connectionModes,
   eq,
   getDb,
   member,
@@ -10,10 +11,11 @@ import {
 import { env } from '@durabull/env'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
-import { Redis } from 'ioredis'
+import { Cluster, Redis } from 'ioredis'
 import { z } from 'zod'
 import { buildIoRedisConnectionOptions } from '../lib/connection-options'
 import { resetQueueDiscoveryState } from '../lib/queue-discovery'
+import type { RedisClient } from '../lib/redis'
 import { validateRedisUrlForEnvironment } from '../lib/url-validation'
 import { requireOrganization } from '../middleware/auth'
 import { connectionTestRateLimiter } from '../middleware/rate-limit'
@@ -44,6 +46,7 @@ const app = new Hono()
     const connections = dbConnections.map((conn) => ({
       id: conn.id,
       name: conn.name,
+      mode: conn.mode ?? 'standalone',
       isDefault: conn.isDefault,
       environment: conn.environment,
       prefix: conn.prefix,
@@ -71,6 +74,7 @@ const app = new Hono()
         id: conn.id,
         name: conn.name,
         url: canViewSecret ? conn.url : null,
+        mode: conn.mode ?? 'standalone',
         isDefault: conn.isDefault,
         environment: conn.environment,
         prefix: conn.prefix,
@@ -89,6 +93,7 @@ const app = new Hono()
       z.object({
         name: z.string().min(1).max(100),
         url: z.string().min(1),
+        mode: z.enum(connectionModes).optional().default('standalone'),
         environment: z.enum(['development', 'staging', 'production']).optional(),
         isDefault: z.boolean().optional(),
         prefix: connectionPrefixSchema.default('bull'),
@@ -134,6 +139,7 @@ const app = new Hono()
       const conn = await redisConnectionRepository.create({
         name: body.name,
         url: body.url,
+        mode: body.mode,
         environment: body.environment ?? 'development',
         isDefault: body.isDefault ?? false,
         prefix: body.prefix,
@@ -146,6 +152,7 @@ const app = new Hono()
           connection: {
             id: conn.id,
             name: conn.name,
+            mode: conn.mode ?? 'standalone',
             isDefault: conn.isDefault,
             environment: conn.environment,
             prefix: conn.prefix,
@@ -165,6 +172,7 @@ const app = new Hono()
       z.object({
         name: z.string().min(1).max(100).optional(),
         url: z.string().min(1).optional(),
+        mode: z.enum(connectionModes).optional(),
         environment: z.enum(['development', 'staging', 'production']).optional(),
         isDefault: z.boolean().optional(),
         prefix: connectionPrefixSchema.optional(),
@@ -220,6 +228,7 @@ const app = new Hono()
       const updateData: Parameters<typeof redisConnectionRepository.update>[2] = {}
       if (body.name !== undefined) updateData.name = body.name
       if (body.url !== undefined) updateData.url = body.url
+      if (body.mode !== undefined) updateData.mode = body.mode
       if (body.environment !== undefined) updateData.environment = body.environment
       if (body.isDefault === false) updateData.isDefault = false
       if (body.prefix !== undefined) updateData.prefix = body.prefix
@@ -241,6 +250,7 @@ const app = new Hono()
         connection: {
           id: conn.id,
           name: conn.name,
+          mode: conn.mode ?? 'standalone',
           isDefault: conn.isDefault,
           environment: conn.environment,
           prefix: conn.prefix,
@@ -297,10 +307,11 @@ const app = new Hono()
       z.object({
         url: z.string().min(1),
         allowSelfSignedCerts: z.boolean().optional(),
+        mode: z.enum(connectionModes).optional().default('standalone'),
       })
     ),
     async (c) => {
-      const { url, allowSelfSignedCerts } = c.req.valid('json')
+      const { url, allowSelfSignedCerts, mode } = c.req.valid('json')
 
       // Validate URL to prevent SSRF attacks
       const validation = validateRedisUrlForEnvironment(url)
@@ -315,18 +326,45 @@ const app = new Hono()
       }
 
       const startTime = Date.now()
-      let redis: Redis | null = null
+      let client: RedisClient | null = null
 
       try {
-        redis = new Redis(url, {
-          connectTimeout: 5000,
-          maxRetriesPerRequest: 1,
-          lazyConnect: true,
-          ...buildIoRedisConnectionOptions({ allowSelfSignedCerts }),
-        })
+        if (mode === 'cluster') {
+          const parsed = new URL(url)
+          const clusterHost = parsed.hostname
+          const clusterPort = parsed.port ? parseInt(parsed.port, 10) : 6379
+          const isTunneled =
+            clusterHost === 'localhost' || clusterHost === '127.0.0.1' || clusterHost === '::1'
+          client = new Cluster([{ host: clusterHost, port: clusterPort }], {
+            lazyConnect: true,
+            redisOptions: {
+              connectTimeout: 5000,
+              maxRetriesPerRequest: 1,
+              ...(parsed.password ? { password: decodeURIComponent(parsed.password) } : {}),
+              ...(parsed.username && parsed.username !== 'default'
+                ? { username: decodeURIComponent(parsed.username) }
+                : {}),
+              ...(parsed.protocol === 'rediss:' ? { tls: {} } : {}),
+              ...buildIoRedisConnectionOptions({ allowSelfSignedCerts }),
+            },
+            ...(isTunneled
+              ? {
+                  natMap: () => ({ host: clusterHost, port: clusterPort }),
+                  scaleReads: 'master' as const,
+                }
+              : {}),
+          })
+        } else {
+          client = new Redis(url, {
+            connectTimeout: 5000,
+            maxRetriesPerRequest: 1,
+            lazyConnect: true,
+            ...buildIoRedisConnectionOptions({ allowSelfSignedCerts }),
+          })
+        }
 
-        await redis.connect()
-        await redis.ping()
+        await client.connect()
+        await client.ping()
 
         const latencyMs = Date.now() - startTime
 
@@ -352,8 +390,8 @@ const app = new Hono()
           400
         )
       } finally {
-        if (redis) {
-          await redis.quit().catch(() => {})
+        if (client) {
+          await client.quit().catch(() => {})
         }
       }
     }

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,9 +1,9 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 import { buildQueueAddOptions, jobOptionsSchema } from '../lib/job-options'
 import { getQueue } from '../lib/redis'
-import { getConnectionRedisOptions } from '../lib/connection-options'
 
 // Default page size for stacktraces and logs
 const DEFAULT_PAGE_SIZE = 50
@@ -95,6 +95,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const status = c.req.query('status')
     const name = c.req.query('name')
@@ -111,7 +112,14 @@ const app = new Hono()
       Number.isInteger(cursor) && cursor !== null ? Math.max(0, cursor) : (page - 1) * pageSize
     const end = start + pageSize - 1
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
 
     if (jobId) {
       const job = await queue.getJob(jobId)
@@ -188,7 +196,10 @@ const app = new Hono()
     if (needsClientFilter) {
       // Fetch each state separately so we know the status without per-job getState() calls,
       // then return all filtered results in one response for client-side pagination.
-      const jobsWithState: Array<{ job: NonNullable<Awaited<ReturnType<typeof queue.getJobs>>[number]>; state: JobState }> = []
+      const jobsWithState: Array<{
+        job: NonNullable<Awaited<ReturnType<typeof queue.getJobs>>[number]>
+        state: JobState
+      }> = []
       for (const state of states) {
         const stateJobs = await queue.getJobs([state])
         for (const job of stateJobs) {
@@ -199,11 +210,7 @@ const app = new Hono()
       }
 
       const filtered = jobsWithState
-        .filter(({ job }) =>
-          name
-            ? job.name.toLowerCase().includes(name.toLowerCase())
-            : true
-        )
+        .filter(({ job }) => (name ? job.name.toLowerCase().includes(name.toLowerCase()) : true))
         .filter(({ job }) =>
           jobId
             ? String(job.id ?? '')
@@ -288,10 +295,18 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     const job = await queue.getJob(jobId)
 
     if (!job) {
@@ -334,6 +349,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
     const pageStr = c.req.query('page')
@@ -345,7 +361,14 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     const job = await queue.getJob(jobId)
 
     if (!job) {
@@ -384,6 +407,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
     const pageStr = c.req.query('page')
@@ -397,7 +421,14 @@ const app = new Hono()
     const start = (page - 1) * pageSize
     const end = start + pageSize - 1
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     // BullMQ getJobLogs accepts start and end parameters for pagination
     const logs = await queue.getJobLogs(jobId, start, end)
 
@@ -416,11 +447,19 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
     const keepMostRecent = 0
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     const job = await queue.getJob(jobId)
 
     if (!job) {
@@ -490,12 +529,20 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
+      const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const jobId = c.req.param('jobId')
       const { keepMostRecent } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions,
+        connectionMode
+      )
       const job = await queue.getJob(jobId)
 
       if (!job) {
@@ -562,12 +609,20 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
+      const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const jobId = c.req.param('jobId')
       const { keepMostRecent } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions,
+        connectionMode
+      )
       const job = await queue.getJob(jobId)
 
       if (!job) {
@@ -636,11 +691,19 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
+      const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const { jobIds, statuses } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions,
+        connectionMode
+      )
       let success = 0
       let failed = 0
       const errors: Array<{ jobId: string; error: string }> = []
@@ -766,11 +829,19 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
+      const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const { jobIds, removeScheduler } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions,
+        connectionMode
+      )
       let success = 0
       let schedulersRemoved = 0
       const errors: Array<{ jobId: string; error: string }> = []
@@ -871,11 +942,19 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
+      const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const { jobIds, jobData } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions,
+        connectionMode
+      )
       let success = 0
       const errors: Array<{ jobId: string; error: string }> = []
 
@@ -914,11 +993,19 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
+      const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const { name, data, ...options } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions,
+        connectionMode
+      )
       const job = await queue.add(name, data, buildQueueAddOptions(options))
 
       return c.json({

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -7,8 +7,8 @@ import {
   DEFAULT_PRIORITY_BUCKETS,
   MAX_METRICS_WINDOW_MINUTES,
 } from '../lib/bullmq-metrics'
-import { discoverQueues, getQueue } from '../lib/redis'
 import { getConnectionRedisOptions } from '../lib/connection-options'
+import { discoverQueues, getQueue } from '../lib/redis'
 
 // Default and max page sizes for pagination
 const DEFAULT_PAGE_SIZE = 50
@@ -52,6 +52,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const query = c.req.valid('query')
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
@@ -62,7 +63,13 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix, redisOptions)
+    const allQueueNames = await discoverQueues(
+      connectionId,
+      connectionUrl,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     const total = allQueueNames.length
 
     // Paginate the queue names BEFORE fetching metrics
@@ -80,7 +87,14 @@ const app = new Hono()
 
     const metrics = await Promise.all(
       paginatedQueueNames.map(async (queueName) => {
-        const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+        const queue = await getQueue(
+          connectionId,
+          connectionUrl,
+          queueName,
+          connectionPrefix,
+          redisOptions,
+          connectionMode
+        )
         const nativeMetrics = await collectQueueNativeMetrics(queue, {
           queueName,
           start: 0,

--- a/apps/api/src/routes/queues.ts
+++ b/apps/api/src/routes/queues.ts
@@ -240,7 +240,14 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
-    const keys = await debugGetBullKeys(connectionId, connectionUrl, connectionPrefix, redisOptions)
+    const connectionMode = c.get('connectionMode')
+    const keys = await debugGetBullKeys(
+      connectionId,
+      connectionUrl,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
 
     // Group keys by pattern to make it easier to understand
     const metaKeys = keys.filter((k) => k.endsWith(':meta'))
@@ -272,6 +279,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
 
     const scanCountParam = c.req.query('scanCount')
     const waitParam = c.req.query('wait')
@@ -283,6 +291,7 @@ const app = new Hono()
       allowSelfSignedCerts: redisOptions.allowSelfSignedCerts,
       scanCount:
         requestedScanCount && Number.isFinite(requestedScanCount) ? requestedScanCount : undefined,
+      mode: connectionMode,
     })
 
     if (waitForCompletion) {
@@ -298,6 +307,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const query = c.req.valid('query')
     const page = Math.max(1, parseInteger(query.page) ?? 1)
     const pageSize = Math.min(parseInteger(query.pageSize) ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE)
@@ -318,6 +328,7 @@ const app = new Hono()
       await startQueueDiscovery(connectionId, connectionUrl, {
         prefix: connectionPrefix,
         allowSelfSignedCerts: redisOptions.allowSelfSignedCerts,
+        mode: connectionMode,
       })
       discovery = await getQueueDiscoveryStatus(connectionId)
       indexedTotal = discovery.indexed.total
@@ -346,7 +357,8 @@ const app = new Hono()
           connectionUrl,
           indexedQueue.name,
           connectionPrefix,
-          redisOptions
+          redisOptions,
+          connectionMode
         )
         const [counts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()])
 
@@ -414,13 +426,15 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const queue = await getQueue(
       connectionId,
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     const [counts, isPaused, workers, schedulers] = await Promise.all([
       queue.getJobCounts(),
@@ -460,6 +474,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const query = c.req.valid('query')
 
@@ -500,7 +515,8 @@ const app = new Hono()
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     const metrics = await collectQueueNativeMetrics(queue, {
       queueName,
@@ -519,13 +535,15 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const queue = await getQueue(
       connectionId,
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     await queue.pause()
     return c.json({ success: true })
@@ -536,13 +554,15 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const queue = await getQueue(
       connectionId,
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     await queue.resume()
     return c.json({ success: true })
@@ -563,6 +583,7 @@ const app = new Hono()
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
       const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const { status, gracePeriod = 0, limit = 1000 } = c.req.valid('json')
       const queue = await getQueue(
@@ -570,7 +591,8 @@ const app = new Hono()
         connectionUrl,
         queueName,
         connectionPrefix,
-        redisOptions
+        redisOptions,
+        connectionMode
       )
 
       const cleanStatus = cleanStatusMap[status as PurgeableQueueStatus]
@@ -602,6 +624,7 @@ const app = new Hono()
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
       const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const { confirmName, statuses, keepMostRecent } = c.req.valid('json')
 
@@ -629,7 +652,8 @@ const app = new Hono()
         connectionUrl,
         queueName,
         connectionPrefix,
-        redisOptions
+        redisOptions,
+        connectionMode
       )
       const removedByStatus = Object.fromEntries(
         statusesToPurge.map((status) => [status, 0])
@@ -839,13 +863,15 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const queue = await getQueue(
       connectionId,
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     await deleteQueueWithDiscoveryCleanup(connectionId, queueName, queue)
     return c.json({ success: true })
@@ -864,6 +890,7 @@ const app = new Hono()
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
       const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const { confirmName } = c.req.valid('json')
 
@@ -877,7 +904,8 @@ const app = new Hono()
         connectionUrl,
         queueName,
         connectionPrefix,
-        redisOptions
+        redisOptions,
+        connectionMode
       )
       const counts = await queue.getJobCounts()
 
@@ -918,13 +946,15 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const queue = await getQueue(
       connectionId,
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     const counts = await queue.getJobCounts()
 

--- a/apps/api/src/routes/redis-keys.ts
+++ b/apps/api/src/routes/redis-keys.ts
@@ -6,9 +6,49 @@ import { getConnectionRedisOptions } from '../lib/connection-options'
 import { getRedis, type RedisClient } from '../lib/redis'
 
 /**
+ * Cursor state for cluster SCAN pagination. Encodes the current master being
+ * scanned and per-master Redis SCAN cursors so each page picks up where the
+ * previous one left off — without re-scanning the whole cluster.
+ */
+interface ClusterScanState {
+  /** Index of the master currently being scanned in the cluster.nodes('master') list */
+  i: number
+  /** Per-master SCAN cursors, parallel to cluster.nodes('master') */
+  c: string[]
+}
+
+const CLUSTER_CURSOR_PREFIX = 'cluster:'
+
+function encodeClusterCursor(state: ClusterScanState): string {
+  return `${CLUSTER_CURSOR_PREFIX}${Buffer.from(JSON.stringify(state), 'utf8').toString('base64url')}`
+}
+
+function decodeClusterCursor(cursor: string, masterCount: number): ClusterScanState {
+  if (!cursor.startsWith(CLUSTER_CURSOR_PREFIX) || cursor === '0') {
+    return { i: 0, c: new Array(masterCount).fill('0') }
+  }
+  try {
+    const decoded = Buffer.from(cursor.slice(CLUSTER_CURSOR_PREFIX.length), 'base64url').toString(
+      'utf8'
+    )
+    const parsed = JSON.parse(decoded) as ClusterScanState
+    // Defensive: pad/trim per-master cursors if cluster topology shifted between calls
+    const cursors = Array.isArray(parsed.c) ? parsed.c.slice(0, masterCount) : []
+    while (cursors.length < masterCount) cursors.push('0')
+    return {
+      i: Math.max(0, Math.min(parsed.i ?? 0, masterCount)),
+      c: cursors,
+    }
+  } catch {
+    return { i: 0, c: new Array(masterCount).fill('0') }
+  }
+}
+
+/**
  * Cluster-aware SCAN: scans all master nodes in a cluster, or uses standard SCAN for standalone.
- * For cluster mode, uses offset-based pagination (cursor is `cluster:<offset>` or '0' for start).
- * For standalone, uses native Redis SCAN cursor.
+ * For cluster mode, returns an encoded cursor that contains per-master SCAN cursors and the
+ * current node index, so successive calls resume where the previous page left off instead of
+ * re-scanning the entire cluster each page.
  */
 async function clusterAwareScan(
   client: RedisClient,
@@ -17,24 +57,30 @@ async function clusterAwareScan(
   count: number
 ): Promise<[string, string[]]> {
   if (client instanceof Cluster) {
-    // Full scan across all master nodes
     const masters = client.nodes('master')
-    const allKeys: string[] = []
-    for (const master of masters) {
-      let nodeCursor = '0'
-      do {
-        const [next, keys] = await master.scan(nodeCursor, 'MATCH', pattern, 'COUNT', count)
-        nodeCursor = next
-        allKeys.push(...keys)
-      } while (nodeCursor !== '0')
+    if (masters.length === 0) return ['0', []]
+
+    const state = decodeClusterCursor(cursor, masters.length)
+    const collected: string[] = []
+
+    // Advance through masters, scanning each incrementally until we have enough keys
+    // or all masters are exhausted.
+    while (state.i < masters.length && collected.length < count) {
+      const master = masters[state.i]
+      const nodeCursor = state.c[state.i] ?? '0'
+      const [next, keys] = await master.scan(nodeCursor, 'MATCH', pattern, 'COUNT', count)
+      state.c[state.i] = next
+      collected.push(...keys)
+
+      if (next === '0') {
+        // This master is exhausted, move to the next one
+        state.i += 1
+      }
     }
 
-    // Offset-based pagination over the full result set
-    const offset = cursor.startsWith('cluster:') ? Number.parseInt(cursor.slice(8), 10) : 0
-    const page = allKeys.slice(offset, offset + count)
-    const nextOffset = offset + page.length
-    const nextCursor = nextOffset < allKeys.length ? `cluster:${nextOffset}` : '0'
-    return [nextCursor, page]
+    const allDone = state.i >= masters.length
+    const nextCursor = allDone ? '0' : encodeClusterCursor(state)
+    return [nextCursor, collected]
   }
   return client.scan(cursor, 'MATCH', pattern, 'COUNT', count)
 }

--- a/apps/api/src/routes/redis-keys.ts
+++ b/apps/api/src/routes/redis-keys.ts
@@ -106,9 +106,23 @@ const MAX_PAGE_SIZE = 100
 // Redis data types
 type RedisDataType = 'string' | 'hash' | 'list' | 'set' | 'zset' | 'stream' | 'none' | 'unknown'
 
-// Helper to check if a key is a BullMQ-managed key
-function isBullKey(key: string): boolean {
-  return key.startsWith('bull:') || key.startsWith('bullmq:')
+/**
+ * Check if a key is a BullMQ-managed key for this connection.
+ *
+ * BullMQ keys follow the pattern `<prefix>:<queueName>:<...>`. The prefix is
+ * usually `bull` but can be customized per connection (e.g. `{bull}` or
+ * `{myprefix}` for cluster-safe hash tagging).
+ *
+ * We always block the BullMQ default prefixes (`bull:`, `bullmq:`) as a safety
+ * net for misconfigured connections, and additionally block the connection's
+ * configured prefix when it differs from the defaults.
+ */
+function isBullKey(key: string, connectionPrefix?: string): boolean {
+  if (key.startsWith('bull:') || key.startsWith('bullmq:')) return true
+  if (connectionPrefix && connectionPrefix !== 'bull' && connectionPrefix !== 'bullmq') {
+    return key.startsWith(`${connectionPrefix}:`)
+  }
+  return false
 }
 
 const app = new Hono()
@@ -130,6 +144,7 @@ const app = new Hono()
     async (c) => {
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
+      const connectionPrefix = c.get('connectionPrefix')
       const redisOptions = getConnectionRedisOptions(c)
       const connectionMode = c.get('connectionMode')
       const { pattern, cursor, pageSize, excludeBull } = c.req.valid('query')
@@ -148,7 +163,9 @@ const app = new Hono()
       const [nextCursor, rawKeys] = await clusterAwareScan(redis, cursor, pattern, scanCount)
 
       // Filter out bull keys if requested
-      const filteredKeys = excludeBull ? rawKeys.filter((key) => !isBullKey(key)) : rawKeys
+      const filteredKeys = excludeBull
+        ? rawKeys.filter((key) => !isBullKey(key, connectionPrefix))
+        : rawKeys
 
       // Get key info for each key (type, TTL)
       const keyInfoPromises = filteredKeys.slice(0, pageSize).map(async (key) => {
@@ -374,13 +391,14 @@ const app = new Hono()
     async (c) => {
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
+      const connectionPrefix = c.get('connectionPrefix')
       const redisOptions = getConnectionRedisOptions(c)
       const connectionMode = c.get('connectionMode')
       const { key } = c.req.valid('param')
       const decodedKey = decodeURIComponent(key)
 
       // Prevent deletion of BullMQ-managed keys
-      if (isBullKey(decodedKey)) {
+      if (isBullKey(decodedKey, connectionPrefix)) {
         return c.json(
           {
             error: 'Cannot delete BullMQ keys',

--- a/apps/api/src/routes/redis-keys.ts
+++ b/apps/api/src/routes/redis-keys.ts
@@ -1,8 +1,58 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
+import { Cluster } from 'ioredis'
 import { z } from 'zod'
-import { getRedis } from '../lib/redis'
 import { getConnectionRedisOptions } from '../lib/connection-options'
+import { getRedis, type RedisClient } from '../lib/redis'
+
+/**
+ * Cluster-aware SCAN: scans all master nodes in a cluster, or uses standard SCAN for standalone.
+ * For cluster mode, uses offset-based pagination (cursor is `cluster:<offset>` or '0' for start).
+ * For standalone, uses native Redis SCAN cursor.
+ */
+async function clusterAwareScan(
+  client: RedisClient,
+  cursor: string,
+  pattern: string,
+  count: number
+): Promise<[string, string[]]> {
+  if (client instanceof Cluster) {
+    // Full scan across all master nodes
+    const masters = client.nodes('master')
+    const allKeys: string[] = []
+    for (const master of masters) {
+      let nodeCursor = '0'
+      do {
+        const [next, keys] = await master.scan(nodeCursor, 'MATCH', pattern, 'COUNT', count)
+        nodeCursor = next
+        allKeys.push(...keys)
+      } while (nodeCursor !== '0')
+    }
+
+    // Offset-based pagination over the full result set
+    const offset = cursor.startsWith('cluster:') ? Number.parseInt(cursor.slice(8), 10) : 0
+    const page = allKeys.slice(offset, offset + count)
+    const nextOffset = offset + page.length
+    const nextCursor = nextOffset < allKeys.length ? `cluster:${nextOffset}` : '0'
+    return [nextCursor, page]
+  }
+  return client.scan(cursor, 'MATCH', pattern, 'COUNT', count)
+}
+
+/**
+ * Cluster-aware DBSIZE: sums dbsize across all master nodes for cluster mode.
+ */
+async function clusterAwareDbSize(client: RedisClient): Promise<number> {
+  if (client instanceof Cluster) {
+    const masters = client.nodes('master')
+    let total = 0
+    for (const master of masters) {
+      total += await master.dbsize()
+    }
+    return total
+  }
+  return client.dbsize()
+}
 
 const DEFAULT_PAGE_SIZE = 50
 const MAX_PAGE_SIZE = 100
@@ -35,14 +85,21 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const { pattern, cursor, pageSize, excludeBull } = c.req.valid('query')
 
-      const redis = await getRedis(connectionId, connectionUrl, undefined, redisOptions)
+      const redis = await getRedis(
+        connectionId,
+        connectionUrl,
+        undefined,
+        redisOptions,
+        connectionMode
+      )
 
       // Use SCAN for efficient key discovery
       // When excluding bull keys, we need to scan more to get enough non-bull keys
       const scanCount = excludeBull ? pageSize * 4 : pageSize * 2
-      const [nextCursor, rawKeys] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', scanCount)
+      const [nextCursor, rawKeys] = await clusterAwareScan(redis, cursor, pattern, scanCount)
 
       // Filter out bull keys if requested
       const filteredKeys = excludeBull ? rawKeys.filter((key) => !isBullKey(key)) : rawKeys
@@ -73,7 +130,7 @@ const app = new Hono()
       // Try to get approximate total count
       let total: number | undefined
       try {
-        total = await redis.dbsize()
+        total = await clusterAwareDbSize(redis)
       } catch {
         // DBSIZE not available
       }
@@ -108,13 +165,20 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const { key } = c.req.valid('param')
       const { limit, offset } = c.req.valid('query')
 
       // URL decode the key since it might contain special characters
       const decodedKey = decodeURIComponent(key)
 
-      const redis = await getRedis(connectionId, connectionUrl, undefined, redisOptions)
+      const redis = await getRedis(
+        connectionId,
+        connectionUrl,
+        undefined,
+        redisOptions,
+        connectionMode
+      )
 
       // Get key type and TTL
       const [type, ttl] = await Promise.all([redis.type(decodedKey), redis.ttl(decodedKey)])
@@ -265,6 +329,7 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const { key } = c.req.valid('param')
       const decodedKey = decodeURIComponent(key)
 
@@ -280,7 +345,13 @@ const app = new Hono()
         )
       }
 
-      const redis = await getRedis(connectionId, connectionUrl, undefined, redisOptions)
+      const redis = await getRedis(
+        connectionId,
+        connectionUrl,
+        undefined,
+        redisOptions,
+        connectionMode
+      )
       const deleted = await redis.del(decodedKey)
 
       return c.json({ success: deleted > 0, deleted })

--- a/apps/api/src/routes/scheduled-jobs.ts
+++ b/apps/api/src/routes/scheduled-jobs.ts
@@ -1,7 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
-import { discoverQueues, getQueue } from '../lib/redis'
 import { getConnectionRedisOptions } from '../lib/connection-options'
+import { discoverQueues, getQueue } from '../lib/redis'
 import {
   buildScheduledJobCreateInput,
   buildScheduledJobUpdateInput,
@@ -72,6 +72,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
 
@@ -81,7 +82,13 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix, redisOptions)
+    const allQueueNames = await discoverQueues(
+      connectionId,
+      connectionUrl,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     const totalQueues = allQueueNames.length
 
     // Paginate at the queue level to prevent loading scheduled jobs from thousands of queues
@@ -92,7 +99,14 @@ const app = new Hono()
     const allScheduledJobs: ScheduledJobSummary[] = []
 
     for (const queueName of paginatedQueueNames) {
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions,
+        connectionMode
+      )
       const schedulers = await queue.getJobSchedulers()
 
       // Get unique job names from schedulers
@@ -124,8 +138,16 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     const schedulers = await queue.getJobSchedulers()
 
     // Get unique job names from schedulers
@@ -151,7 +173,13 @@ const app = new Hono()
     const queueName = c.req.param('queueName')
     const schedulerId = c.req.param('schedulerId')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions
+    )
     const scheduler = (await queue.getJobSchedulers()).find((item) => item.key === schedulerId)
 
     if (!scheduler) {
@@ -173,7 +201,13 @@ const app = new Hono()
     const queueName = c.req.param('queueName')
     const payload = c.req.valid('json')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions
+    )
     const existingSchedulers = await queue.getJobSchedulers()
     const existingScheduler = existingSchedulers.find(
       (scheduler) => scheduler.key === payload.schedulerId
@@ -225,12 +259,18 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
+      const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const schedulerId = c.req.param('schedulerId')
       const payload = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions
+      )
       const existingScheduler = (await queue.getJobSchedulers()).find(
         (scheduler) => scheduler.key === schedulerId
       )
@@ -274,10 +314,18 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const schedulerId = c.req.param('schedulerId')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+    const queue = await getQueue(
+      connectionId,
+      connectionUrl,
+      queueName,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     await queue.removeJobScheduler(schedulerId)
     return c.json({ success: true })
   })

--- a/apps/api/src/routes/scheduled-jobs.ts
+++ b/apps/api/src/routes/scheduled-jobs.ts
@@ -170,6 +170,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const schedulerId = c.req.param('schedulerId')
 
@@ -178,7 +179,8 @@ const app = new Hono()
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     const scheduler = (await queue.getJobSchedulers()).find((item) => item.key === schedulerId)
 
@@ -198,6 +200,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const queueName = c.req.param('queueName')
     const payload = c.req.valid('json')
 
@@ -206,7 +209,8 @@ const app = new Hono()
       connectionUrl,
       queueName,
       connectionPrefix,
-      redisOptions
+      redisOptions,
+      connectionMode
     )
     const existingSchedulers = await queue.getJobSchedulers()
     const existingScheduler = existingSchedulers.find(
@@ -260,6 +264,7 @@ const app = new Hono()
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
       const redisOptions = getConnectionRedisOptions(c)
+      const connectionMode = c.get('connectionMode')
       const queueName = c.req.param('queueName')
       const schedulerId = c.req.param('schedulerId')
       const payload = c.req.valid('json')
@@ -269,7 +274,8 @@ const app = new Hono()
         connectionUrl,
         queueName,
         connectionPrefix,
-        redisOptions
+        redisOptions,
+        connectionMode
       )
       const existingScheduler = (await queue.getJobSchedulers()).find(
         (scheduler) => scheduler.key === schedulerId

--- a/apps/api/src/routes/workers.ts
+++ b/apps/api/src/routes/workers.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
-import { discoverQueues, getQueue, safeGetWorkers } from '../lib/redis'
 import { getConnectionRedisOptions } from '../lib/connection-options'
+import { discoverQueues, getQueue, safeGetWorkers } from '../lib/redis'
 
 // Default and max page sizes for pagination
 const DEFAULT_PAGE_SIZE = 50
@@ -14,6 +14,7 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
+    const connectionMode = c.get('connectionMode')
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
 
@@ -23,7 +24,13 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix, redisOptions)
+    const allQueueNames = await discoverQueues(
+      connectionId,
+      connectionUrl,
+      connectionPrefix,
+      redisOptions,
+      connectionMode
+    )
     const totalQueues = allQueueNames.length
 
     // Paginate the queue names BEFORE fetching worker details
@@ -48,7 +55,14 @@ const app = new Hono()
 
     await Promise.all(
       paginatedQueueNames.map(async (queueName) => {
-        const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+        const queue = await getQueue(
+          connectionId,
+          connectionUrl,
+          queueName,
+          connectionPrefix,
+          redisOptions,
+          connectionMode
+        )
         const [workers, isPaused, counts] = await Promise.all([
           safeGetWorkers(queue),
           queue.isPaused(),

--- a/apps/web/src/components/settings/connections-settings-page.tsx
+++ b/apps/web/src/components/settings/connections-settings-page.tsx
@@ -1,6 +1,6 @@
-import { useNavigate, useParams } from '@tanstack/react-router'
 import { trackEvent } from '@durabull/analytics/browser'
 import { AnalyticsEvents } from '@durabull/analytics/events'
+import { useNavigate, useParams } from '@tanstack/react-router'
 import {
   AlertCircle,
   Check,
@@ -12,6 +12,7 @@ import {
   EyeOff,
   Info,
   Loader2,
+  Network,
   Pencil,
   Plus,
   Server,
@@ -64,6 +65,7 @@ type ConnectionEnvironment = 'development' | 'staging' | 'production'
 interface RedisConnection {
   id: string
   name: string
+  mode: 'standalone' | 'cluster'
   isDefault: boolean
   environment: ConnectionEnvironment | null
   prefix: string
@@ -443,16 +445,20 @@ function ConnectionCard({
             </div>
             <div className="min-w-0">
               <CardTitle className="text-base truncate">{connection.name}</CardTitle>
-              <Badge
-                variant="outline"
-                className={cn(
-                  'mt-1 text-[10px] font-medium',
-                  envConfig.borderColor,
-                  envConfig.color
+              <div className="flex items-center gap-1 mt-1">
+                <Badge
+                  variant="outline"
+                  className={cn('text-[10px] font-medium', envConfig.borderColor, envConfig.color)}
+                >
+                  {envConfig.label}
+                </Badge>
+                {connection.mode === 'cluster' && (
+                  <Badge variant="outline" className="text-[10px] font-medium">
+                    <Network className="h-2.5 w-2.5 mr-0.5" />
+                    Cluster
+                  </Badge>
                 )}
-              >
-                {envConfig.label}
-              </Badge>
+              </div>
             </div>
           </div>
         </div>
@@ -572,6 +578,7 @@ function ConnectionFormDialog({
   const [prefix, setPrefix] = useState('bull')
   const [showUrl, setShowUrl] = useState(false)
   const [environment, setEnvironment] = useState<ConnectionEnvironment>('development')
+  const [connectionMode, setConnectionMode] = useState<'standalone' | 'cluster'>('standalone')
   const [isDefault, setIsDefault] = useState(false)
   const [allowSelfSignedCerts, setAllowSelfSignedCerts] = useState(false)
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null)
@@ -605,6 +612,7 @@ function ConnectionFormDialog({
       setUrl(existingConnection.url ?? '')
       setPrefix(existingConnection.prefix ?? 'bull')
       setEnvironment(existingConnection.environment ?? 'development')
+      setConnectionMode(existingConnection.mode ?? 'standalone')
       setIsDefault(existingConnection.isDefault)
       setAllowSelfSignedCerts(existingConnection.allowSelfSignedCerts ?? false)
     } else if (mode === 'create' && open) {
@@ -612,6 +620,7 @@ function ConnectionFormDialog({
       setUrl('')
       setPrefix('bull')
       setEnvironment('development')
+      setConnectionMode('standalone')
       setIsDefault(false)
       setAllowSelfSignedCerts(false)
       setDiscoveryConnectionId(null)
@@ -631,6 +640,7 @@ function ConnectionFormDialog({
           isDefault,
           prefix,
           allowSelfSignedCerts,
+          mode: connectionMode,
         })
         setDiscoveryConnectionId(created.connection.id)
         await runQueueDiscoveryMutation.mutateAsync(created.connection.id)
@@ -644,6 +654,7 @@ function ConnectionFormDialog({
             isDefault,
             prefix,
             allowSelfSignedCerts,
+            mode: connectionMode,
           },
         })
         onOpenChange(false)
@@ -656,7 +667,11 @@ function ConnectionFormDialog({
   const handleTestConnection = async () => {
     setTestResult(null)
     try {
-      const result = await testMutation.mutateAsync({ url, allowSelfSignedCerts })
+      const result = await testMutation.mutateAsync({
+        url,
+        allowSelfSignedCerts,
+        mode: connectionMode,
+      })
       setTestResult(result)
     } catch (error) {
       setTestResult({
@@ -851,6 +866,39 @@ function ConnectionFormDialog({
                     Having trouble connecting? Read connection troubleshooting
                   </a>
                 </Button>
+              )}
+            </div>
+
+            {/* Connection Mode */}
+            <div className="space-y-2">
+              <Label>Connection Mode</Label>
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  type="button"
+                  variant={connectionMode === 'standalone' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setConnectionMode('standalone')}
+                  className="gap-1.5"
+                >
+                  <Server className="h-3.5 w-3.5" />
+                  Standalone
+                </Button>
+                <Button
+                  type="button"
+                  variant={connectionMode === 'cluster' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setConnectionMode('cluster')}
+                  className="gap-1.5"
+                >
+                  <Network className="h-3.5 w-3.5" />
+                  Cluster
+                </Button>
+              </div>
+              {connectionMode === 'cluster' && (
+                <p className="text-xs text-muted-foreground">
+                  For Redis Cluster deployments (e.g., AWS ElastiCache, Upstash). Provide the
+                  cluster endpoint URL.
+                </p>
               )}
             </div>
 
@@ -1179,7 +1227,9 @@ function StatCard({ title, value, icon: Icon, loading, variant = 'default' }: St
         {loading ? (
           <div className="h-8 w-12 bg-muted rounded animate-pulse" />
         ) : (
-          <div className="font-mono text-2xl font-semibold tracking-tight tabular-nums">{value}</div>
+          <div className="font-mono text-2xl font-semibold tracking-tight tabular-nums">
+            {value}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/hooks/use-connections.ts
+++ b/apps/web/src/hooks/use-connections.ts
@@ -56,6 +56,7 @@ export function useCreateConnection() {
       isDefault?: boolean
       prefix?: string
       allowSelfSignedCerts?: boolean
+      mode?: 'standalone' | 'cluster'
     }) => {
       const res = await api.connections.$post({
         json: data,
@@ -102,6 +103,7 @@ export function useUpdateConnection() {
         isDefault?: boolean
         prefix?: string
         allowSelfSignedCerts?: boolean
+        mode?: 'standalone' | 'cluster'
       }
     }) => {
       const res = await api.connections[':id'].$patch({
@@ -169,12 +171,14 @@ export function useTestConnection() {
     mutationFn: async ({
       url,
       allowSelfSignedCerts,
+      mode,
     }: {
       url: string
       allowSelfSignedCerts?: boolean
+      mode?: 'standalone' | 'cluster'
     }) => {
       const res = await api.connections.test.$post({
-        json: { url, allowSelfSignedCerts },
+        json: { url, allowSelfSignedCerts, mode },
       })
       return handleRes<TestConnectionResponse>(res)
     },

--- a/packages/dal/src/db/env-redis-connections.ts
+++ b/packages/dal/src/db/env-redis-connections.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm'
 import type { Database } from './client'
 import { encryptRedisUrl } from './redis-url-encryption'
 import { validateRedisUrlForEnvironment } from './redis-url-validation'
-import type { ConnectionEnvironment } from './schemas/redis-connection/schema'
+import type { ConnectionEnvironment, ConnectionMode } from './schemas/redis-connection/schema'
 import { redisConnection } from './schemas/redis-connection/schema'
 
 const ENV_PREFIX = 'DURABULL_REDIS_URL_'
@@ -13,12 +13,14 @@ const ENV_ENCRYPTION_KEY = 'DURABULL_REDIS_URL_ENCRYPTION_KEY'
 const ENVIRONMENT_SUFFIX = '_ENVIRONMENT'
 const PREFIX_SUFFIX = '_PREFIX'
 const ALLOW_SELF_SIGNED_CERTS_SUFFIX = '_ALLOW_SELF_SIGNED_CERTS'
+const MODE_SUFFIX = '_MODE'
 const ENV_NAMESPACE_UUID = '2a48b9e7-32fa-4d5a-8f61-7e7a2f6c3f0b'
 
 export interface EnvRedisConnection {
   envName: string
   name: string
   url: string
+  mode: ConnectionMode
   environment: ConnectionEnvironment
   prefix: string
   allowSelfSignedCerts: boolean
@@ -60,6 +62,12 @@ function parseEnvironment(value: string | undefined): ConnectionEnvironment {
   return 'development'
 }
 
+function parseMode(value: string | undefined): ConnectionMode {
+  const normalized = value?.trim().toLowerCase()
+  if (normalized === 'cluster') return 'cluster'
+  return 'standalone'
+}
+
 function normalizeDefaultName(value: string | undefined): string | null {
   const normalized = value?.trim().toUpperCase()
   return normalized && normalized.length > 0 ? normalized : null
@@ -81,7 +89,8 @@ export function getEnvRedisConnections(): EnvRedisConnection[] {
       key === ENV_ENCRYPTION_KEY ||
       key.endsWith(ENVIRONMENT_SUFFIX) ||
       key.endsWith(PREFIX_SUFFIX) ||
-      key.endsWith(ALLOW_SELF_SIGNED_CERTS_SUFFIX)
+      key.endsWith(ALLOW_SELF_SIGNED_CERTS_SUFFIX) ||
+      key.endsWith(MODE_SUFFIX)
     ) {
       continue
     }
@@ -106,11 +115,13 @@ export function getEnvRedisConnections(): EnvRedisConnection[] {
     const allowSelfSignedCerts = parseBoolean(
       process.env[`${key}${ALLOW_SELF_SIGNED_CERTS_SUFFIX}`]
     )
+    const mode = parseMode(process.env[`${key}${MODE_SUFFIX}`])
 
     connections.push({
       envName,
       name: toDisplayName(envName),
       url,
+      mode,
       environment,
       prefix,
       allowSelfSignedCerts,
@@ -212,6 +223,7 @@ export async function syncEnvConnectionsForOrganization(
     const updateSet: Partial<{
       name: string
       url: string
+      mode: ConnectionMode
       environment: ConnectionEnvironment
       prefix: string
       allowSelfSignedCerts: boolean
@@ -220,6 +232,7 @@ export async function syncEnvConnectionsForOrganization(
     }> = {
       name: connection.name,
       url: encryptRedisUrl(connection.url),
+      mode: connection.mode,
       environment: connection.environment,
       prefix: connection.prefix,
       allowSelfSignedCerts: connection.allowSelfSignedCerts,
@@ -233,6 +246,7 @@ export async function syncEnvConnectionsForOrganization(
         id,
         name: connection.name,
         url: encryptRedisUrl(connection.url),
+        mode: connection.mode,
         environment: connection.environment,
         prefix: connection.prefix,
         allowSelfSignedCerts: connection.allowSelfSignedCerts,

--- a/packages/dal/src/db/migrations/20260310120000_add_cluster_mode/migration.sql
+++ b/packages/dal/src/db/migrations/20260310120000_add_cluster_mode/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "redis_connection" ADD COLUMN "mode" text DEFAULT 'standalone' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "redis_connection" ADD CONSTRAINT "redis_connection_mode_check" CHECK ("mode" IN ('standalone', 'cluster'));

--- a/packages/dal/src/db/schemas/redis-connection/schema.ts
+++ b/packages/dal/src/db/schemas/redis-connection/schema.ts
@@ -10,6 +10,13 @@ export const connectionEnvironments = ['development', 'staging', 'production'] a
 export type ConnectionEnvironment = (typeof connectionEnvironments)[number]
 
 /**
+ * Connection mode: standalone (single node) or cluster
+ */
+export const connectionModes = ['standalone', 'cluster'] as const
+
+export type ConnectionMode = (typeof connectionModes)[number]
+
+/**
  * Redis connection table - stores Redis connection configurations
  * Connections are scoped to an organization
  */
@@ -17,6 +24,7 @@ export const redisConnection = pgTable('redis_connection', {
   ...baseColumns,
   name: text('name').notNull(),
   url: text('url').notNull(),
+  mode: text('mode').$type<ConnectionMode>().notNull().default('standalone'),
   isDefault: boolean('is_default').notNull().default(false),
   environment: text('environment').$type<ConnectionEnvironment>().default('development'),
   prefix: text('prefix').notNull().default('bull'),

--- a/packages/dal/src/db/schemas/redis-connection/types.ts
+++ b/packages/dal/src/db/schemas/redis-connection/types.ts
@@ -10,5 +10,5 @@ export type RedisConnection = typeof redisConnection.$inferSelect
  */
 export type NewRedisConnection = typeof redisConnection.$inferInsert
 
-// Re-export ConnectionEnvironment from schema for backwards compatibility
-export type { ConnectionEnvironment } from './schema'
+// Re-export types from schema for backwards compatibility
+export type { ConnectionEnvironment, ConnectionMode } from './schema'

--- a/packages/dal/src/index.ts
+++ b/packages/dal/src/index.ts
@@ -134,7 +134,9 @@ export type {
 } from './db/schemas/organization/types'
 export {
   type ConnectionEnvironment,
+  type ConnectionMode,
   connectionEnvironments,
+  connectionModes,
   redisConnection,
 } from './db/schemas/redis-connection/schema'
 export type { NewRedisConnection, RedisConnection } from './db/schemas/redis-connection/types'

--- a/packages/dal/src/repositories/redis-connection.ts
+++ b/packages/dal/src/repositories/redis-connection.ts
@@ -170,7 +170,7 @@ export const redisConnectionRepository = {
     data: Partial<
       Pick<
         RedisConnection,
-        'name' | 'url' | 'isDefault' | 'environment' | 'prefix' | 'allowSelfSignedCerts'
+        'name' | 'url' | 'mode' | 'isDefault' | 'environment' | 'prefix' | 'allowSelfSignedCerts'
       >
     >
   ): Promise<RedisConnection | null> {
@@ -180,7 +180,7 @@ export const redisConnectionRepository = {
     const updateData: Partial<
       Pick<
         RedisConnection,
-        'name' | 'url' | 'isDefault' | 'environment' | 'prefix' | 'allowSelfSignedCerts'
+        'name' | 'url' | 'mode' | 'isDefault' | 'environment' | 'prefix' | 'allowSelfSignedCerts'
       >
     > = { ...data }
     if (updateData.url !== undefined) {


### PR DESCRIPTION
## Summary
- Add `mode` column (`standalone` | `cluster`) to redis connection schema with migration
- Support ioredis `Cluster` client creation when mode is `cluster` — users provide a single cluster endpoint URL (e.g. AWS ElastiCache, Upstash)
- Cluster-aware SCAN across all master nodes for queue discovery and key listing
- Cluster-aware DBSIZE summing across master nodes
- Thread connection mode through middleware, all consumer routes, and queue helpers
- Support `DURABULL_REDIS_URL_*_MODE=cluster` env var suffix for env-based connections
- Update frontend types to include the mode field

<img width="765" height="327" alt="image" src="https://github.com/user-attachments/assets/7aa20e02-7a09-4a64-b3e4-205101c4786c" />

## Test plan
- [ ] Verify standalone connections still work (no regression)
- [x] Test cluster connection via POST `/api/connections/test` with `mode: "cluster"`
- [ ] Create/update/delete cluster connections via CRUD endpoints
- [x] Verify queue discovery works on cluster (SCAN all master nodes)
- [x] Run `pnpm test` — all existing tests pass
- [x] Run typecheck and lint — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Redis connection modes, including standalone and cluster.
  * Connection screens now let you choose and view the connection mode.
  * Redis search, queue browsing, job actions, metrics, scheduled jobs, and worker views now work with cluster-aware connections.

* **Bug Fixes**
  * Improved Redis key discovery and queue handling so results stay accurate across cluster nodes.
  * Connection tests and saved connections now include the selected mode consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->