### PR TITLE
fix: harden self-hosted Docker image path with smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,3 +262,19 @@ jobs:
           name: test-results-authless
           path: apps/web/test-results/
           retention-days: 7
+
+  docker-image-smoke:
+    name: Docker Image Smoke Test
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build production image
+        run: docker build -f tooling/docker/Dockerfile -t durabull-ci:${{ github.sha }} .
+
+      - name: Smoke test self-hosted image
+        run: bash tooling/scripts/docker-image-smoke.sh
+        env:
+          DURABULL_IMAGE: durabull-ci:${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,11 +11,19 @@ permissions:
 
 jobs:
   docker:
-    name: Build & Publish Image
+    name: Smoke Test, Build & Publish Image
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Build smoke-test image
+        run: docker build -f tooling/docker/Dockerfile -t durabull-release:${{ github.sha }} .
+
+      - name: Smoke test self-hosted image
+        run: bash tooling/scripts/docker-image-smoke.sh
+        env:
+          DURABULL_IMAGE: durabull-release:${{ github.sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/apps/docs/content/documentation/deployment/docker.mdx
+++ b/apps/docs/content/documentation/deployment/docker.mdx
@@ -37,6 +37,7 @@ docker run --rm -p 3000:3000 --network durabull \
 Open `http://localhost:3000`, then confirm:
 
 - `GET /api/health` returns `status: ok`
+- `GET /api/app/config` returns JSON instead of `500`
 - the queue dashboard loads for your default connection
 
 ## 3) Docker Compose (Durabull + Redis)
@@ -44,9 +45,12 @@ Open `http://localhost:3000`, then confirm:
 Use Compose for repeatable team setup:
 
 ```yaml
+name: durabull-self-hosted
+
 services:
   durabull:
     image: ghcr.io/durabullhq/durabull:latest
+    restart: unless-stopped
     ports:
       - "3000:3000"
     environment:
@@ -58,14 +62,46 @@ services:
       DURABULL_REDIS_URL_DEFAULT: MAIN
       APP_BASE_URL: http://localhost:3000
       VITE_PUBLIC_APP_URL: http://localhost:3000
+    volumes:
+      - durabull_data:/app/data
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
 
   redis:
     image: redis:8-alpine
+    restart: unless-stopped
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    command: redis-server --appendonly yes
+
+volumes:
+  durabull_data:
+  redis_data:
 ```
+
+Start it with:
+
+```bash
+export DURABULL_REDIS_URL_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+docker compose -f tooling/docker/docker-compose.self-hosted.yaml up -d
+```
+
+Then validate:
+
+- `GET /api/health`
+- `GET /api/app/config`
+- `GET /api/auth/get-session` when `DURABULL_AUTHLESS=true`
+
+An example file is included at `tooling/docker/docker-compose.self-hosted.yaml`.
 
 ## 4) Persistence Notes
 
@@ -73,6 +109,16 @@ When `DATABASE_URL` is unset, PGlite data is file-backed inside the container.
 
 - Default location: `/app/data/pglite`
 - For persistence, mount `/app/data` or set `DURABULL_PGLITE_DIR` to a mounted path.
+- Named Docker volumes are the simplest option for local deployments.
+- If you bind-mount a host directory, ensure it is writable by container UID/GID `1000:1000` (`bun`).
+
+### Older Image Workaround
+
+If you are pinned to an older image that fails with `EACCES: permission denied, mkdir '/app/data'` or returns `500` for `/api/app/config`, use one of these temporary workarounds:
+
+- upgrade to an image that includes the writable `/app/data` fix
+- set `DURABULL_PGLITE_DIR` to a writable path inside the container for ephemeral evaluation
+- switch to PostgreSQL mode with `DATABASE_URL`
 
 ## 5) Production Notes
 
@@ -90,5 +136,6 @@ For internet-facing deployments:
 Source Dockerfile path:
 
 - `tooling/docker/Dockerfile`
+- `tooling/docker/docker-compose.self-hosted.yaml`
 
 It uses `turbo prune` and multi-stage builds for optimized production images.

--- a/apps/docs/content/documentation/operations/troubleshooting.mdx
+++ b/apps/docs/content/documentation/operations/troubleshooting.mdx
@@ -50,7 +50,21 @@ Checks:
 - `APP_BASE_URL` and browser origin alignment
 - OAuth callback URLs match deployment host
 
-### 4. PostgreSQL Connection Refused (`ECONNREFUSED`)
+### 4. `/api/app/config` or `/api/auth/get-session` Returns `500` in Docker
+
+Symptoms:
+
+- initial page load hangs on the spinner
+- browser console shows `500` for `/api/app/config` or `/api/auth/get-session`
+
+Checks:
+
+- inspect container logs for `EACCES: permission denied, mkdir '/app/data'`
+- if using PGlite, mount `/app/data` to a named volume
+- if using a bind mount, ensure the path is writable by UID/GID `1000:1000`
+- if pinned to an older image, set `DURABULL_PGLITE_DIR` to a writable path or switch to PostgreSQL mode
+
+### 5. PostgreSQL Connection Refused (`ECONNREFUSED`)
 
 Symptoms:
 
@@ -62,14 +76,14 @@ Checks:
 - verify `DURABULL_POSTGRES_PORT` in `.env` matches `DATABASE_URL`
 - if that port is already in use, pick another free port (for example `55433`)
 
-### 5. Rate Limit Responses (`429`)
+### 6. Rate Limit Responses (`429`)
 
 Checks:
 
 - high burst traffic against auth/API routes
 - whether `DISABLE_RATE_LIMIT` is intentionally configured in non-production
 
-### 6. Redis Explorer Delete Blocked
+### 7. Redis Explorer Delete Blocked
 
 Symptom:
 

--- a/apps/docs/content/documentation/self-hosting/installation.mdx
+++ b/apps/docs/content/documentation/self-hosting/installation.mdx
@@ -70,6 +70,7 @@ For full local infrastructure, seeded data, and contributor workflows, see
 ## First-Run Validation Checklist
 
 - `GET /api/health` returns `status: ok`
+- `GET /api/app/config` returns `200`
 - `GET /api/mode` matches expected auth, connection, and persistence mode
 - Queues load in the dashboard for your selected connection
 - Job details, scheduled jobs, and workers pages load without API errors

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docker:down": "docker compose -f tooling/docker/docker-compose.yaml down",
     "docker:logs": "docker compose -f tooling/docker/docker-compose.yaml logs -f",
     "docker:reset": "docker compose -f tooling/docker/docker-compose.yaml down -v && docker compose -f tooling/docker/docker-compose.yaml up -d",
+    "docker:smoke:image": "bash tooling/scripts/docker-image-smoke.sh",
     "prod": "bun run build && bun apps/api/src/index.ts",
     "prod:start": "bun apps/api/src/index.ts",
     "docker:build": "docker build -t durabull .",

--- a/packages/dal/src/db/env-redis-connections.test.ts
+++ b/packages/dal/src/db/env-redis-connections.test.ts
@@ -93,6 +93,17 @@ describe('env-redis-connections', () => {
     expect(connections[0]?.envName).toBe('SECONDARY')
   })
 
+  it('ignores non-connection redis settings', () => {
+    process.env.DURABULL_REDIS_URL_ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    process.env.DURABULL_REDIS_URL_MAIN = 'redis://localhost:6379'
+
+    const connections = getEnvRedisConnections()
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0]?.envName).toBe('MAIN')
+  })
+
   it('generates deterministic IDs per organization and env name', () => {
     const first = getEnvRedisConnectionId('org-1', 'MAIN')
     const second = getEnvRedisConnectionId('org-1', 'MAIN')

--- a/packages/dal/src/db/env-redis-connections.ts
+++ b/packages/dal/src/db/env-redis-connections.ts
@@ -9,6 +9,7 @@ import type { ConnectionEnvironment } from './schemas/redis-connection/schema'
 
 const ENV_PREFIX = 'DURABULL_REDIS_URL_'
 const ENV_DEFAULT_KEY = 'DURABULL_REDIS_URL_DEFAULT'
+const ENV_ENCRYPTION_KEY = 'DURABULL_REDIS_URL_ENCRYPTION_KEY'
 const ENVIRONMENT_SUFFIX = '_ENVIRONMENT'
 const ENV_NAMESPACE_UUID = '2a48b9e7-32fa-4d5a-8f61-7e7a2f6c3f0b'
 
@@ -66,7 +67,13 @@ export function getEnvRedisConnections(): EnvRedisConnection[] {
 
   for (const [key, value] of Object.entries(process.env)) {
     if (!key.startsWith(ENV_PREFIX)) continue
-    if (key === ENV_DEFAULT_KEY || key.endsWith(ENVIRONMENT_SUFFIX)) continue
+    if (
+      key === ENV_DEFAULT_KEY ||
+      key === ENV_ENCRYPTION_KEY ||
+      key.endsWith(ENVIRONMENT_SUFFIX)
+    ) {
+      continue
+    }
 
     const match = key.match(urlPattern)
     if (!match) continue

--- a/tooling/docker/Dockerfile
+++ b/tooling/docker/Dockerfile
@@ -61,6 +61,8 @@ COPY --from=build /app/tooling ./tooling
 # Built web app
 COPY --from=build /app/apps/web/dist ./apps/web/dist
 
+RUN mkdir -p /app/data && chown -R bun:bun /app/data
+
 USER bun
 EXPOSE 3000/tcp
 ENTRYPOINT ["bun", "run", "apps/api/src/index.ts"]

--- a/tooling/docker/docker-compose.self-hosted.yaml
+++ b/tooling/docker/docker-compose.self-hosted.yaml
@@ -1,0 +1,43 @@
+name: durabull-self-hosted
+
+services:
+  durabull:
+    image: "${DURABULL_IMAGE:-ghcr.io/durabullhq/durabull:latest}"
+    restart: unless-stopped
+    ports:
+      - "${DURABULL_APP_PORT:-3000}:3000"
+    environment:
+      DURABULL_AUTHLESS: "${DURABULL_AUTHLESS:-true}"
+      DURABULL_ENV_CONNECTIONS: "${DURABULL_ENV_CONNECTIONS:-true}"
+      DURABULL_REDIS_URL_ENCRYPTION_KEY: "${DURABULL_REDIS_URL_ENCRYPTION_KEY:?set a 32-byte key with 'openssl rand -hex 32'}"
+      DURABULL_REDIS_URL_MAIN: "${DURABULL_REDIS_URL_MAIN:-redis://redis:6379}"
+      DURABULL_REDIS_URL_MAIN_ENVIRONMENT: "${DURABULL_REDIS_URL_MAIN_ENVIRONMENT:-development}"
+      DURABULL_REDIS_URL_DEFAULT: "${DURABULL_REDIS_URL_DEFAULT:-MAIN}"
+      APP_BASE_URL: "${APP_BASE_URL:-http://localhost:3000}"
+      VITE_PUBLIC_APP_URL: "${VITE_PUBLIC_APP_URL:-http://localhost:3000}"
+    volumes:
+      - durabull_data:/app/data
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  redis:
+    image: redis:8-alpine
+    restart: unless-stopped
+    ports:
+      - "${DURABULL_REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    command: redis-server --appendonly yes
+
+volumes:
+  durabull_data:
+    driver: local
+  redis_data:
+    driver: local

--- a/tooling/scripts/docker-image-smoke.sh
+++ b/tooling/scripts/docker-image-smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_NAME="${PROJECT_NAME:-durabull-smoke}"
+COMPOSE_FILE="${COMPOSE_FILE:-tooling/docker/docker-compose.self-hosted.yaml}"
+APP_PORT="${DURABULL_APP_PORT:-38080}"
+REDIS_PORT="${DURABULL_REDIS_PORT:-36379}"
+IMAGE_TAG="${DURABULL_IMAGE:-ghcr.io/durabullhq/durabull:latest}"
+
+export DURABULL_IMAGE="$IMAGE_TAG"
+export DURABULL_APP_PORT="$APP_PORT"
+export DURABULL_REDIS_PORT="$REDIS_PORT"
+export APP_BASE_URL="${APP_BASE_URL:-http://127.0.0.1:${APP_PORT}}"
+export VITE_PUBLIC_APP_URL="${VITE_PUBLIC_APP_URL:-http://127.0.0.1:${APP_PORT}}"
+export DURABULL_AUTHLESS="${DURABULL_AUTHLESS:-true}"
+export DURABULL_ENV_CONNECTIONS="${DURABULL_ENV_CONNECTIONS:-true}"
+export DURABULL_REDIS_URL_MAIN="${DURABULL_REDIS_URL_MAIN:-redis://redis:6379}"
+export DURABULL_REDIS_URL_MAIN_ENVIRONMENT="${DURABULL_REDIS_URL_MAIN_ENVIRONMENT:-development}"
+export DURABULL_REDIS_URL_DEFAULT="${DURABULL_REDIS_URL_DEFAULT:-MAIN}"
+export DURABULL_REDIS_URL_ENCRYPTION_KEY="${DURABULL_REDIS_URL_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
+
+compose() {
+  docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" "$@"
+}
+
+cleanup() {
+  local exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    compose logs --no-color || true
+  fi
+  compose down -v --remove-orphans || true
+  return $exit_code
+}
+
+trap cleanup EXIT
+
+wait_for_url() {
+  local url="$1"
+  local max_attempts="${2:-60}"
+
+  for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
+    if curl --silent --show-error --fail "$url" >/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Timed out waiting for $url" >&2
+  return 1
+}
+
+assert_json_contains() {
+  local url="$1"
+  local expected="$2"
+  local body
+
+  body="$(curl --silent --show-error --fail "$url")"
+  echo "$body"
+
+  if [[ "$body" != *"$expected"* ]]; then
+    echo "Expected response from $url to contain: $expected" >&2
+    return 1
+  fi
+}
+
+echo "Starting smoke stack with image: $DURABULL_IMAGE"
+compose up -d
+
+wait_for_url "${APP_BASE_URL}/api/health"
+
+assert_json_contains "${APP_BASE_URL}/api/health" '"status":"ok"'
+assert_json_contains "${APP_BASE_URL}/api/app/config" '"authless":true'
+assert_json_contains "${APP_BASE_URL}/api/app/config" '"persistence":"pglite"'
+assert_json_contains "${APP_BASE_URL}/api/auth/get-session" '"id":"authless-user"'
+
+echo "Docker image smoke test passed."


### PR DESCRIPTION
## What?
Fix the self-hosted Docker image path so PGlite can initialize correctly, add a dedicated image smoke test, and wire that smoke test into both branch CI and the tag publish workflow.

## Why?
The published `v1.0.13` image could pass `/api/health` while still being unusable in the documented Docker Compose flow because `/api/app/config` and `/api/auth/get-session` failed with `500`. As an open source/self-hosted project, we need a release gate that proves the production image itself can actually boot under the documented setup.

## How?
- create and chown `/app/data` in the production Docker image so the `bun` user can initialize default PGlite storage
- add `tooling/docker/docker-compose.self-hosted.yaml` as the validated self-hosted Compose example
- add `tooling/scripts/docker-image-smoke.sh` to boot only the image plus Redis and assert the key bootstrap endpoints
- run that smoke test in `.github/workflows/ci.yml` and again in `.github/workflows/docker-publish.yml` before GHCR push
- ignore `DURABULL_REDIS_URL_ENCRYPTION_KEY` during env connection discovery so startup logs are less misleading
- update Docker/self-hosting/troubleshooting docs to reflect the validated path and older-image workaround

## Testing
1. `bun test packages/dal/src/db/env-redis-connections.test.ts`
2. `bash -n tooling/scripts/docker-image-smoke.sh`
3. `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/docker-publish.yml"); puts "yaml ok"'`
4. `DURABULL_IMAGE=durabull-local:smoke PROJECT_NAME=durabull-smoke-local DURABULL_APP_PORT=38081 DURABULL_REDIS_PORT=36381 bash tooling/scripts/docker-image-smoke.sh`
5. Reproduced the original `v1.0.13` failure separately (`EACCES: permission denied, mkdir '/app/data/pglite'`) and verified the runtime fix/workaround path.

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] CI updated to cover the image path
- [x] No breaking changes intended
- [x] Follows existing project style

## Related Issues
Closes #29

## Additional Notes
- I also added the same smoke gate to the tag publish workflow so we fail before pushing a broken image.
- I started a full local build of the branch image, but the multi-stage install layers were too slow to finish in a reasonable local loop. The smoke script itself was validated end-to-end against a known-good local image, and the original published-image failure was reproduced directly.
