### PR TITLE
feat(app: update) Implement durable app update checks

### DIFF
--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.agents/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.agents/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.agents/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.agents/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/.claude/skills/grill-me
+++ b/.claude/skills/grill-me
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-me

--- a/.claude/skills/improve-codebase-architecture
+++ b/.claude/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/improve-codebase-architecture

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Resolve release metadata
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          echo "DURABULL_APP_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          echo "DURABULL_BUILD_ID=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "DURABULL_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+          echo "DURABULL_RELEASE_CHANNEL=desktop" >> "$GITHUB_ENV"
+
       - name: Build native release artifacts
         if: github.event_name == 'push'
         run: bun run dist:desktop

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,13 +17,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Resolve release metadata
+        shell: bash
+        run: |
+          echo "DURABULL_APP_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          echo "DURABULL_BUILD_ID=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "DURABULL_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
       - name: Build smoke-test image
-        run: docker build -f tooling/docker/Dockerfile -t durabull-release:${{ github.sha }} .
+        run: |
+          docker build \
+            -f tooling/docker/Dockerfile \
+            --build-arg DURABULL_APP_VERSION="${DURABULL_APP_VERSION}" \
+            --build-arg DURABULL_BUILD_ID="${DURABULL_BUILD_ID}" \
+            --build-arg DURABULL_BUILD_TIME="${DURABULL_BUILD_TIME}" \
+            --build-arg DURABULL_RELEASE_CHANNEL="docker" \
+            -t durabull-release:${{ github.sha }} \
+            .
 
       - name: Smoke test self-hosted image
         run: bash tooling/scripts/docker-image-smoke.sh
         env:
           DURABULL_IMAGE: durabull-release:${{ github.sha }}
+          DURABULL_EXPECTED_BUILD_ID: ${{ env.DURABULL_BUILD_ID }}
+          DURABULL_EXPECTED_RELEASE_CHANNEL: docker
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -57,6 +74,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            DURABULL_APP_VERSION=${{ env.DURABULL_APP_VERSION }}
+            DURABULL_BUILD_ID=${{ env.DURABULL_BUILD_ID }}
+            DURABULL_BUILD_TIME=${{ env.DURABULL_BUILD_TIME }}
+            DURABULL_RELEASE_CHANNEL=docker
 
   trigger-cloud-deploy-hook:
     name: Trigger Cloud Deploy Hook

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,15 +17,15 @@
     "predev": "bun run clear-port-3001",
     "dev": "bun --watch src/index.ts",
     "clear-port-3001": "if [ -n \"$SKIP_CLEAR_PORT_3001\" ]; then echo 'Skipping clear-port-3001'; else lsof -ti:3001 | xargs kill -9 2>/dev/null || echo 'No process found on port 3001'; fi",
-    "build": "bun build src/index.ts --target=bun --outdir=dist --sourcemap=external",
+    "build": "bun scripts/build.ts",
     "start": "bun src/index.ts",
     "start:built": "bun dist/index.js",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "lint": "biome lint ./src",
-    "lint:fix": "biome lint --write ./src",
-    "format": "biome format --write ./src",
-    "format:check": "biome format ./src"
+    "lint": "biome lint ./src ./scripts",
+    "lint:fix": "biome lint --write ./src ./scripts",
+    "format": "biome format --write ./src ./scripts",
+    "format:check": "biome format ./src ./scripts"
   },
   "dependencies": {
     "@durabull/auth": "workspace:*",

--- a/apps/api/scripts/build.ts
+++ b/apps/api/scripts/build.ts
@@ -1,0 +1,44 @@
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import rootPackage from '../../../package.json'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const apiRoot = join(scriptDir, '..')
+
+function firstNonEmpty(...values: Array<string | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+
+  return null
+}
+
+const appVersion = firstNonEmpty(process.env.DURABULL_APP_VERSION, rootPackage.version) ?? '0.0.0'
+const appBuildId =
+  firstNonEmpty(
+    process.env.DURABULL_BUILD_ID,
+    process.env.VERCEL_GIT_COMMIT_SHA,
+    process.env.GITHUB_SHA
+  ) ?? appVersion
+const appBuildTime = firstNonEmpty(process.env.DURABULL_BUILD_TIME)
+
+const result = await Bun.build({
+  entrypoints: [join(apiRoot, 'src', 'index.ts')],
+  target: 'bun',
+  outdir: join(apiRoot, 'dist'),
+  sourcemap: 'external',
+  define: {
+    __DURABULL_APP_VERSION__: JSON.stringify(appVersion),
+    __DURABULL_BUILD_ID__: JSON.stringify(appBuildId),
+    __DURABULL_BUILD_TIME__: JSON.stringify(appBuildTime ?? null),
+  },
+})
+
+if (!result.success) {
+  for (const log of result.logs) {
+    console.error(log)
+  }
+
+  process.exit(1)
+}

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { closeDb } from '@durabull/dal'
 import { env } from '@durabull/env'
 import { createApiApp } from './app'
+import { APP_BUILD_ID, APP_VERSION } from './lib/build-info'
 
 const mutableEnv = env as {
   APP_BASE_URL?: string
@@ -123,6 +124,38 @@ describe('api app config', () => {
         collectionRequired: true,
         dedupeIdentifiedPosthogEvents: false,
         enabled: true,
+      },
+    })
+  })
+
+  it('exposes no-store app version checks without session state', async () => {
+    const { app } = await createApiApp({ enableLogging: false })
+
+    const staleResponse = await app.request(
+      '/api/app/version?clientVersion=0.0.0&clientBuildId=old-build'
+    )
+    const currentResponse = await app.request(
+      `/api/app/version?clientVersion=${APP_VERSION}&clientBuildId=${APP_BUILD_ID}`
+    )
+
+    expect(staleResponse.status).toBe(200)
+    expect(staleResponse.headers.get('Cache-Control')).toBe(
+      'no-store, no-cache, must-revalidate, max-age=0'
+    )
+    expect(await staleResponse.json()).toMatchObject({
+      version: APP_VERSION,
+      buildId: APP_BUILD_ID,
+      update: {
+        required: true,
+        reason: APP_BUILD_ID === APP_VERSION ? 'version_mismatch' : 'build_mismatch',
+      },
+    })
+
+    expect(currentResponse.status).toBe(200)
+    expect(await currentResponse.json()).toMatchObject({
+      update: {
+        required: false,
+        reason: 'up_to_date',
       },
     })
   })

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import { secureHeaders } from 'hono/secure-headers'
 
 import { getAuth } from './lib/auth'
 import { isAuthlessMode } from './lib/authless'
+import { getAppVersionPayload } from './lib/build-info'
 import { RedisUnavailableError } from './lib/redis'
 import { createSessionMiddleware } from './middleware/auth'
 import { createConnectionMiddleware } from './middleware/connection'
@@ -35,6 +36,7 @@ import workersRoutes from './routes/workers'
 
 const DEFAULT_POSTHOG_API_HOST = 'https://us.i.posthog.com'
 const DEFAULT_POSTHOG_UI_HOST = 'https://us.posthog.com'
+const NO_STORE_CACHE_CONTROL = 'no-store, no-cache, must-revalidate, max-age=0'
 const REDIS_CONNECTION_ERROR_MESSAGE =
   'Unable to connect to Redis for this connection. Verify Redis URL, credentials, TLS settings, and IP allowlist, then retry.'
 
@@ -142,6 +144,7 @@ function getAppConfig() {
       uiHost: DEFAULT_POSTHOG_UI_HOST,
     },
     telemetry: getTelemetryStatus(),
+    version: getAppVersionPayload(),
   }
 }
 
@@ -176,6 +179,15 @@ const apiRoutes = new Hono()
   .route('/invitations', invitationsRoutes)
   // Health check (no auth needed)
   .get('/health', (c) => c.json({ status: 'ok', timestamp: Date.now() }))
+  .get('/app/version', (c) => {
+    c.header('Cache-Control', NO_STORE_CACHE_CONTROL)
+    return c.json(
+      getAppVersionPayload({
+        version: c.req.query('clientVersion'),
+        buildId: c.req.query('clientBuildId'),
+      })
+    )
+  })
   // App bootstrap config for the web client
   .get('/app/config', (c) => c.json(getAppConfig()))
   // Backward-compatible app mode subset
@@ -350,6 +362,15 @@ export async function createApiApp(options: CreateApiAppOptions = {}) {
     .route('/auth', authRoutes)
     .route('/invitations', invitationsRoutes)
     .get('/health', (c) => c.json({ status: 'ok', timestamp: Date.now() }))
+    .get('/app/version', (c) => {
+      c.header('Cache-Control', NO_STORE_CACHE_CONTROL)
+      return c.json(
+        getAppVersionPayload({
+          version: c.req.query('clientVersion'),
+          buildId: c.req.query('clientBuildId'),
+        })
+      )
+    })
     .get('/mode', (c) => c.json(getAppMode()))
     .route('/telemetry', telemetryRoutes)
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -64,6 +64,7 @@ startAlertMonitor()
 // Serve static files from web app build (for production)
 const webDistPath = join(import.meta.dir, '../../web/dist')
 const hasWebBuild = existsSync(webDistPath)
+const HTML_CACHE_CONTROL = 'no-store, no-cache, must-revalidate, max-age=0'
 
 if (hasWebBuild) {
   // Serve static assets with immutable cache headers (hashed filenames)
@@ -78,10 +79,29 @@ if (hasWebBuild) {
   )
 
   // Serve other static files (favicons, etc.)
-  app.use('*', serveStatic({ root: webDistPath }))
+  app.use(
+    '*',
+    serveStatic({
+      root: webDistPath,
+      onFound: (path, c) => {
+        if (path.endsWith('.html')) {
+          c.header('Cache-Control', HTML_CACHE_CONTROL)
+        }
+      },
+    })
+  )
 
   // SPA fallback - serve index.html for all unmatched routes
-  app.get('*', serveStatic({ root: webDistPath, path: 'index.html' }))
+  app.get(
+    '*',
+    serveStatic({
+      root: webDistPath,
+      path: 'index.html',
+      onFound: (_path, c) => {
+        c.header('Cache-Control', HTML_CACHE_CONTROL)
+      },
+    })
+  )
 }
 
 // Re-export the API type for RPC client

--- a/apps/api/src/lib/build-info.test.ts
+++ b/apps/api/src/lib/build-info.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+
+const BUILD_INFO_ENV_KEYS = [
+  'DURABULL_APP_VERSION',
+  'DURABULL_BUILD_ID',
+  'DURABULL_BUILD_TIME',
+  'DURABULL_RELEASE_CHANNEL',
+  'GITHUB_SHA',
+  'VERCEL_GIT_COMMIT_SHA',
+] as const
+
+type BuildInfoEnvKey = (typeof BUILD_INFO_ENV_KEYS)[number]
+
+const originalEnv = Object.fromEntries(
+  BUILD_INFO_ENV_KEYS.map((key) => [key, process.env[key]])
+) as Record<BuildInfoEnvKey, string | undefined>
+
+let importCounter = 0
+
+function restoreEnv() {
+  for (const key of BUILD_INFO_ENV_KEYS) {
+    const value = originalEnv[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+async function importBuildInfo(env: Partial<Record<BuildInfoEnvKey, string | undefined>>) {
+  for (const key of BUILD_INFO_ENV_KEYS) {
+    delete process.env[key]
+  }
+
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key as BuildInfoEnvKey]
+    } else {
+      process.env[key as BuildInfoEnvKey] = value
+    }
+  }
+
+  importCounter += 1
+  return import(`./build-info?build-info-test=${importCounter}`) as Promise<
+    typeof import('./build-info')
+  >
+}
+
+describe('build info', () => {
+  afterEach(() => {
+    restoreEnv()
+  })
+
+  it('requires an update when the client version is older than the API version', async () => {
+    const { getAppVersionPayload } = await importBuildInfo({
+      DURABULL_APP_VERSION: '2.0.0',
+    })
+
+    expect(getAppVersionPayload({ version: '1.9.0', buildId: '1.9.0' })).toMatchObject({
+      version: '2.0.0',
+      buildId: '2.0.0',
+      releaseChannel: 'stable',
+      update: {
+        required: true,
+        reason: 'version_mismatch',
+      },
+    })
+  })
+
+  it('requires an update when comparable build ids differ', async () => {
+    const { getAppVersionPayload } = await importBuildInfo({
+      DURABULL_APP_VERSION: '2.0.0',
+      DURABULL_BUILD_ID: 'server-build',
+      DURABULL_BUILD_TIME: '2026-05-01T12:00:00.000Z',
+      DURABULL_RELEASE_CHANNEL: 'desktop',
+    })
+
+    expect(getAppVersionPayload({ version: '2.0.0', buildId: 'client-build' })).toEqual({
+      version: '2.0.0',
+      buildId: 'server-build',
+      buildTime: '2026-05-01T12:00:00.000Z',
+      releaseChannel: 'desktop',
+      update: {
+        required: true,
+        reason: 'build_mismatch',
+      },
+    })
+  })
+
+  it('does not create a false build mismatch when the API has no distinct build id', async () => {
+    const { getAppVersionPayload } = await importBuildInfo({
+      DURABULL_APP_VERSION: '2.0.0',
+    })
+
+    expect(getAppVersionPayload({ version: '2.0.0', buildId: 'client-build' })).toMatchObject({
+      buildId: '2.0.0',
+      update: {
+        required: false,
+        reason: 'up_to_date',
+      },
+    })
+  })
+
+  it('does not require an update when the client version is missing or unknown', async () => {
+    const { getAppVersionPayload } = await importBuildInfo({
+      DURABULL_APP_VERSION: '2.0.0',
+      DURABULL_BUILD_ID: 'server-build',
+    })
+
+    expect(getAppVersionPayload({ version: 'unknown', buildId: 'client-build' })).toMatchObject({
+      update: {
+        required: false,
+        reason: 'missing_client_version',
+      },
+    })
+    expect(getAppVersionPayload()).toMatchObject({
+      update: {
+        required: false,
+        reason: 'missing_client_version',
+      },
+    })
+  })
+
+  it('uses hosted commit metadata as the build id fallback', async () => {
+    const { getAppVersionPayload } = await importBuildInfo({
+      DURABULL_APP_VERSION: '2.0.0',
+      GITHUB_SHA: 'github-build',
+      VERCEL_GIT_COMMIT_SHA: 'vercel-build',
+    })
+
+    expect(getAppVersionPayload({ version: '2.0.0', buildId: 'vercel-build' })).toMatchObject({
+      buildId: 'vercel-build',
+      update: {
+        required: false,
+        reason: 'up_to_date',
+      },
+    })
+  })
+})

--- a/apps/api/src/lib/build-info.ts
+++ b/apps/api/src/lib/build-info.ts
@@ -1,0 +1,107 @@
+import rootPackage from '../../../../package.json'
+
+declare const __DURABULL_APP_VERSION__: string | undefined
+declare const __DURABULL_BUILD_ID__: string | undefined
+declare const __DURABULL_BUILD_TIME__: string | null | undefined
+
+const DEFAULT_RELEASE_CHANNEL = 'stable'
+const EMBEDDED_APP_VERSION =
+  typeof __DURABULL_APP_VERSION__ === 'undefined' ? undefined : __DURABULL_APP_VERSION__
+const EMBEDDED_BUILD_ID =
+  typeof __DURABULL_BUILD_ID__ === 'undefined' ? undefined : __DURABULL_BUILD_ID__
+const EMBEDDED_BUILD_TIME =
+  typeof __DURABULL_BUILD_TIME__ === 'undefined' ? undefined : __DURABULL_BUILD_TIME__
+
+function firstNonEmpty(...values: Array<string | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+
+  return null
+}
+
+function normalizeBuildId(value: string | null): string {
+  return value ?? APP_VERSION
+}
+
+export const APP_VERSION =
+  firstNonEmpty(process.env.DURABULL_APP_VERSION, EMBEDDED_APP_VERSION, rootPackage.version) ??
+  '0.0.0'
+export const APP_BUILD_ID = normalizeBuildId(
+  firstNonEmpty(
+    process.env.DURABULL_BUILD_ID,
+    EMBEDDED_BUILD_ID,
+    process.env.VERCEL_GIT_COMMIT_SHA,
+    process.env.GITHUB_SHA
+  )
+)
+export const APP_BUILD_TIME = firstNonEmpty(
+  process.env.DURABULL_BUILD_TIME,
+  EMBEDDED_BUILD_TIME ?? undefined
+)
+export const APP_RELEASE_CHANNEL =
+  firstNonEmpty(process.env.DURABULL_RELEASE_CHANNEL) ?? DEFAULT_RELEASE_CHANNEL
+
+export type AppUpdateReason =
+  | 'build_mismatch'
+  | 'missing_client_version'
+  | 'up_to_date'
+  | 'version_mismatch'
+
+export interface AppVersionPayload {
+  version: string
+  buildId: string
+  buildTime: string | null
+  releaseChannel: string
+  update: {
+    required: boolean
+    reason: AppUpdateReason
+  }
+}
+
+interface ClientBuildInfo {
+  version?: string | null
+  buildId?: string | null
+}
+
+function normalizeClientValue(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed && trimmed !== 'unknown' ? trimmed : null
+}
+
+function hasDistinctBuildId(version: string | null, buildId: string | null): boolean {
+  return Boolean(version && buildId && buildId !== version)
+}
+
+export function getAppVersionPayload(clientBuild: ClientBuildInfo = {}): AppVersionPayload {
+  const clientVersion = normalizeClientValue(clientBuild.version)
+  const clientBuildId = normalizeClientValue(clientBuild.buildId)
+  const canCompareBuildIds =
+    hasDistinctBuildId(APP_VERSION, APP_BUILD_ID) &&
+    hasDistinctBuildId(clientVersion, clientBuildId)
+
+  let required = false
+  let reason: AppUpdateReason = 'up_to_date'
+
+  if (!clientVersion) {
+    reason = 'missing_client_version'
+  } else if (canCompareBuildIds && clientBuildId !== APP_BUILD_ID) {
+    required = true
+    reason = 'build_mismatch'
+  } else if (clientVersion !== APP_VERSION) {
+    required = true
+    reason = 'version_mismatch'
+  }
+
+  return {
+    version: APP_VERSION,
+    buildId: APP_BUILD_ID,
+    buildTime: APP_BUILD_TIME,
+    releaseChannel: APP_RELEASE_CHANNEL,
+    update: {
+      required,
+      reason,
+    },
+  }
+}

--- a/apps/api/src/lib/redis.test.ts
+++ b/apps/api/src/lib/redis.test.ts
@@ -5,6 +5,12 @@ const queueInstances: Array<{
   opts: { prefix?: string; connection?: { url?: string } }
 }> = []
 const scanCalls: Array<Array<string | number>> = []
+let importId = 0
+
+async function importFreshRedis(): Promise<typeof import('./redis')> {
+  importId += 1
+  return import(`./redis?redis-prefix-test=${importId}`) as Promise<typeof import('./redis')>
+}
 
 mock.module('bullmq', () => ({
   Queue: class MockQueue {
@@ -52,7 +58,7 @@ describe('redis queue prefix handling', () => {
   })
 
   it('caches queues separately by connection URL and prefix', async () => {
-    const { getQueue } = await import('./redis')
+    const { getQueue } = await importFreshRedis()
 
     const first = await getQueue('conn-1', 'redis://localhost:6379/0', 'email', 'bull')
     const same = await getQueue('conn-1', 'redis://localhost:6379/0', 'email', 'bull')
@@ -74,7 +80,7 @@ describe('redis queue prefix handling', () => {
   })
 
   it('escapes prefix glob characters when scanning queue metadata', async () => {
-    const { debugGetBullKeys, scanQueuesPage } = await import('./redis')
+    const { debugGetBullKeys, scanQueuesPage } = await importFreshRedis()
 
     await scanQueuesPage('conn-2', 'redis://localhost:6379/0', '0', 100, 'bull\\prod[1]*?')
     await debugGetBullKeys('conn-3', 'redis://localhost:6379/0', 'bull\\prod[1]*?')

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -21,5 +21,5 @@
     },
     "baseUrl": "."
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "scripts/**/*.ts"]
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -164,6 +164,7 @@ function buildServerEnvironment(
   env.APP_BASE_URL = baseUrl
   env.VITE_PUBLIC_APP_URL = baseUrl
   env.PORT = String(port)
+  env.DURABULL_RELEASE_CHANNEL = app.isPackaged ? 'desktop' : 'desktop-dev'
   env.DURABULL_AUTHLESS = 'true'
   env.DURABULL_ENV_CONNECTIONS = 'false'
   env.DURABULL_PGLITE_DIR = join(app.getPath('userData'), 'pglite')

--- a/apps/web/src/components/app-update-banner.test.tsx
+++ b/apps/web/src/components/app-update-banner.test.tsx
@@ -1,0 +1,118 @@
+import { AnalyticsEvents } from '@durabull/analytics'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AppUpdateBanner } from './app-update-banner'
+
+const mocks = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  useAppVersionCheck: vi.fn(),
+}))
+
+vi.mock('@durabull/analytics', async () => {
+  const actual = await vi.importActual<typeof import('@durabull/analytics')>('@durabull/analytics')
+  return {
+    ...actual,
+    trackEvent: mocks.trackEvent,
+  }
+})
+
+vi.mock('@/hooks/use-app-version-check', () => ({
+  useAppVersionCheck: mocks.useAppVersionCheck,
+}))
+
+describe('AppUpdateBanner', () => {
+  beforeEach(() => {
+    mocks.trackEvent.mockReset()
+    mocks.useAppVersionCheck.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stays hidden when the current build matches the API build', () => {
+    mocks.useAppVersionCheck.mockReturnValue({
+      client: { version: '1.4.0', buildId: 'build-a', buildTime: null },
+      server: {
+        version: '1.4.0',
+        buildId: 'build-a',
+        buildTime: null,
+        releaseChannel: 'stable',
+        update: { required: false, reason: 'up_to_date' },
+      },
+      updateRequired: false,
+      updateReason: 'up_to_date',
+      isChecking: false,
+      error: null,
+    })
+
+    render(<AppUpdateBanner />)
+
+    expect(screen.queryByRole('button', { name: /update/i })).not.toBeInTheDocument()
+  })
+
+  it('tracks the update click and triggers the update action', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+    mocks.useAppVersionCheck.mockReturnValue({
+      client: { version: '1.3.0', buildId: 'build-a', buildTime: null },
+      server: {
+        version: '1.4.0',
+        buildId: 'build-b',
+        buildTime: null,
+        releaseChannel: 'stable',
+        update: { required: true, reason: 'build_mismatch' },
+      },
+      updateRequired: true,
+      updateReason: 'build_mismatch',
+      isChecking: false,
+      error: null,
+    })
+
+    render(<AppUpdateBanner onUpdate={onUpdate} />)
+
+    await user.click(screen.getByRole('button', { name: /update/i }))
+
+    expect(mocks.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvents.APP_UPDATE_CLICKED,
+      expect.objectContaining({
+        app_version: '1.3.0',
+        app_build_id: 'build-a',
+        server_version: '1.4.0',
+        server_build_id: 'build-b',
+        update_reason: 'build_mismatch',
+        action: 'reload',
+      })
+    )
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1))
+  })
+
+  it('still triggers the update action if analytics tracking fails', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+    mocks.trackEvent.mockImplementation(() => {
+      throw new Error('posthog unavailable')
+    })
+    mocks.useAppVersionCheck.mockReturnValue({
+      client: { version: '1.3.0', buildId: 'build-a', buildTime: null },
+      server: {
+        version: '1.4.0',
+        buildId: 'build-b',
+        buildTime: null,
+        releaseChannel: 'stable',
+        update: { required: true, reason: 'build_mismatch' },
+      },
+      updateRequired: true,
+      updateReason: 'build_mismatch',
+      isChecking: false,
+      error: null,
+    })
+
+    render(<AppUpdateBanner onUpdate={onUpdate} />)
+
+    await user.click(screen.getByRole('button', { name: /update/i }))
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1))
+  })
+})

--- a/apps/web/src/components/app-update-banner.tsx
+++ b/apps/web/src/components/app-update-banner.tsx
@@ -1,0 +1,71 @@
+import { AnalyticsEvents, AnalyticsProperties, trackEvent } from '@durabull/analytics'
+import { RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { useAppVersionCheck } from '@/hooks/use-app-version-check'
+
+export function reloadToLatestBuild() {
+  const nextUrl = new URL(window.location.href)
+  nextUrl.searchParams.set('__durabull_update', Date.now().toString(36))
+  window.location.replace(nextUrl.toString())
+}
+
+interface AppUpdateBannerProps {
+  onUpdate?: () => void
+}
+
+export function AppUpdateBanner({ onUpdate = reloadToLatestBuild }: AppUpdateBannerProps) {
+  const { client, server, updateRequired, updateReason } = useAppVersionCheck()
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  if (!updateRequired || !server) return null
+
+  const handleUpdate = () => {
+    setIsUpdating(true)
+    try {
+      trackEvent(AnalyticsEvents.APP_UPDATE_CLICKED, {
+        [AnalyticsProperties.APP_VERSION]: client.version,
+        [AnalyticsProperties.APP_BUILD_ID]: client.buildId,
+        [AnalyticsProperties.CLIENT_VERSION]: client.version,
+        [AnalyticsProperties.CLIENT_BUILD_ID]: client.buildId,
+        [AnalyticsProperties.API_VERSION]: server.version,
+        [AnalyticsProperties.API_BUILD_ID]: server.buildId,
+        [AnalyticsProperties.SERVER_VERSION]: server.version,
+        [AnalyticsProperties.SERVER_BUILD_ID]: server.buildId,
+        [AnalyticsProperties.UPDATE_REASON]: updateReason,
+        [AnalyticsProperties.RELEASE_CHANNEL]: server.releaseChannel,
+        action: 'reload',
+      })
+    } catch {
+      // Updating the app must not depend on analytics availability.
+    }
+
+    window.setTimeout(onUpdate, 150)
+  }
+
+  return (
+    <aside
+      aria-label="Application update"
+      aria-live="polite"
+      className="fixed right-4 bottom-4 z-50 w-[calc(100vw-2rem)] max-w-sm rounded-lg border border-amber-500/30 bg-background/95 p-3 text-foreground shadow-2xl shadow-black/25 backdrop-blur supports-[backdrop-filter]:bg-background/85"
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-amber-500/15 text-amber-500">
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-5">Update available</p>
+          <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+            Reload to apply the latest Durabull build.
+          </p>
+          <div className="mt-3 flex justify-end">
+            <Button size="sm" onClick={handleUpdate} disabled={isUpdating}>
+              <RefreshCw className={isUpdating ? 'mr-2 h-4 w-4 animate-spin' : 'mr-2 h-4 w-4'} />
+              Update
+            </Button>
+          </div>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/web/src/hooks/use-app-config.ts
+++ b/apps/web/src/hooks/use-app-config.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { api, type InferResponseType } from '@/lib/api'
+import { APP_BUILD_INFO } from '@/lib/app-version'
 
 type ServerAppConfigResponse = InferResponseType<(typeof api.app.config)['$get'], 200>
 
@@ -27,6 +28,16 @@ const FALLBACK_APP_CONFIG: AppConfigResponse = {
     dedupeIdentifiedPosthogEvents: false,
     disclosureUrl: 'https://durabull.io/privacy',
   },
+  version: {
+    version: APP_BUILD_INFO.version,
+    buildId: APP_BUILD_INFO.buildId,
+    buildTime: APP_BUILD_INFO.buildTime,
+    releaseChannel: 'development',
+    update: {
+      required: false,
+      reason: 'up_to_date',
+    },
+  },
 }
 
 export const appConfigQueryKey = ['app-config'] as const
@@ -47,7 +58,12 @@ export function useAppConfig() {
     retry: 3,
   })
 
-  const config = data ?? FALLBACK_APP_CONFIG
+  const config = data
+    ? {
+        ...data,
+        version: data.version ?? FALLBACK_APP_CONFIG.version,
+      }
+    : FALLBACK_APP_CONFIG
 
   return {
     config,

--- a/apps/web/src/hooks/use-app-version-check.test.tsx
+++ b/apps/web/src/hooks/use-app-version-check.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  APP_VERSION_CHECK_INTERVAL_MS,
+  isAppUpdateRequired,
+  useAppVersionCheck,
+} from './use-app-version-check'
+
+const mocks = vi.hoisted(() => ({
+  fetchApi: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  fetchApi: mocks.fetchApi,
+}))
+
+vi.mock('@/lib/app-version', () => ({
+  APP_BUILD_INFO: {
+    version: '1.2.3',
+    buildId: 'client-build',
+    buildTime: null,
+  },
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useAppVersionCheck', () => {
+  beforeEach(() => {
+    mocks.fetchApi.mockReset()
+  })
+
+  it('checks the no-store version endpoint with the current client build metadata', async () => {
+    mocks.fetchApi.mockResolvedValue({
+      version: '1.2.4',
+      buildId: 'server-build',
+      buildTime: null,
+      releaseChannel: 'stable',
+      update: {
+        required: true,
+        reason: 'build_mismatch',
+      },
+    })
+
+    const { result } = renderHook(() => useAppVersionCheck(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.server?.buildId).toBe('server-build'))
+
+    expect(mocks.fetchApi).toHaveBeenCalledWith(
+      '/api/app/version?clientVersion=1.2.3&clientBuildId=client-build',
+      {
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache',
+        },
+      }
+    )
+    expect(result.current.updateRequired).toBe(true)
+    expect(result.current.updateReason).toBe('build_mismatch')
+    expect(result.current.client).toEqual({
+      version: '1.2.3',
+      buildId: 'client-build',
+      buildTime: null,
+    })
+  })
+
+  it('uses a five minute polling interval', () => {
+    expect(APP_VERSION_CHECK_INTERVAL_MS).toBe(5 * 60 * 1000)
+  })
+
+  it('only treats explicit server update responses as stale', () => {
+    expect(isAppUpdateRequired(null)).toBe(false)
+    expect(
+      isAppUpdateRequired({
+        version: '1.2.3',
+        buildId: 'client-build',
+        buildTime: null,
+        releaseChannel: 'stable',
+        update: {
+          required: false,
+          reason: 'up_to_date',
+        },
+      })
+    ).toBe(false)
+    expect(
+      isAppUpdateRequired({
+        version: '1.2.4',
+        buildId: 'server-build',
+        buildTime: null,
+        releaseChannel: 'stable',
+        update: {
+          required: true,
+          reason: 'build_mismatch',
+        },
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/web/src/hooks/use-app-version-check.ts
+++ b/apps/web/src/hooks/use-app-version-check.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchApi, type api, type InferResponseType } from '@/lib/api'
+import { APP_BUILD_INFO } from '@/lib/app-version'
+
+export const APP_VERSION_CHECK_INTERVAL_MS = 5 * 60 * 1000
+
+export type ServerAppVersion = InferResponseType<(typeof api.app.version)['$get'], 200>
+
+export interface AppVersionCheckResult {
+  client: typeof APP_BUILD_INFO
+  server: ServerAppVersion | null
+  updateRequired: boolean
+  updateReason: ServerAppVersion['update']['reason'] | 'check_failed'
+  isChecking: boolean
+  error: Error | null
+}
+
+export const appVersionQueryKey = [
+  'app-version',
+  APP_BUILD_INFO.version,
+  APP_BUILD_INFO.buildId,
+] as const
+
+function getVersionCheckPath(): string {
+  const params = new URLSearchParams({
+    clientVersion: APP_BUILD_INFO.version,
+    clientBuildId: APP_BUILD_INFO.buildId,
+  })
+
+  return `/api/app/version?${params.toString()}`
+}
+
+async function fetchAppVersion(): Promise<ServerAppVersion> {
+  return fetchApi<ServerAppVersion>(getVersionCheckPath(), {
+    cache: 'no-store',
+    headers: {
+      'Cache-Control': 'no-cache',
+    },
+  })
+}
+
+export function isAppUpdateRequired(server: ServerAppVersion | null): boolean {
+  return server?.update?.required === true
+}
+
+export function useAppVersionCheck(): AppVersionCheckResult {
+  const { data, error, isFetching } = useQuery({
+    queryKey: appVersionQueryKey,
+    queryFn: fetchAppVersion,
+    refetchInterval: APP_VERSION_CHECK_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: false,
+    retry: 2,
+    staleTime: 0,
+  })
+
+  return {
+    client: APP_BUILD_INFO,
+    server: data ?? null,
+    updateRequired: isAppUpdateRequired(data ?? null),
+    updateReason: data?.update?.reason ?? (error ? 'check_failed' : 'up_to_date'),
+    isChecking: isFetching,
+    error: error instanceof Error ? error : null,
+  }
+}

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -1,0 +1,22 @@
+declare const __DURABULL_APP_VERSION__: string | undefined
+declare const __DURABULL_BUILD_ID__: string | undefined
+declare const __DURABULL_BUILD_TIME__: string | null | undefined
+
+function readDefinedString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+export const APP_BUILD_INFO = {
+  version: readDefinedString(
+    typeof __DURABULL_APP_VERSION__ === 'undefined' ? undefined : __DURABULL_APP_VERSION__,
+    'unknown'
+  ),
+  buildId: readDefinedString(
+    typeof __DURABULL_BUILD_ID__ === 'undefined' ? undefined : __DURABULL_BUILD_ID__,
+    'unknown'
+  ),
+  buildTime:
+    typeof __DURABULL_BUILD_TIME__ === 'string' && __DURABULL_BUILD_TIME__.trim()
+      ? __DURABULL_BUILD_TIME__.trim()
+      : null,
+} as const

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,11 +1,25 @@
+import { configureDurabullTelemetry } from '@durabull/analytics'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { APP_BUILD_INFO } from './lib/app-version'
 import { getRouter } from './router'
 import './styles.css'
 
 const router = getRouter()
+const runtime =
+  typeof navigator !== 'undefined' && /\belectron\b/i.test(navigator.userAgent) ? 'electron' : 'web'
+
+configureDurabullTelemetry({
+  enabled: false,
+  collectionRequired: true,
+  runtimeContext: {
+    app_version: APP_BUILD_INFO.version,
+    app_build_id: APP_BUILD_INFO.buildId,
+    runtime,
+  },
+})
 
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Root element not found')

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -24,7 +24,8 @@ import {
   Users,
 } from 'lucide-react'
 import { PostHogProvider } from 'posthog-js/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { AppUpdateBanner } from '@/components/app-update-banner'
 import { APP_TOP_BAR_HEIGHT_CLASS, AppTopBar, AppTopBarProvider } from '@/components/app-top-bar'
 import { ConnectionProvider, useConnection } from '@/components/connection-provider'
 import { ConnectionSelector } from '@/components/connection-selector'
@@ -44,6 +45,7 @@ import { useAuth } from '@/hooks/use-auth'
 import { useIsElectronShell } from '@/hooks/use-electron-shell'
 import { type Organization, useOrganizations } from '@/hooks/use-organization'
 import { usePageViewTracking } from '@/hooks/use-page-view-tracking'
+import { APP_BUILD_INFO } from '@/lib/app-version'
 import { cn } from '@/lib/utils'
 
 /**
@@ -90,6 +92,33 @@ export const Route = createRootRouteWithContext<{
 
 function RootComponent() {
   const { config, isLoading } = useAppConfig()
+  const isElectronShell = useIsElectronShell()
+  const telemetryRuntimeContext = useMemo(
+    () => ({
+      authless: config.authless,
+      env_connections: config.envConnections,
+      environment: config.environment,
+      persistence: config.persistence,
+      runtime: isElectronShell ? 'electron' : 'web',
+      stateless: config.stateless,
+      app_version: APP_BUILD_INFO.version,
+      app_build_id: APP_BUILD_INFO.buildId,
+      api_version: config.version.version,
+      api_build_id: config.version.buildId,
+      release_channel: config.version.releaseChannel,
+    }),
+    [
+      config.authless,
+      config.envConnections,
+      config.environment,
+      config.persistence,
+      config.stateless,
+      config.version.version,
+      config.version.buildId,
+      config.version.releaseChannel,
+      isElectronShell,
+    ]
+  )
 
   useEffect(() => {
     configureDurabullTelemetry({
@@ -97,16 +126,15 @@ function RootComponent() {
       collectionRequired: config.telemetry.collectionRequired,
       dedupeIdentifiedPosthogEvents: config.telemetry.dedupeIdentifiedPosthogEvents,
       disclosureUrl: config.telemetry.disclosureUrl,
-      runtimeContext: {
-        authless: config.authless,
-        env_connections: config.envConnections,
-        environment: config.environment,
-        persistence: config.persistence,
-        runtime: 'web',
-        stateless: config.stateless,
-      },
+      runtimeContext: telemetryRuntimeContext,
     })
-  }, [config])
+  }, [
+    config.telemetry.enabled,
+    config.telemetry.collectionRequired,
+    config.telemetry.dedupeIdentifiedPosthogEvents,
+    config.telemetry.disclosureUrl,
+    telemetryRuntimeContext,
+  ])
 
   // Render children without PostHog if config is missing
   const content = (
@@ -114,6 +142,7 @@ function RootComponent() {
       <ConnectionProvider>
         <RootLayout />
       </ConnectionProvider>
+      <AppUpdateBanner />
       <Toaster />
       {USE_DEVTOOLS && <TanStackRouterDevtools position="bottom-right" />}
       {USE_DEVTOOLS && <ReactQueryDevtools buttonPosition="bottom-left" />}
@@ -142,6 +171,13 @@ function RootComponent() {
         persistence: 'localStorage+cookie',
         cross_subdomain_cookie: true,
         debug: config.environment === 'development',
+        loaded: (posthog) => {
+          try {
+            posthog.register(telemetryRuntimeContext)
+          } catch {
+            // PostHog setup must never block application startup.
+          }
+        },
       }}
     >
       {content}

--- a/apps/web/src/routes/job-detail-remove.test.tsx
+++ b/apps/web/src/routes/job-detail-remove.test.tsx
@@ -2,32 +2,26 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const {
-  routeState,
-  topBarState,
-  navigateMock,
-  removeMutateMock,
-  retryMutateMock,
-  trackEventMock,
-} = vi.hoisted(() => ({
-  routeState: {
-    params: {
-      orgSlug: 'acme',
-      connectionId: 'conn-1',
-      queueName: 'emails',
-      jobId: 'repeat:scheduler-key:123',
+const { routeState, topBarState, navigateMock, removeMutateMock, retryMutateMock, trackEventMock } =
+  vi.hoisted(() => ({
+    routeState: {
+      params: {
+        orgSlug: 'acme',
+        connectionId: 'conn-1',
+        queueName: 'emails',
+        jobId: 'repeat:scheduler-key:123',
+      },
+      search: { tab: 'data' as const },
     },
-    search: { tab: 'data' as const },
-  },
-  topBarState: { config: null as null | { actions?: React.ReactNode } },
-  navigateMock: vi.fn(),
-  removeMutateMock: vi.fn(),
-  retryMutateMock: vi.fn(),
-  trackEventMock: vi.fn(),
-}))
+    topBarState: { config: null as null | { actions?: React.ReactNode } },
+    navigateMock: vi.fn(),
+    removeMutateMock: vi.fn(),
+    retryMutateMock: vi.fn(),
+    trackEventMock: vi.fn(),
+  }))
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  Link: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
   createFileRoute: () => (options: unknown) => ({
     useParams: () => routeState.params,
     useSearch: () => routeState.search,
@@ -136,7 +130,7 @@ describe('job detail scheduled removal', () => {
     const Component = Route.options.component as () => React.ReactNode
 
     render(<Component />)
-    render(<>{topBarState.config?.actions}</>)
+    render(<div>{topBarState.config?.actions}</div>)
 
     await user.click(screen.getByRole('button', { name: 'Remove' }))
     await user.click(screen.getByRole('menuitem', { name: /Remove Job & Stop Scheduler/i }))
@@ -162,7 +156,7 @@ describe('job detail scheduled removal', () => {
     const Component = Route.options.component as () => React.ReactNode
 
     render(<Component />)
-    render(<>{topBarState.config?.actions}</>)
+    render(<div>{topBarState.config?.actions}</div>)
 
     await user.click(screen.getByRole('button', { name: 'Remove' }))
     expect(screen.getByText('Remove Job?')).toBeInTheDocument()

--- a/apps/web/src/routes/queue-detail-remove.test.tsx
+++ b/apps/web/src/routes/queue-detail-remove.test.tsx
@@ -37,7 +37,7 @@ const {
 }))
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  Link: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
   Outlet: () => null,
   createFileRoute: () => (options: unknown) => ({
     useParams: () => routeState.params,

--- a/apps/web/src/routes/queue-detail-scheduled-create.test.tsx
+++ b/apps/web/src/routes/queue-detail-scheduled-create.test.tsx
@@ -39,7 +39,7 @@ const { routeState, topBarState, scheduledJobsState, navigateMock, trackEventMoc
 )
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  Link: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
   Outlet: () => null,
   createFileRoute: () => (options: unknown) => ({
     useParams: () => routeState.params,
@@ -207,7 +207,7 @@ describe('queue detail scheduled job creation', () => {
     const Component = Route.options.component as () => React.ReactNode
 
     render(<Component />)
-    render(<>{topBarState.config?.actions}</>)
+    render(<div>{topBarState.config?.actions}</div>)
 
     await user.click(screen.getByRole('button', { name: 'Schedule Job' }))
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import viteReact from '@vitejs/plugin-react'
@@ -7,6 +8,26 @@ import tsConfigPaths from 'vite-tsconfig-paths'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+const require = createRequire(import.meta.url)
+const rootPackage = require('../../package.json') as { version?: string }
+
+function firstNonEmpty(...values: Array<string | undefined>): string {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+
+  return ''
+}
+
+const appVersion = firstNonEmpty(process.env.DURABULL_APP_VERSION, rootPackage.version) || '0.0.0'
+const appBuildId =
+  firstNonEmpty(
+    process.env.DURABULL_BUILD_ID,
+    process.env.VERCEL_GIT_COMMIT_SHA,
+    process.env.GITHUB_SHA
+  ) || appVersion
+const appBuildTime = firstNonEmpty(process.env.DURABULL_BUILD_TIME)
 
 /**
  * Pure SPA Vite Configuration
@@ -21,6 +42,11 @@ const __dirname = path.dirname(__filename)
  */
 export default defineConfig({
   envDir: path.resolve(__dirname, '../..'),
+  define: {
+    __DURABULL_APP_VERSION__: JSON.stringify(appVersion),
+    __DURABULL_BUILD_ID__: JSON.stringify(appBuildId),
+    __DURABULL_BUILD_TIME__: JSON.stringify(appBuildTime || null),
+  },
   server: {
     port: 5173,
     host: 'localhost',

--- a/packages/analytics/src/client.test.ts
+++ b/packages/analytics/src/client.test.ts
@@ -5,6 +5,7 @@ const captureMock = mock(() => {})
 const groupMock = mock(() => {})
 const identifyMock = mock(() => {})
 const initMock = mock(() => {})
+const registerMock = mock(() => {})
 const resetMock = mock(() => {})
 
 mock.module('posthog-js', () => ({
@@ -13,6 +14,7 @@ mock.module('posthog-js', () => ({
     group: groupMock,
     identify: identifyMock,
     init: initMock,
+    register: registerMock,
     reset: resetMock,
   },
 }))
@@ -48,6 +50,7 @@ describe('analytics client telemetry fanout', () => {
     groupMock.mockClear()
     identifyMock.mockClear()
     initMock.mockClear()
+    registerMock.mockClear()
     resetMock.mockClear()
 
     fetchMock = mock(async () => new Response(null, { status: 202 }))
@@ -63,6 +66,8 @@ describe('analytics client telemetry fanout', () => {
       collectionRequired: true,
       endpoint: '/api/telemetry/events',
       runtimeContext: {
+        app_build_id: 'build-123',
+        app_version: '1.4.0',
         environment: 'production',
         runtime: 'web',
       },
@@ -91,6 +96,8 @@ describe('analytics client telemetry fanout', () => {
     const durabullEvent = lastFetchBody(fetchMock)
     expect(durabullEvent.event).toBe(AnalyticsEvents.QUEUE_PAUSED)
     expect(durabullEvent.properties).toEqual({
+      app_build_id: 'build-123',
+      app_version: '1.4.0',
       environment: 'production',
       runtime: 'web',
       success: true,
@@ -98,8 +105,18 @@ describe('analytics client telemetry fanout', () => {
     expect(durabullEvent.properties).not.toHaveProperty('queue_name')
 
     expect(captureMock).toHaveBeenCalledWith(AnalyticsEvents.QUEUE_PAUSED, {
+      app_build_id: 'build-123',
+      app_version: '1.4.0',
+      environment: 'production',
       queue_name: 'billing-production',
+      runtime: 'web',
       success: true,
+    })
+    expect(registerMock).toHaveBeenCalledWith({
+      app_build_id: 'build-123',
+      app_version: '1.4.0',
+      environment: 'production',
+      runtime: 'web',
     })
   })
 
@@ -117,7 +134,11 @@ describe('analytics client telemetry fanout', () => {
     )
     expect(captureMock).toHaveBeenCalledWith('$pageview', {
       $current_url: rawUrl,
+      app_build_id: 'build-123',
+      app_version: '1.4.0',
+      environment: 'production',
       path: '/acme/c/conn-1/queues/billing/jobs/job-1',
+      runtime: 'web',
     })
   })
 
@@ -132,6 +153,8 @@ describe('analytics client telemetry fanout', () => {
     const durabullEvent = lastFetchBody(fetchMock)
     expect(durabullEvent.event).toBe(AnalyticsEvents.USER_CREATED)
     expect(durabullEvent.properties).toEqual({
+      app_build_id: 'build-123',
+      app_version: '1.4.0',
       environment: 'production',
       runtime: 'web',
     })

--- a/packages/analytics/src/client.ts
+++ b/packages/analytics/src/client.ts
@@ -44,6 +44,15 @@ let durabullTelemetryConfig: DurabullTelemetryConfig = {
 let sessionId: string | null = null
 let hasIdentifiedPosthogUser = false
 
+type AnalyticsPropertyValue = string | number | boolean | null
+
+function isAnalyticsPropertyValue(value: unknown): value is AnalyticsPropertyValue {
+  if (value === null) return true
+  if (typeof value === 'string') return true
+  if (typeof value === 'boolean') return true
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
 function getSessionId(): string {
   if (sessionId) return sessionId
 
@@ -96,6 +105,46 @@ function sendDurabullTelemetry(eventName: string, properties?: Record<string, un
   }
 }
 
+function getRuntimeContextProperties(): Record<string, AnalyticsPropertyValue> {
+  const runtimeContext = durabullTelemetryConfig.runtimeContext ?? {}
+  const properties: Record<string, AnalyticsPropertyValue> = {}
+
+  for (const [key, value] of Object.entries(runtimeContext)) {
+    if (isAnalyticsPropertyValue(value)) {
+      properties[key] = value
+    }
+  }
+
+  return properties
+}
+
+function withRuntimeContext(
+  properties?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const runtimeContext = getRuntimeContextProperties()
+  if (Object.keys(runtimeContext).length === 0) {
+    return properties
+  }
+
+  return {
+    ...runtimeContext,
+    ...(properties ?? {}),
+  }
+}
+
+function registerPosthogRuntimeContext() {
+  if (typeof window === 'undefined') return
+
+  const runtimeContext = getRuntimeContextProperties()
+  if (Object.keys(runtimeContext).length === 0) return
+
+  try {
+    posthog.register(runtimeContext)
+  } catch {
+    // Analytics setup must never block product runtime.
+  }
+}
+
 /**
  * Configure Durabull-owned anonymous telemetry.
  *
@@ -107,6 +156,7 @@ export function configureDurabullTelemetry(config: DurabullTelemetryConfig) {
     ...config,
     endpoint: config.endpoint ?? DEFAULT_TELEMETRY_ENDPOINT,
   }
+  registerPosthogRuntimeContext()
 }
 
 /**
@@ -137,6 +187,7 @@ export function initAnalytics(
     // Persist user identity across sessions
     persistence: 'localStorage+cookie',
   })
+  registerPosthogRuntimeContext()
 }
 
 /**
@@ -227,7 +278,11 @@ export function trackEvent(eventName: string, properties?: Record<string, unknow
 
   sendDurabullTelemetry(eventName, properties)
 
-  posthog.capture(eventName, properties)
+  try {
+    posthog.capture(eventName, withRuntimeContext(properties))
+  } catch {
+    // Analytics must never affect product behavior.
+  }
 }
 
 /**
@@ -245,7 +300,11 @@ export function trackPageView(path: string, properties?: Record<string, unknown>
 
   sendDurabullTelemetry(PAGEVIEW_EVENT, pageViewProperties)
 
-  posthog.capture(PAGEVIEW_EVENT, pageViewProperties)
+  try {
+    posthog.capture(PAGEVIEW_EVENT, withRuntimeContext(pageViewProperties))
+  } catch {
+    // Analytics must never affect product behavior.
+  }
 }
 
 /**

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -105,6 +105,9 @@ export const AnalyticsEvents = {
 
   // Settings Events
   SETTINGS_VIEWED: 'settings_viewed',
+
+  // App Lifecycle Events
+  APP_UPDATE_CLICKED: 'app_update_clicked',
 } as const
 
 /**
@@ -177,8 +180,18 @@ export const AnalyticsProperties = {
   SCHEDULER_ID: 'scheduler_id',
 
   // Metadata
+  API_BUILD_ID: 'api_build_id',
+  API_VERSION: 'api_version',
+  APP_BUILD_ID: 'app_build_id',
+  APP_VERSION: 'app_version',
+  CLIENT_BUILD_ID: 'client_build_id',
+  CLIENT_VERSION: 'client_version',
   PAGE: 'page',
+  RELEASE_CHANNEL: 'release_channel',
+  SERVER_BUILD_ID: 'server_build_id',
+  SERVER_VERSION: 'server_version',
   TAB: 'tab',
+  UPDATE_REASON: 'update_reason',
   VISIBLE: 'visible',
 } as const
 

--- a/packages/analytics/src/sanitizer.test.ts
+++ b/packages/analytics/src/sanitizer.test.ts
@@ -51,21 +51,41 @@ describe('telemetry sanitizer', () => {
   it('keeps allowlisted booleans, enums, and numeric aggregates', () => {
     const result = sanitizeTelemetryEvent(AnalyticsEvents.QUEUE_CLEANED, {
       action: 'clean',
+      api_build_id: 'server-build-123',
+      api_version: '1.4.0',
+      app_build_id: 'client-build-123',
+      app_version: '1.3.0',
+      client_build_id: 'client-build-123',
+      client_version: '1.3.0',
       connection_environment: 'production',
       duration_bucket: '1s-5s',
       job_count: 42,
       queue_status: 'completed',
+      release_channel: 'stable',
+      server_build_id: 'server-build-123',
+      server_version: '1.4.0',
       success: true,
+      update_reason: 'build_mismatch',
       visible: false,
     })
 
     expect(result.properties).toEqual({
       action: 'clean',
+      api_build_id: 'server-build-123',
+      api_version: '1.4.0',
+      app_build_id: 'client-build-123',
+      app_version: '1.3.0',
+      client_build_id: 'client-build-123',
+      client_version: '1.3.0',
       connection_environment: 'production',
       duration_bucket: '1s-5s',
       job_count: 42,
       queue_status: 'completed',
+      release_channel: 'stable',
+      server_build_id: 'server-build-123',
+      server_version: '1.4.0',
       success: true,
+      update_reason: 'build_mismatch',
       visible: false,
     })
   })

--- a/packages/analytics/src/sanitizer.ts
+++ b/packages/analytics/src/sanitizer.ts
@@ -59,9 +59,14 @@ const FORBIDDEN_PROPERTY_KEYS = new Set([
 
 const ALLOWED_PROPERTY_KEYS = new Set([
   'action',
+  'api_build_id',
+  'api_version',
+  'app_build_id',
   'app_version',
   'auth_method',
   'authless',
+  'client_build_id',
+  'client_version',
   'connection_environment',
   'dialog_type',
   'duration_bucket',
@@ -85,11 +90,15 @@ const ALLOWED_PROPERTY_KEYS = new Set([
   'provider',
   'queue_count_bucket',
   'queue_status',
+  'release_channel',
   'runtime',
+  'server_build_id',
+  'server_version',
   'stateless',
   'success',
   'tab',
   'theme',
+  'update_reason',
   'visible',
 ])
 

--- a/packages/dal/src/repositories/alert-event.ts
+++ b/packages/dal/src/repositories/alert-event.ts
@@ -1,5 +1,5 @@
 import { uuidv7 } from '@durabull/utils/uuid'
-import { and, desc, eq, lt, sql } from 'drizzle-orm'
+import { and, desc, eq, sql } from 'drizzle-orm'
 import { getDb } from '../db/client'
 import { alertEvent, type AlertEventStatus } from '../db/schemas/alert-event/schema'
 import type { AlertEvent, NewAlertEvent } from '../db/schemas/alert-event/types'

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
+    },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "c77b86b4332919499608f9af1880074e1fec65a59b95c70c27a9f39cd137865e"
+    }
+  }
+}

--- a/tooling/docker/Dockerfile
+++ b/tooling/docker/Dockerfile
@@ -34,6 +34,14 @@ RUN bun install --omit=dev --no-save --ignore-scripts
 # Build: Build the web app
 # -----------------------------------------------------------------------------
 FROM deps AS build
+ARG DURABULL_APP_VERSION
+ARG DURABULL_BUILD_ID
+ARG DURABULL_BUILD_TIME
+ARG DURABULL_RELEASE_CHANNEL=stable
+ENV DURABULL_APP_VERSION=$DURABULL_APP_VERSION
+ENV DURABULL_BUILD_ID=$DURABULL_BUILD_ID
+ENV DURABULL_BUILD_TIME=$DURABULL_BUILD_TIME
+ENV DURABULL_RELEASE_CHANNEL=$DURABULL_RELEASE_CHANNEL
 COPY --from=prune /app/out/full/ .
 # Run vite build directly (skip tsc typecheck - it runs in CI separately)
 RUN cd apps/web && bun x vite build
@@ -43,8 +51,16 @@ RUN cd apps/web && bun x vite build
 # -----------------------------------------------------------------------------
 FROM base AS release
 
+ARG DURABULL_APP_VERSION
+ARG DURABULL_BUILD_ID
+ARG DURABULL_BUILD_TIME
+ARG DURABULL_RELEASE_CHANNEL=stable
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV DURABULL_APP_VERSION=$DURABULL_APP_VERSION
+ENV DURABULL_BUILD_ID=$DURABULL_BUILD_ID
+ENV DURABULL_BUILD_TIME=$DURABULL_BUILD_TIME
+ENV DURABULL_RELEASE_CHANNEL=$DURABULL_RELEASE_CHANNEL
 
 # Production deps only (smaller image)
 COPY --from=prod-deps /app/node_modules ./node_modules

--- a/tooling/scripts/docker-image-smoke.sh
+++ b/tooling/scripts/docker-image-smoke.sh
@@ -72,6 +72,14 @@ wait_for_url "${APP_BASE_URL}/api/health"
 assert_json_contains "${APP_BASE_URL}/api/health" '"status":"ok"'
 assert_json_contains "${APP_BASE_URL}/api/app/config" '"authless":true'
 assert_json_contains "${APP_BASE_URL}/api/app/config" '"persistence":"pglite"'
+if [[ -n "${DURABULL_EXPECTED_BUILD_ID:-}" ]]; then
+  assert_json_contains "${APP_BASE_URL}/api/app/version" "\"buildId\":\"${DURABULL_EXPECTED_BUILD_ID}\""
+fi
+if [[ -n "${DURABULL_EXPECTED_RELEASE_CHANNEL:-}" ]]; then
+  assert_json_contains \
+    "${APP_BASE_URL}/api/app/version" \
+    "\"releaseChannel\":\"${DURABULL_EXPECTED_RELEASE_CHANNEL}\""
+fi
 assert_json_contains "${APP_BASE_URL}/api/auth/get-session" '"id":"authless-user"'
 
 echo "Docker image smoke test passed."

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,14 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": [
+        "DURABULL_APP_VERSION",
+        "DURABULL_BUILD_ID",
+        "DURABULL_BUILD_TIME",
+        "DURABULL_RELEASE_CHANNEL",
+        "GITHUB_SHA",
+        "VERCEL_GIT_COMMIT_SHA"
+      ],
       "outputs": ["dist/**", ".output/**", ".next/**", "out/**", "release/**"],
       "passThroughEnv": [
         "DATABASE_URL",
@@ -11,7 +19,9 @@
         "MARKETPLACE_*",
         "RESEND_API_KEY",
         "DURABULL_*",
+        "GITHUB_SHA",
         "VITE_PUBLIC_APP_URL",
+        "VERCEL_GIT_COMMIT_SHA",
         "NEXT_PUBLIC_WEB_APP_URL",
         "NEXT_PUBLIC_POSTHOG_KEY",
         "POSTHOG_KEY",
@@ -32,7 +42,9 @@
         "GITHUB_CLIENT_ID",
         "GITHUB_CLIENT_SECRET",
         "DURABULL_*",
+        "GITHUB_SHA",
         "VITE_PUBLIC_APP_URL",
+        "VERCEL_GIT_COMMIT_SHA",
         "NEXT_PUBLIC_WEB_APP_URL",
         "NEXT_PUBLIC_POSTHOG_KEY",
         "POSTHOG_KEY",
@@ -41,6 +53,14 @@
     },
     "dist": {
       "dependsOn": ["build"],
+      "env": [
+        "DURABULL_APP_VERSION",
+        "DURABULL_BUILD_ID",
+        "DURABULL_BUILD_TIME",
+        "DURABULL_RELEASE_CHANNEL",
+        "GITHUB_SHA",
+        "VERCEL_GIT_COMMIT_SHA"
+      ],
       "outputs": ["release/**"],
       "passThroughEnv": [
         "DATABASE_URL",
@@ -49,7 +69,9 @@
         "MARKETPLACE_*",
         "RESEND_API_KEY",
         "DURABULL_*",
+        "GITHUB_SHA",
         "VITE_PUBLIC_APP_URL",
+        "VERCEL_GIT_COMMIT_SHA",
         "NEXT_PUBLIC_WEB_APP_URL",
         "NEXT_PUBLIC_POSTHOG_KEY",
         "POSTHOG_KEY",
@@ -58,6 +80,14 @@
     },
     "dist:dir": {
       "dependsOn": ["build"],
+      "env": [
+        "DURABULL_APP_VERSION",
+        "DURABULL_BUILD_ID",
+        "DURABULL_BUILD_TIME",
+        "DURABULL_RELEASE_CHANNEL",
+        "GITHUB_SHA",
+        "VERCEL_GIT_COMMIT_SHA"
+      ],
       "outputs": ["release/**"],
       "passThroughEnv": [
         "DATABASE_URL",
@@ -66,7 +96,9 @@
         "MARKETPLACE_*",
         "RESEND_API_KEY",
         "DURABULL_*",
+        "GITHUB_SHA",
         "VITE_PUBLIC_APP_URL",
+        "VERCEL_GIT_COMMIT_SHA",
         "NEXT_PUBLIC_WEB_APP_URL",
         "NEXT_PUBLIC_POSTHOG_KEY",
         "POSTHOG_KEY",
@@ -102,7 +134,9 @@
         "CI",
         "DURABULL_*",
         "APP_BASE_URL",
+        "GITHUB_SHA",
         "VITE_PUBLIC_APP_URL",
+        "VERCEL_GIT_COMMIT_SHA",
         "NEXT_PUBLIC_WEB_APP_URL",
         "NEXT_PUBLIC_POSTHOG_KEY",
         "POSTHOG_KEY",


### PR DESCRIPTION
## Summary

- Adds a no-store API version endpoint with conservative version/build comparison rules.
- Embeds release metadata into API and web builds and wires Turbo env cache keys for it.
- Adds the five-minute client version check plus a persistent update banner that reloads to the latest build.
- Adds update-click analytics and runtime version metadata for Durabull telemetry/PostHog.
- Handles web and Electron runtime metadata and keeps updater reloads independent from analytics failures.
- Threads Docker release metadata explicitly so tagged image builds embed `DURABULL_APP_VERSION` as the tag version and `DURABULL_BUILD_ID` as the GitHub commit SHA.
- Threads desktop release metadata explicitly for tag-triggered native builds.
- Extends the Docker smoke test to assert expected build id and release channel when release metadata is provided.
- Stages the previously untracked skill/config files requested for this work.

Closes #59

## Validation

- `bun --filter @durabull/api test` - 73 passed
- `bun --filter @durabull/web test:unit` - 69 passed
- `bun --filter @durabull/analytics test` - 10 passed
- `bun --filter @durabull/desktop test` - 5 passed
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bash -n tooling/scripts/docker-image-smoke.sh`
- Synthetic metadata build: `DURABULL_APP_VERSION=9.9.9 DURABULL_BUILD_ID=triple-check-sha DURABULL_BUILD_TIME=2026-05-01T22:00:00Z ...` and verified generated API/web artifacts included those values.
- `git diff --check`
- `git diff --cached --check`

## Notes

- `bun run build` emits the existing Vite chunk-size warning; the build completed successfully.
- Local Docker build with explicit metadata args reached the Dockerfile dependency install layers, but was canceled after `bun install` stalled without output for several minutes; not counted as a passing check.
