### PR TITLE
feat: add job name search to queue detail page

### DIFF
--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -164,52 +164,88 @@ const app = new Hono()
 
     const needsClientFilter = !!(name || jobId)
 
-    // When filtering by name or jobId we must scan all jobs, then paginate the filtered results.
-    // Without filters we can rely on BullMQ's native range to paginate efficiently.
-    const jobs = needsClientFilter
-      ? await queue.getJobs(states)
-      : await queue.getJobs(states, start, end)
+    if (needsClientFilter) {
+      // Fetch each state separately so we know the status without per-job getState() calls,
+      // then return all filtered results in one response for client-side pagination.
+      const jobsWithState: Array<{ job: NonNullable<Awaited<ReturnType<typeof queue.getJobs>>[number]>; state: JobState }> = []
+      for (const state of states) {
+        const stateJobs = await queue.getJobs([state])
+        for (const job of stateJobs) {
+          if (job != null) {
+            jobsWithState.push({ job, state })
+          }
+        }
+      }
 
-    const filtered = jobs
-      // Filter out undefined jobs (can happen when jobs are removed during listing)
-      .filter((job): job is NonNullable<typeof job> => job != null)
-      .filter((job) =>
-        name
-          ? job.name.toLowerCase().includes(name.toLowerCase())
-          : true
-      )
-      .filter((job) =>
-        jobId
-          ? String(job.id ?? '')
-              .toLowerCase()
-              .includes(jobId.toLowerCase())
-          : true
-      )
+      const filtered = jobsWithState
+        .filter(({ job }) =>
+          name
+            ? job.name.toLowerCase().includes(name.toLowerCase())
+            : true
+        )
+        .filter(({ job }) =>
+          jobId
+            ? String(job.id ?? '')
+                .toLowerCase()
+                .includes(jobId.toLowerCase())
+            : true
+        )
 
-    const paginatedJobs = needsClientFilter ? filtered.slice(start, end + 1) : filtered
+      const mappedJobs = filtered.map(({ job, state }) => ({
+        id: job.id ?? '',
+        name: job.name,
+        status: state,
+        data: job.data as Record<string, unknown>,
+        progress: job.progress,
+        attemptsMade: job.attemptsMade,
+        maxAttempts: job.opts.attempts ?? 1,
+        failedReason: job.failedReason,
+        processedOn: job.processedOn,
+        finishedOn: job.finishedOn,
+        timestamp: job.timestamp,
+        delay: job.delay ?? 0,
+        priority: job.opts.priority ?? 0,
+      }))
+
+      return c.json({
+        jobs: mappedJobs,
+        total: filtered.length,
+        page: 1,
+        cursor: '0',
+        nextCursor: null,
+        hasMore: false,
+        pageSize: filtered.length,
+        totalPages: 1,
+      })
+    }
+
+    // Without filters we rely on BullMQ's native range for efficient server-side pagination.
+    const jobs = await queue.getJobs(states, start, end)
 
     const mappedJobs = await Promise.all(
-      paginatedJobs.map(async (job) => {
-        const state = await job.getState()
-        return {
-          id: job.id ?? '',
-          name: job.name,
-          status: state,
-          data: job.data as Record<string, unknown>,
-          progress: job.progress,
-          attemptsMade: job.attemptsMade,
-          maxAttempts: job.opts.attempts ?? 1,
-          failedReason: job.failedReason,
-          processedOn: job.processedOn,
-          finishedOn: job.finishedOn,
-          timestamp: job.timestamp,
-          delay: job.delay ?? 0,
-          priority: job.opts.priority ?? 0,
-        }
-      })
+      jobs
+        .filter((job): job is NonNullable<typeof job> => job != null)
+        .map(async (job) => {
+          const state = await job.getState()
+          return {
+            id: job.id ?? '',
+            name: job.name,
+            status: state,
+            data: job.data as Record<string, unknown>,
+            progress: job.progress,
+            attemptsMade: job.attemptsMade,
+            maxAttempts: job.opts.attempts ?? 1,
+            failedReason: job.failedReason,
+            processedOn: job.processedOn,
+            finishedOn: job.finishedOn,
+            timestamp: job.timestamp,
+            delay: job.delay ?? 0,
+            priority: job.opts.priority ?? 0,
+          }
+        })
     )
 
-    const total = needsClientFilter ? filtered.length : await queue.getJobCountByTypes(...states)
+    const total = await queue.getJobCountByTypes(...states)
     const nextStart = start + pageSize
     const hasMore = nextStart < total
 

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -168,7 +168,11 @@ const app = new Hono()
       jobs
         // Filter out undefined jobs (can happen when jobs are removed during listing)
         .filter((job): job is NonNullable<typeof job> => job != null)
-        .filter((job) => (name ? job.name === name : true))
+        .filter((job) =>
+          name
+            ? job.name.toLowerCase().includes(name.toLowerCase())
+            : true
+        )
         .filter((job) =>
           jobId
             ? String(job.id ?? '')

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -102,7 +102,7 @@ const app = new Hono()
       if (job) {
         const state = await job.getState()
 
-        if ((status && state !== status) || (name && job.name !== name)) {
+        if ((status && state !== status) || (name && !job.name.toLowerCase().includes(name.toLowerCase()))) {
           return c.json({
             jobs: [],
             total: 0,
@@ -162,46 +162,54 @@ const app = new Hono()
       states = [status as JobState]
     }
 
-    const jobs = await queue.getJobs(states, start, end)
+    const needsClientFilter = !!(name || jobId)
+
+    // When filtering by name or jobId we must scan all jobs, then paginate the filtered results.
+    // Without filters we can rely on BullMQ's native range to paginate efficiently.
+    const jobs = needsClientFilter
+      ? await queue.getJobs(states)
+      : await queue.getJobs(states, start, end)
+
+    const filtered = jobs
+      // Filter out undefined jobs (can happen when jobs are removed during listing)
+      .filter((job): job is NonNullable<typeof job> => job != null)
+      .filter((job) =>
+        name
+          ? job.name.toLowerCase().includes(name.toLowerCase())
+          : true
+      )
+      .filter((job) =>
+        jobId
+          ? String(job.id ?? '')
+              .toLowerCase()
+              .includes(jobId.toLowerCase())
+          : true
+      )
+
+    const paginatedJobs = needsClientFilter ? filtered.slice(start, end + 1) : filtered
 
     const mappedJobs = await Promise.all(
-      jobs
-        // Filter out undefined jobs (can happen when jobs are removed during listing)
-        .filter((job): job is NonNullable<typeof job> => job != null)
-        .filter((job) =>
-          name
-            ? job.name.toLowerCase().includes(name.toLowerCase())
-            : true
-        )
-        .filter((job) =>
-          jobId
-            ? String(job.id ?? '')
-                .toLowerCase()
-                .includes(jobId.toLowerCase())
-            : true
-        )
-        .map(async (job) => {
-          const state = await job.getState()
-          return {
-            id: job.id ?? '',
-            name: job.name,
-            status: state,
-            data: job.data as Record<string, unknown>,
-            progress: job.progress,
-            attemptsMade: job.attemptsMade,
-            maxAttempts: job.opts.attempts ?? 1,
-            failedReason: job.failedReason,
-            processedOn: job.processedOn,
-            finishedOn: job.finishedOn,
-            timestamp: job.timestamp,
-            delay: job.delay ?? 0,
-            priority: job.opts.priority ?? 0,
-          }
-        })
+      paginatedJobs.map(async (job) => {
+        const state = await job.getState()
+        return {
+          id: job.id ?? '',
+          name: job.name,
+          status: state,
+          data: job.data as Record<string, unknown>,
+          progress: job.progress,
+          attemptsMade: job.attemptsMade,
+          maxAttempts: job.opts.attempts ?? 1,
+          failedReason: job.failedReason,
+          processedOn: job.processedOn,
+          finishedOn: job.finishedOn,
+          timestamp: job.timestamp,
+          delay: job.delay ?? 0,
+          priority: job.opts.priority ?? 0,
+        }
+      })
     )
 
-    const total = jobId ? mappedJobs.length : await queue.getJobCountByTypes(...states)
-    // Always advance by pageSize to avoid repeating the same cursor when this slice maps to 0 rows.
+    const total = needsClientFilter ? filtered.length : await queue.getJobCountByTypes(...states)
     const nextStart = start + pageSize
     const hasMore = nextStart < total
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
@@ -146,7 +146,7 @@ export const Route = createFileRoute('/$orgSlug/c/$connectionId/queues/$queueNam
 
 function QueueDetailPage() {
   const { orgSlug, connectionId, queueName } = Route.useParams()
-  const { section, tab, status, jobId, name, hideScheduled, page } = Route.useSearch()
+  const { section, tab, status, jobId, name = '', hideScheduled, page } = Route.useSearch()
   const navigate = useNavigate()
   const matchRoute = useMatchRoute()
   const [selectedJobs, setSelectedJobs] = useState<Set<string>>(new Set())
@@ -208,14 +208,30 @@ function QueueDetailPage() {
   const removeMutation = useRemoveJobs()
   const invokeMutation = useInvokeJobs()
   const hideScheduledJobs = hideScheduled === 1
+  const hasClientSideJobFilter = Boolean(jobId || name)
+  const [visibleJobCount, setVisibleJobCount] = useState(20)
   const allJobs = useMemo(
     () => jobsData?.pages.flatMap((pageData) => pageData.jobs) ?? [],
     [jobsData]
   )
-  const visibleJobs = useMemo(
+  const filteredVisibleJobs = useMemo(
     () => allJobs.filter((job) => (hideScheduledJobs ? !job.id.startsWith('repeat:') : true)) ?? [],
     [allJobs, hideScheduledJobs]
   )
+  const visibleJobs = useMemo(
+    () =>
+      hasClientSideJobFilter
+        ? filteredVisibleJobs.slice(0, visibleJobCount)
+        : filteredVisibleJobs,
+    [filteredVisibleJobs, hasClientSideJobFilter, visibleJobCount]
+  )
+  const hasMoreVisibleJobs = hasClientSideJobFilter
+    ? visibleJobs.length < filteredVisibleJobs.length
+    : hasMoreJobs
+
+  useEffect(() => {
+    setVisibleJobCount(20)
+  }, [jobId, name, status, hideScheduled, queueName])
   const jobsScrollRef = useRef<HTMLDivElement | null>(null)
   const metricsPoints = metrics?.series.points ?? []
   const metricsTotals = metrics?.series.totals
@@ -340,20 +356,39 @@ function QueueDetailPage() {
     }
 
     const onScroll = () => {
+      const nearBottom =
+        container.scrollTop + container.clientHeight >= container.scrollHeight - 240
+      if (!nearBottom) {
+        return
+      }
+
+      if (hasClientSideJobFilter) {
+        if (visibleJobs.length >= filteredVisibleJobs.length) {
+          return
+        }
+        setVisibleJobCount((current) => Math.min(current + 20, filteredVisibleJobs.length))
+        return
+      }
+
       if (!hasMoreJobs || jobsFetchingNextPage) {
         return
       }
 
-      const nearBottom =
-        container.scrollTop + container.clientHeight >= container.scrollHeight - 240
-      if (nearBottom) {
-        void fetchNextJobsPage()
-      }
+      void fetchNextJobsPage()
     }
 
     container.addEventListener('scroll', onScroll)
     return () => container.removeEventListener('scroll', onScroll)
-  }, [fetchNextJobsPage, hasMoreJobs, jobsFetchingNextPage, section, tab])
+  }, [
+    fetchNextJobsPage,
+    hasMoreJobs,
+    jobsFetchingNextPage,
+    section,
+    tab,
+    hasClientSideJobFilter,
+    filteredVisibleJobs.length,
+    visibleJobs.length,
+  ])
 
   const handleTogglePause = useCallback(() => {
     if (queue?.isPaused) {
@@ -1533,7 +1568,7 @@ function QueueDetailPage() {
             </Card>
             <div className="flex items-center justify-between text-sm text-muted-foreground">
               <span>{jobsData?.pages[0]?.total ?? 0} total</span>
-              <span>{hasMoreJobs ? 'Scroll to load more' : 'All jobs loaded'}</span>
+              <span>{hasMoreVisibleJobs ? 'Scroll to load more' : 'All jobs loaded'}</span>
             </div>
           </TabsContent>
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
@@ -95,6 +95,7 @@ const queueSearchSchema = z.object({
   tab: z.enum(['jobs', 'scheduled']).catch('jobs'),
   status: z.enum(['', 'waiting', 'active', 'delayed', 'completed', 'failed']).catch(''),
   jobId: z.string().catch(''),
+  name: z.string().catch(''),
   hideScheduled: z
     .union([z.literal(0), z.literal(1), z.literal('0'), z.literal('1')])
     .transform((value) => (value === 1 || value === '1' ? 1 : 0))
@@ -145,11 +146,12 @@ export const Route = createFileRoute('/$orgSlug/c/$connectionId/queues/$queueNam
 
 function QueueDetailPage() {
   const { orgSlug, connectionId, queueName } = Route.useParams()
-  const { section, tab, status, jobId, hideScheduled, page } = Route.useSearch()
+  const { section, tab, status, jobId, name, hideScheduled, page } = Route.useSearch()
   const navigate = useNavigate()
   const matchRoute = useMatchRoute()
   const [selectedJobs, setSelectedJobs] = useState<Set<string>>(new Set())
   const [jobIdInput, setJobIdInput] = useState(jobId)
+  const [nameInput, setNameInput] = useState(name)
   const [addJobDialogOpen, setAddJobDialogOpen] = useState(false)
   const [retryDialogOpen, setRetryDialogOpen] = useState(false)
   const [purgeDialogOpen, setPurgeDialogOpen] = useState(false)
@@ -183,6 +185,7 @@ function QueueDetailPage() {
   } = useJobs(queueName, {
     status: status || undefined,
     jobId: jobId || undefined,
+    name: name || undefined,
     pageSize: 20,
   })
   const {
@@ -280,6 +283,10 @@ function QueueDetailPage() {
     setJobIdInput(jobId)
   }, [jobId])
 
+  useEffect(() => {
+    setNameInput(name)
+  }, [name])
+
   const handleCopyPrometheus = useCallback(async () => {
     if (!prometheusText || typeof navigator === 'undefined' || !navigator.clipboard) {
       return
@@ -300,13 +307,31 @@ function QueueDetailPage() {
     const timer = setTimeout(() => {
       navigate({
         to: '.',
-        search: { section, tab, status, jobId: normalizedJobId, hideScheduled, page: 1 },
+        search: { section, tab, status, jobId: normalizedJobId, name, hideScheduled, page: 1 },
         replace: true,
       })
     }, 300)
 
     return () => clearTimeout(timer)
-  }, [jobIdInput, jobId, section, tab, status, hideScheduled, navigate])
+  }, [jobIdInput, jobId, section, tab, status, name, hideScheduled, navigate])
+
+  useEffect(() => {
+    const normalizedName = nameInput.trim()
+
+    if (normalizedName === name) {
+      return
+    }
+
+    const timer = setTimeout(() => {
+      navigate({
+        to: '.',
+        search: { section, tab, status, jobId, name: normalizedName, hideScheduled, page: 1 },
+        replace: true,
+      })
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [nameInput, name, section, tab, status, jobId, hideScheduled, navigate])
 
   useEffect(() => {
     const container = jobsScrollRef.current
@@ -565,6 +590,7 @@ function QueueDetailPage() {
               tab,
               status,
               jobId,
+              name,
               hideScheduled,
               page,
             },
@@ -1295,7 +1321,7 @@ function QueueDetailPage() {
           onValueChange={(newTab) =>
             navigate({
               to: '.',
-              search: { section, tab: newTab as typeof tab, status, jobId, hideScheduled, page },
+              search: { section, tab: newTab as typeof tab, status, jobId, name, hideScheduled, page },
               replace: true,
             })
           }
@@ -1315,7 +1341,7 @@ function QueueDetailPage() {
                       })
                       navigate({
                         to: '.',
-                        search: { section, tab, status: newStatus, jobId, hideScheduled, page: 1 },
+                        search: { section, tab, status: newStatus, jobId, name, hideScheduled, page: 1 },
                         replace: true,
                       })
                     }}
@@ -1332,8 +1358,15 @@ function QueueDetailPage() {
                     value={jobIdInput}
                     onChange={(e) => setJobIdInput(e.target.value)}
                     placeholder="Search by job ID"
-                    className="w-64 max-w-full"
+                    className="w-48 max-w-full"
                     aria-label="Search jobs by ID"
+                  />
+                  <Input
+                    value={nameInput}
+                    onChange={(e) => setNameInput(e.target.value)}
+                    placeholder="Search by job name"
+                    className="w-48 max-w-full"
+                    aria-label="Search jobs by name"
                   />
                   <label className="inline-flex items-center gap-2 text-sm text-muted-foreground">
                     <input
@@ -1347,6 +1380,7 @@ function QueueDetailPage() {
                             tab,
                             status,
                             jobId,
+                            name,
                             hideScheduled: e.target.checked ? 1 : 0,
                             page: 1,
                           },


### PR DESCRIPTION
## Summary
- Adds a "Search by job name" input field to the queue detail toolbar, alongside the existing job ID search
- Uses case-insensitive substring matching so searching "email" matches "sendEmail", "email-notification", etc.
- Fixes a pagination bug where name and jobId filters were applied *after* BullMQ's paginated slice, causing empty results even when matching jobs existed on later pages — now fetches all jobs when filters are active, filters first, then paginates

<img width="1220" height="862" alt="image" src="https://github.com/user-attachments/assets/5f519f94-5a9a-4354-bd67-dbb59aedcd1e" />


## Test plan
- [x] Navigate to a queue detail page and verify the new "Search by job name" input appears next to "Search by job ID"
- [x] Search for a job name that exists — verify matching jobs are returned across all pages
- [x] Search for a partial job name — verify substring matching works (e.g. "REFRESH" matches "REFRESH_SEO_LANDING_PAGE")
- [x] Verify job ID search still works correctly
- [x] Combine status filter + name filter and verify both are applied
- [x] Clear the name search field and verify all jobs are shown again

🤖 Generated with [Claude Code](https://claude.com/claude-code)