### PR TITLE
fix: safely fetch workers to handle permission errors

### DIFF
--- a/apps/api/src/lib/redis.ts
+++ b/apps/api/src/lib/redis.ts
@@ -336,3 +336,18 @@ export async function getQueue(
 
   return queues.get(cacheKey)!
 }
+
+/**
+ * Safely fetch workers, returning empty array if CLIENT LIST permission is unavailable
+ */
+export async function safeGetWorkers(queue: Queue): Promise<Array<Record<string, string>>> {
+  try {
+    return await queue.getWorkers()
+  } catch (error) {
+    console.warn(
+      `❌ Could not fetch workers for queue ${queue.name}:`,
+      error instanceof Error ? error.message : 'unknown error'
+    )
+    return []
+  }
+}

--- a/apps/api/src/routes/queues.ts
+++ b/apps/api/src/routes/queues.ts
@@ -15,7 +15,7 @@ import {
   waitForQueueDiscovery,
 } from '../lib/queue-discovery'
 import { deleteQueueWithDiscoveryCleanup } from '../lib/delete-queue'
-import { debugGetBullKeys, getQueue } from '../lib/redis'
+import { debugGetBullKeys, getQueue, safeGetWorkers } from '../lib/redis'
 
 // Default and max page sizes for pagination
 const DEFAULT_PAGE_SIZE = 50
@@ -316,7 +316,7 @@ const app = new Hono()
     const [counts, isPaused, workers, schedulers] = await Promise.all([
       queue.getJobCounts(),
       queue.isPaused(),
-      queue.getWorkers(),
+      safeGetWorkers(queue),
       queue.getJobSchedulers(),
     ])
 

--- a/apps/api/src/routes/workers.ts
+++ b/apps/api/src/routes/workers.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { discoverQueues, getQueue } from '../lib/redis'
+import { discoverQueues, getQueue, safeGetWorkers } from '../lib/redis'
 
 // Default and max page sizes for pagination
 const DEFAULT_PAGE_SIZE = 50
@@ -47,7 +47,7 @@ const app = new Hono()
       paginatedQueueNames.map(async (queueName) => {
         const queue = await getQueue(connectionId, connectionUrl, queueName)
         const [workers, isPaused, counts] = await Promise.all([
-          queue.getWorkers(),
+          safeGetWorkers(queue),
           queue.isPaused(),
           queue.getJobCounts(),
         ])


### PR DESCRIPTION
Fix a bug where fetching workers caused the page to crash and not show any details on users without CLIENT LIST permission.

This affected two places:
- The queues page where it would crash after a few seconds, which will now just always show "0 workers connected".
- The workers page (obviously) which will now always show "No Workers Connected".

This is meant to make sure that the page does not crash. I was not currently sure what message / page to show when it crashes which is why for now it states that there are no workers (by returning an empty array)

Issue #51 