### PR TITLE
[codex] Show app version in settings

### DIFF
--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listAccounts: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: unknown) => ({
+    options,
+  }),
+}))
+
+vi.mock('@durabull/analytics', () => ({
+  AnalyticsEvents: {
+    DIALOG_CLOSED: 'DIALOG_CLOSED',
+    DIALOG_OPENED: 'DIALOG_OPENED',
+    USER_ACCOUNT_LINKED: 'USER_ACCOUNT_LINKED',
+    USER_ACCOUNT_UNLINKED: 'USER_ACCOUNT_UNLINKED',
+  },
+  DialogType: {
+    UNLINK_ACCOUNT: 'UNLINK_ACCOUNT',
+  },
+  trackEvent: mocks.trackEvent,
+}))
+
+vi.mock('@/components/app-top-bar', () => ({
+  useAppTopBar: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-app-config', () => ({
+  useAppConfig: () => ({
+    config: {
+      telemetry: {
+        collectionRequired: true,
+        disclosureUrl: 'https://durabull.io/privacy',
+      },
+    },
+  }),
+}))
+
+vi.mock('@/hooks/use-auth', () => ({
+  linkSocial: vi.fn(),
+  listAccounts: mocks.listAccounts,
+  unlinkAccount: vi.fn(),
+  useAuth: () => ({
+    user: {
+      id: 'user-1',
+      email: 'test@example.com',
+    },
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/lib/app-version', () => ({
+  APP_BUILD_INFO: {
+    version: '1.2.3-test',
+    buildId: 'test-build',
+    buildTime: null,
+  },
+}))
+
+import { Route } from '@/routes/settings'
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    mocks.listAccounts.mockReset()
+    mocks.listAccounts.mockResolvedValue({ data: [] })
+    mocks.trackEvent.mockReset()
+  })
+
+  it('shows the current app version quietly on the settings page', () => {
+    const Component = Route.options.component as () => React.ReactNode
+
+    render(<Component />)
+
+    expect(screen.getByText('Durabull v1.2.3-test')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -30,6 +30,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAppConfig } from '@/hooks/use-app-config'
 import { linkSocial, listAccounts, unlinkAccount, useAuth } from '@/hooks/use-auth'
+import { APP_BUILD_INFO } from '@/lib/app-version'
 import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/settings')({
@@ -334,6 +335,10 @@ function SettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      <p className="px-1 text-right text-[11px] text-muted-foreground/70">
+        Durabull v{APP_BUILD_INFO.version}
+      </p>
 
       {/* Unlink Confirmation Dialog */}
       <Dialog


### PR DESCRIPTION
## Summary

- Show the current Durabull app version at the bottom of the settings page using existing build metadata.
- Add a focused settings page UI test that verifies the version label renders.

## Impact

Users can quickly confirm which app version they are running without the version competing with primary settings content.

## Validation

- `bun run --filter @durabull/web test:unit -- src/routes/settings.test.tsx`
- `bun run --filter @durabull/web typecheck`
- `bun run --filter @durabull/web lint`
