### PR TITLE
Reset queue discovery state after connection changes

### DIFF
--- a/apps/api/src/lib/queue-discovery.test.ts
+++ b/apps/api/src/lib/queue-discovery.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   and,
   closeDb,
@@ -25,6 +25,23 @@ const originalDatabaseUrl = mutableEnv.DATABASE_URL
 const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
 
 let tempPgliteDir = ''
+let redisSnapshotQueueNames = ['fresh-queue']
+let scanQueuesPageCalls = 0
+
+mock.module('./redis', () => ({
+  RedisUnavailableError: class RedisUnavailableError extends Error {},
+  debugGetBullKeys: async () => [],
+  discoverQueues: async () => [],
+  getQueue: async () => ({}),
+  getRedis: async () => ({}),
+  scanQueuesPage: async () => {
+    scanQueuesPageCalls += 1
+    return {
+      cursor: '0',
+      queueNames: redisSnapshotQueueNames,
+    }
+  },
+}))
 
 async function seedConnection() {
   const db = await getDb()
@@ -80,6 +97,8 @@ describe('redisDiscoveredQueueRepository.syncConnectionSnapshot', () => {
     process.env.DURABULL_PGLITE_DIR = tempPgliteDir
     delete process.env.DATABASE_URL
     mutableEnv.DATABASE_URL = undefined
+    redisSnapshotQueueNames = ['fresh-queue']
+    scanQueuesPageCalls = 0
     await closeDb()
     await seedConnection()
   })
@@ -140,5 +159,31 @@ describe('redisDiscoveredQueueRepository.syncConnectionSnapshot', () => {
     ).rejects.toThrow('snapshot sync failed')
 
     expect(await listQueueNames()).toEqual([{ name: 'conversation-message', state: 'confirmed' }])
+  })
+
+  it('clears completed runtime state so empty indexes can rediscover after connection changes', async () => {
+    const {
+      getQueueDiscoveryStatus,
+      resetQueueDiscoveryState,
+      startQueueDiscovery,
+      waitForQueueDiscovery,
+    } = await import('./queue-discovery')
+
+    await startQueueDiscovery(TEST_CONNECTION_ID, 'redis://localhost:6379/0')
+    await waitForQueueDiscovery(TEST_CONNECTION_ID)
+
+    const completedStatus = await getQueueDiscoveryStatus(TEST_CONNECTION_ID)
+    expect(completedStatus.completedAt).not.toBeNull()
+    expect(completedStatus.indexed.total).toBe(1)
+    expect(scanQueuesPageCalls).toBe(1)
+
+    await redisDiscoveredQueueRepository.deleteByConnection(TEST_CONNECTION_ID)
+    resetQueueDiscoveryState(TEST_CONNECTION_ID)
+
+    const resetStatus = await getQueueDiscoveryStatus(TEST_CONNECTION_ID)
+    expect(resetStatus.startedAt).toBeNull()
+    expect(resetStatus.completedAt).toBeNull()
+    expect(resetStatus.lastError).toBeNull()
+    expect(resetStatus.indexed.total).toBe(0)
   })
 })

--- a/apps/api/src/lib/queue-discovery.ts
+++ b/apps/api/src/lib/queue-discovery.ts
@@ -81,6 +81,8 @@ async function runQueueDiscovery(
   const discoveredQueueNames = new Set<string>()
 
   do {
+    if (discoveryStateByConnection.get(connectionId) !== runtime) return
+
     const page = await scanQueuesPage(connectionId, connectionUrl, cursor, scanCount, prefix)
     cursor = page.cursor
     runtime.scannedPages += 1
@@ -91,6 +93,8 @@ async function runQueueDiscovery(
 
     runtime.confirmedThisRun = discoveredQueueNames.size
   } while (cursor !== '0')
+
+  if (discoveryStateByConnection.get(connectionId) !== runtime) return
 
   const syncResult = await redisDiscoveredQueueRepository.syncConnectionSnapshot(
     connectionId,
@@ -105,6 +109,11 @@ export async function getQueueDiscoveryStatus(connectionId: string): Promise<Que
   const runtime = discoveryStateByConnection.get(connectionId)
   const snapshot = await getIndexedSnapshot(connectionId)
   return toDiscoveryStatus(runtime, snapshot)
+}
+
+export function resetQueueDiscoveryState(connectionId: string): void {
+  discoveryStateByConnection.delete(connectionId)
+  activeDiscoveryRuns.delete(connectionId)
 }
 
 export async function startQueueDiscovery(
@@ -136,13 +145,19 @@ export async function startQueueDiscovery(
 
   const runPromise = runQueueDiscovery(connectionId, connectionUrl, scanCount, prefix)
     .catch((error) => {
-      runtime.lastError = error instanceof Error ? error.message : String(error)
+      if (discoveryStateByConnection.get(connectionId) === runtime) {
+        runtime.lastError = error instanceof Error ? error.message : String(error)
+      }
       throw error
     })
     .finally(() => {
-      runtime.running = false
-      runtime.completedAt = Date.now()
-      activeDiscoveryRuns.delete(connectionId)
+      if (discoveryStateByConnection.get(connectionId) === runtime) {
+        runtime.running = false
+        runtime.completedAt = Date.now()
+      }
+      if (activeDiscoveryRuns.get(connectionId) === runPromise) {
+        activeDiscoveryRuns.delete(connectionId)
+      }
     })
 
   activeDiscoveryRuns.set(connectionId, runPromise)

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -8,6 +8,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { Redis } from 'ioredis'
 import { z } from 'zod'
+import { resetQueueDiscoveryState } from '../lib/queue-discovery'
 import { validateRedisUrlForEnvironment } from '../lib/url-validation'
 import { requireOrganization } from '../middleware/auth'
 import { connectionTestRateLimiter } from '../middleware/rate-limit'
@@ -205,6 +206,7 @@ const app = new Hono()
 
       if (shouldClearDiscoveredQueues) {
         await redisDiscoveredQueueRepository.deleteByConnection(id)
+        resetQueueDiscoveryState(id)
       }
 
       return c.json({


### PR DESCRIPTION
## Summary

Fixes #57.

Resets in-memory queue discovery state when a Redis connection URL or BullMQ prefix changes. The update path already clears persisted discovered queue rows; this makes the runtime state match that cleared index so the queues route can automatically start discovery again on the next load.

## Details

- Adds `resetQueueDiscoveryState(connectionId)` to clear completed/failed/running discovery runtime markers.
- Guards stale discovery promises so an old scan cannot repopulate rows or clobber a newer run after reset.
- Calls the reset when connection updates clear discovered queue rows.
- Adds coverage proving completed runtime state returns to "never attempted" after reset.

## Validation

- `bun test apps/api/src/lib/queue-discovery.test.ts apps/api/src/routes/connections.test.ts`
- `bun run --filter @durabull/api lint`
- `bun run --filter @durabull/api typecheck`
