### PR TITLE
[codex] Relax general API rate limit

### DIFF
--- a/apps/api/src/middleware/rate-limit.test.ts
+++ b/apps/api/src/middleware/rate-limit.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { env } from '@durabull/env'
+import { Hono } from 'hono'
+import { apiRateLimiter } from './rate-limit'
+
+const mutableEnv = env as {
+  CI?: boolean
+  DISABLE_RATE_LIMIT?: boolean
+  NODE_ENV?: 'development' | 'test' | 'production'
+}
+
+const originalCi = mutableEnv.CI
+const originalDisableRateLimit = mutableEnv.DISABLE_RATE_LIMIT
+const originalNodeEnv = mutableEnv.NODE_ENV
+
+describe('apiRateLimiter', () => {
+  beforeEach(() => {
+    mutableEnv.CI = false
+    mutableEnv.DISABLE_RATE_LIMIT = false
+    mutableEnv.NODE_ENV = 'production'
+  })
+
+  afterEach(() => {
+    mutableEnv.CI = originalCi
+    mutableEnv.DISABLE_RATE_LIMIT = originalDisableRateLimit
+    mutableEnv.NODE_ENV = originalNodeEnv
+  })
+
+  it('allows a normal multi-tab app startup burst from one client', async () => {
+    const app = new Hono()
+    app.use('/api/*', apiRateLimiter)
+    app.get('/api/ping', (c) => c.json({ ok: true }))
+
+    const responses = await Promise.all(
+      Array.from({ length: 150 }, () =>
+        app.request('/api/ping', {
+          headers: { 'x-forwarded-for': '203.0.113.10' },
+        })
+      )
+    )
+
+    expect(responses.every((response) => response.status === 200)).toBe(true)
+    expect(responses[0]?.headers.get('X-RateLimit-Limit')).toBe('600')
+  })
+})

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -14,6 +14,9 @@ interface RateLimitEntry {
 // In-memory store for rate limiting
 const rateLimitStore = new Map<string, RateLimitEntry>()
 
+const GENERAL_API_RATE_LIMIT_WINDOW_MS = 60 * 1000
+const GENERAL_API_RATE_LIMIT_MAX_REQUESTS = 600
+
 // Clean up expired entries periodically
 setInterval(
   () => {
@@ -195,8 +198,8 @@ export const authRateLimiter = rateLimiter({
  * Prevents abuse while allowing normal usage.
  */
 export const apiRateLimiter = rateLimiter({
-  windowMs: 10 * 1000, // 10 seconds
-  limit: 50, // 50 requests per 10 seconds
+  windowMs: GENERAL_API_RATE_LIMIT_WINDOW_MS,
+  limit: GENERAL_API_RATE_LIMIT_MAX_REQUESTS,
   keyPrefix: 'rl:api',
   // Custom handler to distinguish from auth errors
   onRateLimit: (c) =>


### PR DESCRIPTION
## Summary
- increase the general API rate limit from 50 requests per 10 seconds to 600 requests per minute
- keep stricter auth and connection-test limiters unchanged
- add a regression test for a normal multi-tab startup burst behind one forwarded IP

## Root cause
Normal dashboard startup fans out across many API calls, and multiple tabs share the same per-client-IP limiter bucket. The previous 50 requests per 10 seconds bucket could be exhausted by ordinary refresh or multi-tab usage.

## Validation
- `bun test apps/api/src/middleware/rate-limit.test.ts`
- `bun run --filter @durabull/api typecheck`
- `bun run --filter @durabull/api lint`

Closes #66