### PR TITLE
[codex] Add Linear alert notification channel

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "stripe": {
+      "enabled": true
+    }
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,7 @@ BETTER_AUTH_SECRET=replace-me-with-a-long-random-string
 # LINEAR_OAUTH_CLIENT_ID=
 # LINEAR_OAUTH_CLIENT_SECRET=
 # LINEAR_OAUTH_REDIRECT_URI=
+# LINEAR_OAUTH_ACTOR=user
 
 # -----------------------------------------------------------------------------
 # Alerting (optional)

--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,7 @@ BETTER_AUTH_SECRET=replace-me-with-a-long-random-string
 # LINEAR_OAUTH_CLIENT_ID=
 # LINEAR_OAUTH_CLIENT_SECRET=
 # LINEAR_OAUTH_REDIRECT_URI=
+# Optional: use app-actor OAuth mode by setting this to app.
 # LINEAR_OAUTH_ACTOR=user
 
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ REDIS_URL=redis://localhost:56379
 # Required when Redis connection URLs are persisted in the database.
 # Generate with: openssl rand -hex 32
 DURABULL_REDIS_URL_ENCRYPTION_KEY=replace-with-64-char-hex-key
+# Required when secrets are persisted in the database.
+# Generate with: openssl rand -hex 32
+DURABULL_SECRET_ENCRYPTION_KEY=replace-with-64-char-hex-key
 
 # Stateless Persistence Mode:
 # - Leave DATABASE_URL unset to use local PGlite persistence at ./data/pglite
@@ -77,6 +80,13 @@ BETTER_AUTH_SECRET=replace-me-with-a-long-random-string
 # Email (optional)
 # -----------------------------------------------------------------------------
 # RESEND_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Linear
+# -----------------------------------------------------------------------------
+# LINEAR_OAUTH_CLIENT_ID=
+# LINEAR_OAUTH_CLIENT_SECRET=
+# LINEAR_OAUTH_REDIRECT_URI=
 
 # -----------------------------------------------------------------------------
 # Alerting (optional)

--- a/apps/api/src/lib/alert-evaluator.ts
+++ b/apps/api/src/lib/alert-evaluator.ts
@@ -223,7 +223,12 @@ export function evaluateRule(
       return evaluateQueueStalled(parsed.data, snapshot, cursor)
     }
     case 'job_failed':
-      return { triggered: false, summary: '', context: {} }
+      return {
+        triggered: false,
+        summary:
+          'job_failed rules are evaluated by the failed-job scan and are not supported by this live test yet.',
+        context: { unsupportedLiveTest: true },
+      }
     default:
       return { triggered: false, summary: `Unknown rule type: ${rule.type}`, context: {} }
   }

--- a/apps/api/src/lib/alert-evaluator.ts
+++ b/apps/api/src/lib/alert-evaluator.ts
@@ -77,9 +77,7 @@ export function evaluateFailureThreshold(
   // Only count the delta if the cursor falls within the configured window.
   // If the monitor was down or the last check is older than the window, skip
   // to avoid counting a large backlog as a sudden spike.
-  const minutesSinceLastCheck = cursor
-    ? (Date.now() - cursor.lastCheckedAt.getTime()) / 60_000
-    : 0
+  const minutesSinceLastCheck = cursor ? (Date.now() - cursor.lastCheckedAt.getTime()) / 60_000 : 0
 
   // Allow a 10% tolerance beyond the window to account for polling jitter and clock drift
   const windowWithTolerance = config.windowMinutes * 1.1
@@ -224,6 +222,8 @@ export function evaluateRule(
       }
       return evaluateQueueStalled(parsed.data, snapshot, cursor)
     }
+    case 'job_failed':
+      return { triggered: false, summary: '', context: {} }
     default:
       return { triggered: false, summary: `Unknown rule type: ${rule.type}`, context: {} }
   }

--- a/apps/api/src/lib/alert-monitor.test.ts
+++ b/apps/api/src/lib/alert-monitor.test.ts
@@ -496,4 +496,52 @@ describe('alert monitor', () => {
     expect(events).toHaveLength(1)
     expect(events[0]?.queueName).toBe('email-send')
   })
+
+  it('creates at most one job_failed event per failed job id', async () => {
+    const dispatchAlertNotificationMock = mock(async () => {})
+    mock.module('./alert-notifier', () => ({
+      dispatchAlertNotification: dispatchAlertNotificationMock,
+      processAlertDeliveries: mock(async () => {}),
+    }))
+
+    const { __alertMonitorTestUtils } = await loadMonitorModule()
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: testConnectionId,
+      queueName: 'email-send',
+      name: 'Failed job issues',
+      type: 'job_failed',
+      config: { maxIssuesPerPoll: 100 },
+      cooldownMinutes: 30,
+      notificationChannels: [{ type: 'linear', target: 'org-default', teamId: 'team-1' }],
+    })
+
+    const failedJob = {
+      id: 'job-1',
+      name: 'send-email',
+      failedReason: 'SMTP rejected recipient',
+      attemptsMade: 2,
+      finishedOn: Date.now(),
+      opts: { attempts: 3 },
+    }
+    const queue = {
+      getJobs: mock(async () => [failedJob]),
+    }
+    const connection = createConnection()
+
+    await __alertMonitorTestUtils.scanFailedJobsAndMaybeAlert(rule, queue, connection, 'email-send')
+    await __alertMonitorTestUtils.scanFailedJobsAndMaybeAlert(rule, queue, connection, 'email-send')
+
+    const events = await listRuleEvents(rule.id)
+    expect(events).toHaveLength(1)
+    expect(events[0]?.dedupeKey).toBe(`job:${testConnectionId}:email-send:job-1`)
+    expect(events[0]?.context).toMatchObject({
+      jobId: 'job-1',
+      jobName: 'send-email',
+      failedReason: 'SMTP rejected recipient',
+      attemptsMade: 2,
+      attempts: 3,
+    })
+    expect(dispatchAlertNotificationMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/api/src/lib/alert-monitor.ts
+++ b/apps/api/src/lib/alert-monitor.ts
@@ -1,4 +1,5 @@
 import {
+  alertDeliveryRepository,
   alertCheckCursorRepository,
   alertEventRepository,
   alertRuleRepository,
@@ -8,8 +9,13 @@ import {
   type RedisConnection,
 } from '@durabull/dal'
 import { env } from '@durabull/env'
+import type { JobType } from 'bullmq'
 import { evaluateRule, type CursorState, type QueueSnapshot } from './alert-evaluator'
-import { dispatchAlertNotification, type NotificationChannel } from './alert-notifier'
+import {
+  dispatchAlertNotification,
+  processAlertDeliveries,
+  type NotificationChannel,
+} from './alert-notifier'
 import { getQueue } from './redis'
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000
@@ -20,6 +26,8 @@ const MAX_CONCURRENT_QUEUES = 5
 const METRICS_WINDOW_MINUTES = 60
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000
 const EVENT_RETENTION_DAYS = 90
+const DEFAULT_JOB_FAILED_MAX_ISSUES_PER_POLL = 100
+const HARD_CAP_JOB_FAILED_MAX_ISSUES_PER_POLL = 500
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
 let cleanupTimer: ReturnType<typeof setInterval> | null = null
@@ -244,7 +252,11 @@ async function processConnection(connectionId: string, rules: AlertRule[]): Prom
 
       const applicableRules = rules.filter((rule) => isRuleApplicableToQueue(rule, queueName))
       for (const rule of applicableRules) {
-        await evaluateAndMaybeAlert(rule, snapshot, cursor, connection)
+        if (rule.type === 'job_failed') {
+          await scanFailedJobsAndMaybeAlert(rule, queue, connection, queueName)
+        } else {
+          await evaluateAndMaybeAlert(rule, snapshot, cursor, connection)
+        }
       }
 
       await alertCheckCursorRepository.upsert({
@@ -315,9 +327,118 @@ async function evaluateAndMaybeAlert(
 
   try {
     await dispatchAlertNotification(event, channels, connection, rule.name)
-    await alertEventRepository.markNotificationSent(event.id)
+    await markLegacyNotificationSentIfComplete(event.id)
   } catch (error) {
     console.error('[alert-monitor] Notification dispatch failed:', error)
+  }
+}
+
+async function scanFailedJobsAndMaybeAlert(
+  rule: AlertRule,
+  queue: {
+    getJobs: (
+      types?: JobType | JobType[],
+      start?: number,
+      end?: number,
+      asc?: boolean
+    ) => Promise<unknown[]>
+  },
+  connection: RedisConnection,
+  queueName: string
+): Promise<void> {
+  const config = (rule.config ?? {}) as Record<string, unknown>
+  const requestedMax =
+    typeof config.maxIssuesPerPoll === 'number'
+      ? Math.floor(config.maxIssuesPerPoll)
+      : DEFAULT_JOB_FAILED_MAX_ISSUES_PER_POLL
+  const maxIssuesPerPoll = Math.min(
+    HARD_CAP_JOB_FAILED_MAX_ISSUES_PER_POLL,
+    Math.max(1, requestedMax)
+  )
+
+  const jobs = await queue.getJobs(['failed'], 0, maxIssuesPerPoll - 1, false)
+  for (const rawJob of jobs) {
+    const job = normalizeFailedJob(rawJob)
+    if (!job.id) continue
+
+    const dedupeKey = `job:${connection.id}:${queueName}:${job.id}`
+    const { event, created } = await alertEventRepository.createOrGetByDedupeKey({
+      alertRuleId: rule.id,
+      organizationId: rule.organizationId,
+      connectionId: rule.connectionId,
+      queueName,
+      type: rule.type,
+      status: 'firing',
+      summary: `Job ${job.id} failed in ${queueName}${job.failedReason ? `: ${job.failedReason}` : ''}`,
+      context: {
+        jobId: job.id,
+        jobName: job.name,
+        failedReason: job.failedReason,
+        attemptsMade: job.attemptsMade,
+        attempts: job.attempts,
+        failedAt: job.failedAt,
+      },
+      firedAt: job.failedAt ? new Date(job.failedAt) : new Date(),
+      dedupeKey,
+    })
+
+    if (!created) {
+      await processAlertDeliveries(event, connection, rule.name)
+      await markLegacyNotificationSentIfComplete(event.id)
+      continue
+    }
+
+    console.log(`[alert-monitor] Job failed alert fired: ${event.summary}`)
+
+    const channels = (rule.notificationChannels ?? []) as NotificationChannel[]
+    if (channels.length === 0) continue
+
+    try {
+      await dispatchAlertNotification(event, channels, connection, rule.name)
+      await markLegacyNotificationSentIfComplete(event.id)
+    } catch (error) {
+      console.error('[alert-monitor] Job failed notification dispatch failed:', error)
+    }
+  }
+}
+
+function normalizeFailedJob(rawJob: unknown): {
+  id: string | null
+  name: string | null
+  failedReason: string | null
+  attemptsMade: number | null
+  attempts: number | null
+  failedAt: string | null
+} {
+  const source =
+    typeof rawJob === 'object' && rawJob !== null ? (rawJob as Record<string, unknown>) : {}
+  const opts =
+    typeof source.opts === 'object' && source.opts !== null
+      ? (source.opts as Record<string, unknown>)
+      : {}
+  const failedAtMs =
+    typeof source.finishedOn === 'number'
+      ? source.finishedOn
+      : typeof source.processedOn === 'number'
+        ? source.processedOn
+        : null
+
+  return {
+    id: typeof source.id === 'string' || typeof source.id === 'number' ? String(source.id) : null,
+    name: typeof source.name === 'string' ? source.name : null,
+    failedReason:
+      typeof source.failedReason === 'string' ? source.failedReason.slice(0, 500) : null,
+    attemptsMade: typeof source.attemptsMade === 'number' ? source.attemptsMade : null,
+    attempts: typeof opts.attempts === 'number' ? opts.attempts : null,
+    failedAt: failedAtMs ? new Date(failedAtMs).toISOString() : null,
+  }
+}
+
+async function markLegacyNotificationSentIfComplete(eventId: string): Promise<void> {
+  const counts = await alertDeliveryRepository.countByStatuses(eventId)
+  const total = counts.pending + counts.claimed + counts.delivered + counts.failed
+  if (total === 0 || counts.delivered === total) {
+    await alertEventRepository.markNotificationSent(eventId)
   }
 }
 
@@ -355,6 +476,8 @@ export const __alertMonitorTestUtils = {
   getUniqueQueueNames,
   isRuleApplicableToQueue,
   evaluateAndMaybeAlert,
+  scanFailedJobsAndMaybeAlert,
+  normalizeFailedJob,
   processConnection,
   processWithConcurrency,
 }

--- a/apps/api/src/lib/alert-notifier.test.ts
+++ b/apps/api/src/lib/alert-notifier.test.ts
@@ -16,6 +16,23 @@ describe('buildAlertAppUrls', () => {
     expect(urls.muteUrl).toBe('https://app.durabull.io/acme-inc/c/conn_123/alerts?ruleId=rule_456')
   })
 
+  it('builds job-specific urls when a job id is supplied', () => {
+    const urls = buildAlertAppUrls({
+      appBaseUrl: 'https://app.durabull.io/',
+      organizationSlug: 'acme-inc',
+      connectionId: 'conn_123',
+      queueName: 'email-send',
+      alertRuleId: 'rule_456',
+      jobId: 'job_789',
+    })
+
+    expect(urls.dashboardUrl).toBe('https://app.durabull.io/acme-inc/c/conn_123/queues/email-send')
+    expect(urls.jobUrl).toBe(
+      'https://app.durabull.io/acme-inc/c/conn_123/queues/email-send/jobs/job_789'
+    )
+    expect(urls.jobUrl).not.toBe(urls.dashboardUrl)
+  })
+
   it('falls back to the app root if the organization slug is unavailable', () => {
     const urls = buildAlertAppUrls({
       appBaseUrl: 'https://app.durabull.io',

--- a/apps/api/src/lib/alert-notifier.test.ts
+++ b/apps/api/src/lib/alert-notifier.test.ts
@@ -12,6 +12,7 @@ describe('buildAlertAppUrls', () => {
     })
 
     expect(urls.dashboardUrl).toBe('https://app.durabull.io/acme-inc/c/conn_123/queues/email-send')
+    expect(urls.jobUrl).toBe('https://app.durabull.io/acme-inc/c/conn_123/queues/email-send')
     expect(urls.muteUrl).toBe('https://app.durabull.io/acme-inc/c/conn_123/alerts?ruleId=rule_456')
   })
 
@@ -26,6 +27,7 @@ describe('buildAlertAppUrls', () => {
 
     expect(urls).toEqual({
       dashboardUrl: 'https://app.durabull.io',
+      jobUrl: 'https://app.durabull.io',
       muteUrl: 'https://app.durabull.io',
     })
   })
@@ -40,6 +42,9 @@ describe('buildAlertAppUrls', () => {
     })
 
     expect(urls.dashboardUrl).toBe(
+      'https://app.durabull.io/acme%20ops/c/conn%2F123/queues/email%2Fsend%20jobs'
+    )
+    expect(urls.jobUrl).toBe(
       'https://app.durabull.io/acme%20ops/c/conn%2F123/queues/email%2Fsend%20jobs'
     )
     expect(urls.muteUrl).toBe(

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -1,18 +1,25 @@
 import {
+  type AlertDelivery,
+  type AlertEvent,
   alertDeliveryRepository,
   eq,
   getDb,
   linearIntegrationRepository,
   linearJobIssueRepository,
   organization,
-  type AlertDelivery,
-  type AlertEvent,
   type RedisConnection,
 } from '@durabull/dal'
 import { isEmailConfigured } from '@durabull/email'
 import { env } from '@durabull/env'
 import { createLinearIssue, LinearApiError } from './linear-client'
 import { getValidLinearAccessToken } from './linear-oauth'
+
+class NonRetryableDeliveryError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NonRetryableDeliveryError'
+  }
+}
 
 export type NotificationChannel =
   | {
@@ -63,7 +70,7 @@ export async function processAlertDeliveries(
       switch (delivery.channelType) {
         case 'email':
           await sendAlertEmail(delivery.target, event, connection, ruleName, organizationSlug)
-          await alertDeliveryRepository.markDelivered(delivery.id)
+          await alertDeliveryRepository.markDelivered(delivery.id, {}, delivery.claimedAt)
           break
         case 'linear':
           await sendLinearAlert(delivery, event, connection, ruleName, organizationSlug)
@@ -72,11 +79,15 @@ export async function processAlertDeliveries(
           await alertDeliveryRepository.markFailed(delivery.id, {
             error: `Unknown channel type: ${delivery.channelType}`,
             retryable: false,
+            expectedClaimedAt: delivery.claimedAt,
           })
       }
     } catch (error) {
       const retry = classifyDeliveryFailure(error, delivery.attemptCount + 1)
-      await alertDeliveryRepository.markFailed(delivery.id, retry)
+      await alertDeliveryRepository.markFailed(delivery.id, {
+        ...retry,
+        expectedClaimedAt: delivery.claimedAt,
+      })
     }
   }
 }
@@ -102,8 +113,9 @@ async function sendAlertEmail(
   organizationSlug: string | null
 ): Promise<void> {
   if (!isEmailConfigured()) {
-    console.warn('[alert-notifier] RESEND_API_KEY not configured, skipping email')
-    return
+    throw new NonRetryableDeliveryError(
+      'Email delivery is not configured because RESEND_API_KEY is missing.'
+    )
   }
 
   const { sendAlertNotificationEmail } = await import('@durabull/email')
@@ -162,8 +174,26 @@ async function sendLinearAlert(
     jobId: jobContext.jobId,
   })
 
+  const existingIssue = jobContext.jobId
+    ? await linearJobIssueRepository.findByJob({
+        organizationId: event.organizationId,
+        connectionId: event.connectionId,
+        queueName: event.queueName,
+        jobId: jobContext.jobId,
+      })
+    : null
+
+  if (existingIssue) {
+    await markLinearDeliveryDelivered(delivery, {
+      id: existingIssue.linearIssueId,
+      identifier: existingIssue.linearIssueIdentifier,
+      url: existingIssue.linearIssueUrl,
+    })
+    return
+  }
+
   const accessToken = await getValidLinearAccessToken(integration)
-  const issue = await createLinearIssue(accessToken, {
+  const issue = await createLinearIssueOnce(accessToken, {
     teamId,
     title: buildLinearIssueTitle(event, connection, ruleName, jobContext.jobName),
     description: buildLinearIssueDescription({
@@ -180,26 +210,81 @@ async function sendLinearAlert(
     priority: channel.priority ?? integration.defaultPriority,
   })
 
-  await alertDeliveryRepository.markDelivered(delivery.id, {
-    externalId: issue.id,
-    externalIdentifier: issue.identifier,
-    externalUrl: issue.url,
-    providerMetadata: {
-      ...((delivery.providerMetadata ?? {}) as Record<string, unknown>),
-      issue,
-    },
-  })
+  try {
+    const deliveredIssue = jobContext.jobId
+      ? linearJobIssueToDeliveryIssue(
+          await linearJobIssueRepository.createOrGet({
+            organizationId: event.organizationId,
+            connectionId: event.connectionId,
+            queueName: event.queueName,
+            jobId: jobContext.jobId,
+            alertEventId: event.id,
+            linearIssueId: issue.id,
+            linearIssueIdentifier: issue.identifier,
+            linearIssueUrl: issue.url,
+          })
+        )
+      : issue
 
-  if (jobContext.jobId) {
-    await linearJobIssueRepository.createOrGet({
-      organizationId: event.organizationId,
-      connectionId: event.connectionId,
-      queueName: event.queueName,
-      jobId: jobContext.jobId,
-      alertEventId: event.id,
-      linearIssueId: issue.id,
-      linearIssueIdentifier: issue.identifier,
-      linearIssueUrl: issue.url,
+    await markLinearDeliveryDelivered(delivery, deliveredIssue)
+  } catch {
+    throw new LinearApiError(
+      `Linear issue ${issue.identifier} was created, but Durabull could not record the delivery. Manual reconciliation is required before retrying.`,
+      { status: 500, retryable: false }
+    )
+  }
+}
+
+async function createLinearIssueOnce(
+  accessToken: string,
+  input: Parameters<typeof createLinearIssue>[1]
+): ReturnType<typeof createLinearIssue> {
+  try {
+    return await createLinearIssue(accessToken, input)
+  } catch (error) {
+    if (error instanceof LinearApiError && error.retryable && error.status !== 429) {
+      throw new LinearApiError(
+        'Linear issue creation returned an ambiguous failure. Manual reconciliation is required before retrying to avoid duplicate issues.',
+        { status: error.status, retryable: false }
+      )
+    }
+    throw error
+  }
+}
+
+function linearJobIssueToDeliveryIssue(issue: {
+  linearIssueId: string
+  linearIssueIdentifier: string
+  linearIssueUrl: string
+}): { id: string; identifier: string; url: string } {
+  return {
+    id: issue.linearIssueId,
+    identifier: issue.linearIssueIdentifier,
+    url: issue.linearIssueUrl,
+  }
+}
+
+async function markLinearDeliveryDelivered(
+  delivery: AlertDelivery,
+  issue: { id: string; identifier: string; url: string }
+): Promise<void> {
+  const marked = await alertDeliveryRepository.markDelivered(
+    delivery.id,
+    {
+      externalId: issue.id,
+      externalIdentifier: issue.identifier,
+      externalUrl: issue.url,
+      providerMetadata: {
+        ...((delivery.providerMetadata ?? {}) as Record<string, unknown>),
+        issue,
+      },
+    },
+    delivery.claimedAt
+  )
+  if (!marked) {
+    throw new LinearApiError('Alert delivery claim was lost before it could be completed.', {
+      status: 409,
+      retryable: false,
     })
   }
 }
@@ -294,7 +379,10 @@ function classifyDeliveryFailure(
   attemptCount: number
 ): { error: string; retryable: boolean; nextRetryAt?: Date | null } {
   const message = error instanceof Error ? error.message : String(error)
-  const retryable = error instanceof LinearApiError ? error.retryable : true
+  const retryable =
+    error instanceof LinearApiError
+      ? error.retryable
+      : !(error instanceof NonRetryableDeliveryError)
   if (!retryable) return { error: message, retryable: false }
 
   const resetAt = error instanceof LinearApiError ? error.rateLimitResetAt : null

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -70,7 +70,7 @@ export async function processAlertDeliveries(
       switch (delivery.channelType) {
         case 'email':
           await sendAlertEmail(delivery.target, event, connection, ruleName, organizationSlug)
-          await alertDeliveryRepository.markDelivered(delivery.id, {}, delivery.claimedAt)
+          await alertDeliveryRepository.markDelivered(delivery.id, {}, requireClaimedAt(delivery))
           break
         case 'linear':
           await sendLinearAlert(delivery, event, connection, ruleName, organizationSlug)
@@ -79,14 +79,14 @@ export async function processAlertDeliveries(
           await alertDeliveryRepository.markFailed(delivery.id, {
             error: `Unknown channel type: ${delivery.channelType}`,
             retryable: false,
-            expectedClaimedAt: delivery.claimedAt,
+            expectedClaimedAt: requireClaimedAt(delivery),
           })
       }
     } catch (error) {
       const retry = classifyDeliveryFailure(error, delivery.attemptCount + 1)
       await alertDeliveryRepository.markFailed(delivery.id, {
         ...retry,
-        expectedClaimedAt: delivery.claimedAt,
+        expectedClaimedAt: requireClaimedAt(delivery),
       })
     }
   }
@@ -279,7 +279,7 @@ async function markLinearDeliveryDelivered(
         issue,
       },
     },
-    delivery.claimedAt
+    requireClaimedAt(delivery)
   )
   if (!marked) {
     throw new LinearApiError('Alert delivery claim was lost before it could be completed.', {
@@ -287,6 +287,14 @@ async function markLinearDeliveryDelivered(
       retryable: false,
     })
   }
+}
+
+function requireClaimedAt(delivery: AlertDelivery): Date {
+  if (delivery.claimedAt instanceof Date) return delivery.claimedAt
+  throw new LinearApiError('Alert delivery was not claimed before finalization.', {
+    status: 409,
+    retryable: false,
+  })
 }
 
 function parseLinearChannel(value: unknown): Extract<NotificationChannel, { type: 'linear' }> {
@@ -333,10 +341,12 @@ function buildLinearIssueTitle(
   jobName: string | null
 ): string {
   if (event.type === 'job_failed') {
-    return `[Durabull] ${connection.name}/${event.queueName} job failed${jobName ? `: ${jobName}` : ''}`
+    return `[Durabull] ${connection.name}/${event.queueName} job failed${
+      jobName ? `: ${safeLinearMarkdown(jobName, 200)}` : ''
+    }`
   }
 
-  return `[Durabull] ${ruleName} fired for ${connection.name}/${event.queueName}`
+  return `[Durabull] ${safeLinearMarkdown(ruleName, 200)} fired for ${connection.name}/${event.queueName}`
 }
 
 function buildLinearIssueDescription({
@@ -353,17 +363,19 @@ function buildLinearIssueDescription({
   jobContext: ReturnType<typeof getJobContext>
 }): string {
   const lines = [
-    `Durabull alert rule **${ruleName}** fired.`,
+    `Durabull alert rule **${safeLinearMarkdown(ruleName, 200)}** fired.`,
     '',
     `- Connection: ${connection.name}`,
     `- Queue: ${event.queueName}`,
-    `- Summary: ${event.summary}`,
+    `- Summary: ${safeLinearMarkdown(event.summary)}`,
     `- Fired at: ${event.firedAt.toISOString()}`,
   ]
 
   if (jobContext.jobId) lines.push(`- Job ID: ${jobContext.jobId}`)
-  if (jobContext.jobName) lines.push(`- Job name: ${jobContext.jobName}`)
-  if (jobContext.failedReason) lines.push(`- Failure reason: ${jobContext.failedReason}`)
+  if (jobContext.jobName) lines.push(`- Job name: ${safeLinearMarkdown(jobContext.jobName, 200)}`)
+  if (jobContext.failedReason) {
+    lines.push(`- Failure reason: ${safeLinearMarkdown(jobContext.failedReason)}`)
+  }
   if (jobContext.attemptsMade !== null) {
     lines.push(`- Attempts made: ${jobContext.attemptsMade}`)
   }
@@ -372,6 +384,15 @@ function buildLinearIssueDescription({
   lines.push('', `[Open in Durabull](${jobUrl})`)
 
   return lines.join('\n')
+}
+
+function safeLinearMarkdown(value: string, maxLength = 1000): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  const truncated =
+    normalized.length > maxLength
+      ? `${normalized.slice(0, Math.max(0, maxLength - 1))}...`
+      : normalized
+  return truncated.replace(/([\\`*_{}[\]()#+\-.!>])/g, '\\$1')
 }
 
 function classifyDeliveryFailure(

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -1,6 +1,5 @@
 import {
   alertDeliveryRepository,
-  decryptSecret,
   eq,
   getDb,
   linearIntegrationRepository,
@@ -13,6 +12,7 @@ import {
 import { isEmailConfigured } from '@durabull/email'
 import { env } from '@durabull/env'
 import { createLinearIssue, LinearApiError } from './linear-client'
+import { getValidLinearAccessToken } from './linear-oauth'
 
 export type NotificationChannel =
   | {
@@ -162,8 +162,8 @@ async function sendLinearAlert(
     jobId: jobContext.jobId,
   })
 
-  const apiKey = decryptSecret(integration.encryptedApiKey)
-  const issue = await createLinearIssue(apiKey, {
+  const accessToken = await getValidLinearAccessToken(integration)
+  const issue = await createLinearIssue(accessToken, {
     teamId,
     title: buildLinearIssueTitle(event, connection, ruleName, jobContext.jobName),
     description: buildLinearIssueDescription({

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -184,6 +184,16 @@ async function sendLinearAlert(
     : null
 
   if (existingIssue) {
+    await linearJobIssueRepository.createOrGet({
+      organizationId: event.organizationId,
+      connectionId: event.connectionId,
+      queueName: event.queueName,
+      jobId: existingIssue.jobId,
+      alertEventId: event.id,
+      linearIssueId: existingIssue.linearIssueId,
+      linearIssueIdentifier: existingIssue.linearIssueIdentifier,
+      linearIssueUrl: existingIssue.linearIssueUrl,
+    })
     await markLinearDeliveryDelivered(delivery, {
       id: existingIssue.linearIssueId,
       identifier: existingIssue.linearIssueIdentifier,

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -1,11 +1,34 @@
-import { eq, getDb, organization, type AlertEvent, type RedisConnection } from '@durabull/dal'
+import {
+  alertDeliveryRepository,
+  decryptSecret,
+  eq,
+  getDb,
+  linearIntegrationRepository,
+  linearJobIssueRepository,
+  organization,
+  type AlertDelivery,
+  type AlertEvent,
+  type RedisConnection,
+} from '@durabull/dal'
 import { isEmailConfigured } from '@durabull/email'
 import { env } from '@durabull/env'
+import { createLinearIssue, LinearApiError } from './linear-client'
 
-export interface NotificationChannel {
-  type: 'email'
-  target: string
-}
+export type NotificationChannel =
+  | {
+      type: 'email'
+      target: string
+    }
+  | {
+      type: 'linear'
+      target: 'org-default'
+      teamId?: string
+      projectId?: string
+      labelIds?: string[]
+      assigneeId?: string
+      stateId?: string
+      priority?: number
+    }
 
 export async function dispatchAlertNotification(
   event: AlertEvent,
@@ -13,17 +36,62 @@ export async function dispatchAlertNotification(
   connection: RedisConnection,
   ruleName: string
 ): Promise<void> {
+  const deliveries = channels.map((channel) => ({
+    alertEventId: event.id,
+    organizationId: event.organizationId,
+    channelType: channel.type,
+    target: getDeliveryTarget(channel),
+    providerMetadata: channel,
+  }))
+
+  await alertDeliveryRepository.enqueueMany(deliveries)
+  await processAlertDeliveries(event, connection, ruleName)
+}
+
+export async function processAlertDeliveries(
+  event: AlertEvent,
+  connection: RedisConnection,
+  ruleName: string
+): Promise<void> {
+  const dueDeliveries = await alertDeliveryRepository.claimDueForEvent(event.id)
+  if (dueDeliveries.length === 0) return
+
   const organizationSlug = await getOrganizationSlug(event.organizationId)
 
-  for (const channel of channels) {
-    switch (channel.type) {
-      case 'email':
-        await sendAlertEmail(channel.target, event, connection, ruleName, organizationSlug)
-        break
-      default:
-        console.warn(`[alert-notifier] Unknown channel type: ${String(channel)}`)
+  for (const delivery of dueDeliveries) {
+    try {
+      switch (delivery.channelType) {
+        case 'email':
+          await sendAlertEmail(delivery.target, event, connection, ruleName, organizationSlug)
+          await alertDeliveryRepository.markDelivered(delivery.id)
+          break
+        case 'linear':
+          await sendLinearAlert(delivery, event, connection, ruleName, organizationSlug)
+          break
+        default:
+          await alertDeliveryRepository.markFailed(delivery.id, {
+            error: `Unknown channel type: ${delivery.channelType}`,
+            retryable: false,
+          })
+      }
+    } catch (error) {
+      const retry = classifyDeliveryFailure(error, delivery.attemptCount + 1)
+      await alertDeliveryRepository.markFailed(delivery.id, retry)
     }
   }
+}
+
+function getDeliveryTarget(channel: NotificationChannel): string {
+  if (channel.type === 'email') return channel.target
+  return [
+    'org-default',
+    channel.teamId ?? '',
+    channel.projectId ?? '',
+    channel.assigneeId ?? '',
+    channel.stateId ?? '',
+    channel.priority ?? '',
+    ...(channel.labelIds ?? []),
+  ].join(':')
 }
 
 async function sendAlertEmail(
@@ -60,6 +128,185 @@ async function sendAlertEmail(
   })
 }
 
+async function sendLinearAlert(
+  delivery: AlertDelivery,
+  event: AlertEvent,
+  connection: RedisConnection,
+  ruleName: string,
+  organizationSlug: string | null
+): Promise<void> {
+  const integration = await linearIntegrationRepository.findByOrganization(event.organizationId)
+  if (!integration) {
+    throw new LinearApiError('Linear integration is not configured for this organization.', {
+      status: 400,
+      retryable: false,
+    })
+  }
+
+  const channel = parseLinearChannel(delivery.providerMetadata)
+  const teamId = channel.teamId ?? integration.defaultTeamId
+  if (!teamId) {
+    throw new LinearApiError('Linear team is required before alert delivery can create issues.', {
+      status: 400,
+      retryable: false,
+    })
+  }
+
+  const jobContext = getJobContext(event.context)
+  const { jobUrl } = buildAlertAppUrls({
+    appBaseUrl: env.APP_BASE_URL,
+    organizationSlug,
+    connectionId: connection.id,
+    queueName: event.queueName,
+    alertRuleId: event.alertRuleId,
+    jobId: jobContext.jobId,
+  })
+
+  const apiKey = decryptSecret(integration.encryptedApiKey)
+  const issue = await createLinearIssue(apiKey, {
+    teamId,
+    title: buildLinearIssueTitle(event, connection, ruleName, jobContext.jobName),
+    description: buildLinearIssueDescription({
+      event,
+      connection,
+      ruleName,
+      jobUrl,
+      jobContext,
+    }),
+    projectId: channel.projectId ?? integration.defaultProjectId,
+    labelIds: channel.labelIds?.length ? channel.labelIds : integration.defaultLabelIds,
+    assigneeId: channel.assigneeId ?? integration.defaultAssigneeId,
+    stateId: channel.stateId ?? integration.defaultStateId,
+    priority: channel.priority ?? integration.defaultPriority,
+  })
+
+  await alertDeliveryRepository.markDelivered(delivery.id, {
+    externalId: issue.id,
+    externalIdentifier: issue.identifier,
+    externalUrl: issue.url,
+    providerMetadata: {
+      ...((delivery.providerMetadata ?? {}) as Record<string, unknown>),
+      issue,
+    },
+  })
+
+  if (jobContext.jobId) {
+    await linearJobIssueRepository.createOrGet({
+      organizationId: event.organizationId,
+      connectionId: event.connectionId,
+      queueName: event.queueName,
+      jobId: jobContext.jobId,
+      alertEventId: event.id,
+      linearIssueId: issue.id,
+      linearIssueIdentifier: issue.identifier,
+      linearIssueUrl: issue.url,
+    })
+  }
+}
+
+function parseLinearChannel(value: unknown): Extract<NotificationChannel, { type: 'linear' }> {
+  const source =
+    typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+  return {
+    type: 'linear',
+    target: 'org-default',
+    teamId: typeof source.teamId === 'string' ? source.teamId : undefined,
+    projectId: typeof source.projectId === 'string' ? source.projectId : undefined,
+    labelIds: Array.isArray(source.labelIds)
+      ? source.labelIds.filter((label): label is string => typeof label === 'string')
+      : undefined,
+    assigneeId: typeof source.assigneeId === 'string' ? source.assigneeId : undefined,
+    stateId: typeof source.stateId === 'string' ? source.stateId : undefined,
+    priority: typeof source.priority === 'number' ? source.priority : undefined,
+  }
+}
+
+function getJobContext(context: unknown): {
+  jobId: string | null
+  jobName: string | null
+  failedReason: string | null
+  attemptsMade: number | null
+  attempts: number | null
+  failedAt: string | null
+} {
+  const source =
+    typeof context === 'object' && context !== null ? (context as Record<string, unknown>) : {}
+  return {
+    jobId: typeof source.jobId === 'string' ? source.jobId : null,
+    jobName: typeof source.jobName === 'string' ? source.jobName : null,
+    failedReason: typeof source.failedReason === 'string' ? source.failedReason : null,
+    attemptsMade: typeof source.attemptsMade === 'number' ? source.attemptsMade : null,
+    attempts: typeof source.attempts === 'number' ? source.attempts : null,
+    failedAt: typeof source.failedAt === 'string' ? source.failedAt : null,
+  }
+}
+
+function buildLinearIssueTitle(
+  event: AlertEvent,
+  connection: RedisConnection,
+  ruleName: string,
+  jobName: string | null
+): string {
+  if (event.type === 'job_failed') {
+    return `[Durabull] ${connection.name}/${event.queueName} job failed${jobName ? `: ${jobName}` : ''}`
+  }
+
+  return `[Durabull] ${ruleName} fired for ${connection.name}/${event.queueName}`
+}
+
+function buildLinearIssueDescription({
+  event,
+  connection,
+  ruleName,
+  jobUrl,
+  jobContext,
+}: {
+  event: AlertEvent
+  connection: RedisConnection
+  ruleName: string
+  jobUrl: string
+  jobContext: ReturnType<typeof getJobContext>
+}): string {
+  const lines = [
+    `Durabull alert rule **${ruleName}** fired.`,
+    '',
+    `- Connection: ${connection.name}`,
+    `- Queue: ${event.queueName}`,
+    `- Summary: ${event.summary}`,
+    `- Fired at: ${event.firedAt.toISOString()}`,
+  ]
+
+  if (jobContext.jobId) lines.push(`- Job ID: ${jobContext.jobId}`)
+  if (jobContext.jobName) lines.push(`- Job name: ${jobContext.jobName}`)
+  if (jobContext.failedReason) lines.push(`- Failure reason: ${jobContext.failedReason}`)
+  if (jobContext.attemptsMade !== null) {
+    lines.push(`- Attempts made: ${jobContext.attemptsMade}`)
+  }
+  if (jobContext.attempts !== null) lines.push(`- Max attempts: ${jobContext.attempts}`)
+  if (jobContext.failedAt) lines.push(`- Failed at: ${jobContext.failedAt}`)
+  lines.push('', `[Open in Durabull](${jobUrl})`)
+
+  return lines.join('\n')
+}
+
+function classifyDeliveryFailure(
+  error: unknown,
+  attemptCount: number
+): { error: string; retryable: boolean; nextRetryAt?: Date | null } {
+  const message = error instanceof Error ? error.message : String(error)
+  const retryable = error instanceof LinearApiError ? error.retryable : true
+  if (!retryable) return { error: message, retryable: false }
+
+  const resetAt = error instanceof LinearApiError ? error.rateLimitResetAt : null
+  const backoffMs = Math.min(60 * 60 * 1000, 2 ** Math.max(0, attemptCount - 1) * 30_000)
+  return {
+    error: message,
+    retryable: true,
+    nextRetryAt:
+      resetAt && resetAt.getTime() > Date.now() ? resetAt : new Date(Date.now() + backoffMs),
+  }
+}
+
 async function getOrganizationSlug(organizationId: string): Promise<string | null> {
   const db = await getDb()
   const rows = await db
@@ -77,13 +324,15 @@ export function buildAlertAppUrls({
   connectionId,
   queueName,
   alertRuleId,
+  jobId,
 }: {
   appBaseUrl: string
   organizationSlug: string | null
   connectionId: string
   queueName: string
   alertRuleId: string
-}): { dashboardUrl: string; muteUrl: string } {
+  jobId?: string | null
+}): { dashboardUrl: string; muteUrl: string; jobUrl: string } {
   const baseUrl = appBaseUrl.replace(/\/+$/, '')
 
   if (!organizationSlug) {
@@ -91,6 +340,7 @@ export function buildAlertAppUrls({
     return {
       dashboardUrl: baseUrl,
       muteUrl: baseUrl,
+      jobUrl: baseUrl,
     }
   }
 
@@ -101,6 +351,9 @@ export function buildAlertAppUrls({
 
   return {
     dashboardUrl: `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}`,
+    jobUrl: jobId
+      ? `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}/jobs/${encodeURIComponent(jobId)}`
+      : `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}`,
     muteUrl: `${baseUrl}/${orgSegment}/c/${connectionSegment}/alerts?${ruleQuery}`,
   }
 }

--- a/apps/api/src/lib/linear-client.ts
+++ b/apps/api/src/lib/linear-client.ts
@@ -1,6 +1,7 @@
 const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql'
 const LINEAR_TOKEN_ENDPOINT = 'https://api.linear.app/oauth/token'
 const LINEAR_REVOKE_ENDPOINT = 'https://api.linear.app/oauth/revoke'
+const LINEAR_REQUEST_TIMEOUT_MS = 30_000
 
 interface LinearGraphQLError {
   message?: string
@@ -119,23 +120,44 @@ function normalizeTokenPayload(payload: Record<string, unknown>): LinearOauthTok
   }
 }
 
-async function requestOauthToken(body: URLSearchParams): Promise<LinearOauthTokenResponse> {
-  let response: Response
+async function fetchLinear(
+  url: string,
+  init: RequestInit,
+  failureLabel: string
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), LINEAR_REQUEST_TIMEOUT_MS)
+
   try {
-    response = await fetch(LINEAR_TOKEN_ENDPOINT, {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    })
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === 'AbortError'
+    throw new LinearApiError(
+      aborted
+        ? `${failureLabel} timed out after ${LINEAR_REQUEST_TIMEOUT_MS}ms`
+        : error instanceof Error
+          ? error.message
+          : failureLabel,
+      { status: 0, retryable: true }
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function requestOauthToken(body: URLSearchParams): Promise<LinearOauthTokenResponse> {
+  const response = await fetchLinear(
+    LINEAR_TOKEN_ENDPOINT,
+    {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       body,
-    })
-  } catch (error) {
-    throw new LinearApiError(
-      error instanceof Error ? error.message : 'Linear OAuth network error',
-      {
-        status: 0,
-        retryable: true,
-      }
-    )
-  }
+    },
+    'Linear OAuth network error'
+  )
 
   const payload = (await response.json().catch(() => null)) as
     | (Record<string, unknown> & LinearOauthErrorResponse)
@@ -205,11 +227,15 @@ export async function revokeLinearOauthToken(input: {
     client_secret: input.clientSecret,
   })
 
-  const response = await fetch(LINEAR_REVOKE_ENDPOINT, {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body,
-  })
+  const response = await fetchLinear(
+    LINEAR_REVOKE_ENDPOINT,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    },
+    'Linear OAuth revoke network error'
+  )
 
   if (!response.ok && response.status !== 400) {
     throw new LinearApiError(`Linear OAuth revoke failed (${response.status})`, {
@@ -224,22 +250,18 @@ async function linearGraphql<T>(
   query: string,
   variables: Record<string, unknown> = {}
 ): Promise<T> {
-  let response: Response
-  try {
-    response = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
+  const response = await fetchLinear(
+    LINEAR_GRAPHQL_ENDPOINT,
+    {
       method: 'POST',
       headers: {
         authorization: `Bearer ${accessToken}`,
         'content-type': 'application/json',
       },
       body: JSON.stringify({ query, variables }),
-    })
-  } catch (error) {
-    throw new LinearApiError(error instanceof Error ? error.message : 'Linear network error', {
-      status: 0,
-      retryable: true,
-    })
-  }
+    },
+    'Linear network error'
+  )
 
   const rateLimitResetAt = parseRateLimitReset(response.headers)
   const retryable =
@@ -352,11 +374,19 @@ export async function createLinearIssue(
         teamId: input.teamId,
         title: input.title,
         description: input.description,
-        ...(input.projectId ? { projectId: input.projectId } : {}),
+        ...(input.projectId !== null && input.projectId !== undefined
+          ? { projectId: input.projectId }
+          : {}),
         ...(input.labelIds?.length ? { labelIds: input.labelIds } : {}),
-        ...(input.assigneeId ? { assigneeId: input.assigneeId } : {}),
-        ...(input.stateId ? { stateId: input.stateId } : {}),
-        ...(input.priority ? { priority: input.priority } : {}),
+        ...(input.assigneeId !== null && input.assigneeId !== undefined
+          ? { assigneeId: input.assigneeId }
+          : {}),
+        ...(input.stateId !== null && input.stateId !== undefined
+          ? { stateId: input.stateId }
+          : {}),
+        ...(input.priority !== null && input.priority !== undefined
+          ? { priority: input.priority }
+          : {}),
       },
     }
   )

--- a/apps/api/src/lib/linear-client.ts
+++ b/apps/api/src/lib/linear-client.ts
@@ -1,4 +1,6 @@
 const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql'
+const LINEAR_TOKEN_ENDPOINT = 'https://api.linear.app/oauth/token'
+const LINEAR_REVOKE_ENDPOINT = 'https://api.linear.app/oauth/revoke'
 
 interface LinearGraphQLError {
   message?: string
@@ -11,6 +13,20 @@ interface LinearGraphQLError {
 interface LinearGraphQLResponse<T> {
   data?: T
   errors?: LinearGraphQLError[]
+}
+
+interface LinearOauthErrorResponse {
+  error?: string
+  error_description?: string
+}
+
+export interface LinearOauthTokenResponse {
+  accessToken: string
+  refreshToken: string
+  tokenType: string
+  expiresIn: number
+  scopes: string
+  accessTokenExpiresAt: Date
 }
 
 export class LinearApiError extends Error {
@@ -70,11 +86,141 @@ function parseRateLimitReset(headers: Headers): Date | null {
 }
 
 function redactLinearError(message: string): string {
-  return message.replace(/lin_api_[A-Za-z0-9_-]+/g, '[REDACTED_LINEAR_API_KEY]')
+  return message
+    .replace(/lin_api_[A-Za-z0-9_-]+/g, '[REDACTED_LINEAR_TOKEN]')
+    .replace(/([A-Za-z0-9_-]{32,})/g, '[REDACTED_LINEAR_TOKEN]')
+}
+
+function normalizeScope(scope: unknown): string {
+  if (Array.isArray(scope)) {
+    return scope.filter((item): item is string => typeof item === 'string').join(' ')
+  }
+  return typeof scope === 'string' ? scope : ''
+}
+
+function normalizeTokenPayload(payload: Record<string, unknown>): LinearOauthTokenResponse {
+  const accessToken = typeof payload.access_token === 'string' ? payload.access_token : ''
+  const refreshToken = typeof payload.refresh_token === 'string' ? payload.refresh_token : ''
+  const expiresIn = typeof payload.expires_in === 'number' ? payload.expires_in : 86_399
+  if (!accessToken || !refreshToken) {
+    throw new LinearApiError('Linear OAuth token response was missing required tokens.', {
+      status: 400,
+      retryable: false,
+    })
+  }
+
+  return {
+    accessToken,
+    refreshToken,
+    tokenType: typeof payload.token_type === 'string' ? payload.token_type : 'Bearer',
+    expiresIn,
+    scopes: normalizeScope(payload.scope),
+    accessTokenExpiresAt: new Date(Date.now() + Math.max(0, expiresIn - 60) * 1000),
+  }
+}
+
+async function requestOauthToken(body: URLSearchParams): Promise<LinearOauthTokenResponse> {
+  let response: Response
+  try {
+    response = await fetch(LINEAR_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    })
+  } catch (error) {
+    throw new LinearApiError(
+      error instanceof Error ? error.message : 'Linear OAuth network error',
+      {
+        status: 0,
+        retryable: true,
+      }
+    )
+  }
+
+  const payload = (await response.json().catch(() => null)) as
+    | (Record<string, unknown> & LinearOauthErrorResponse)
+    | null
+
+  if (!response.ok) {
+    throw new LinearApiError(
+      redactLinearError(
+        payload?.error_description ?? payload?.error ?? `Linear OAuth failed (${response.status})`
+      ),
+      { status: response.status, retryable: response.status >= 500 || response.status === 429 }
+    )
+  }
+
+  if (!payload) {
+    throw new LinearApiError('Linear OAuth returned an empty response.', {
+      status: response.status,
+      retryable: true,
+    })
+  }
+
+  return normalizeTokenPayload(payload)
+}
+
+export async function exchangeLinearOauthCode(input: {
+  code: string
+  redirectUri: string
+  clientId: string
+  clientSecret: string
+}): Promise<LinearOauthTokenResponse> {
+  const body = new URLSearchParams({
+    code: input.code,
+    redirect_uri: input.redirectUri,
+    client_id: input.clientId,
+    client_secret: input.clientSecret,
+    grant_type: 'authorization_code',
+  })
+
+  return requestOauthToken(body)
+}
+
+export async function refreshLinearOauthToken(input: {
+  refreshToken: string
+  clientId: string
+  clientSecret: string
+}): Promise<LinearOauthTokenResponse> {
+  const body = new URLSearchParams({
+    refresh_token: input.refreshToken,
+    client_id: input.clientId,
+    client_secret: input.clientSecret,
+    grant_type: 'refresh_token',
+  })
+
+  return requestOauthToken(body)
+}
+
+export async function revokeLinearOauthToken(input: {
+  token: string
+  tokenTypeHint: 'access_token' | 'refresh_token'
+  clientId: string
+  clientSecret: string
+}): Promise<void> {
+  const body = new URLSearchParams({
+    token: input.token,
+    token_type_hint: input.tokenTypeHint,
+    client_id: input.clientId,
+    client_secret: input.clientSecret,
+  })
+
+  const response = await fetch(LINEAR_REVOKE_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+
+  if (!response.ok && response.status !== 400) {
+    throw new LinearApiError(`Linear OAuth revoke failed (${response.status})`, {
+      status: response.status,
+      retryable: response.status >= 500 || response.status === 429,
+    })
+  }
 }
 
 async function linearGraphql<T>(
-  apiKey: string,
+  accessToken: string,
   query: string,
   variables: Record<string, unknown> = {}
 ): Promise<T> {
@@ -83,7 +229,7 @@ async function linearGraphql<T>(
     response = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
       method: 'POST',
       headers: {
-        authorization: apiKey,
+        authorization: `Bearer ${accessToken}`,
         'content-type': 'application/json',
       },
       body: JSON.stringify({ query, variables }),
@@ -142,16 +288,18 @@ async function linearGraphql<T>(
   return payload.data
 }
 
-export async function validateLinearApiKey(apiKey: string): Promise<{ organizationName: string }> {
+export async function validateLinearAccessToken(
+  accessToken: string
+): Promise<{ organizationName: string }> {
   const data = await linearGraphql<{ organization: { name: string } }>(
-    apiKey,
-    'query DurabullValidateLinearKey { organization { name } }'
+    accessToken,
+    'query DurabullValidateLinearToken { organization { name } }'
   )
 
   return { organizationName: data.organization.name }
 }
 
-export async function fetchLinearMetadata(apiKey: string): Promise<LinearMetadata> {
+export async function fetchLinearMetadata(accessToken: string): Promise<LinearMetadata> {
   const data = await linearGraphql<{
     teams: { nodes: LinearTeamSummary[] }
     projects: { nodes: Array<{ id: string; name: string }> }
@@ -159,7 +307,7 @@ export async function fetchLinearMetadata(apiKey: string): Promise<LinearMetadat
     users: { nodes: Array<{ id: string; name: string; email?: string | null }> }
     workflowStates: { nodes: Array<{ id: string; name: string; team: { id: string } }> }
   }>(
-    apiKey,
+    accessToken,
     `query DurabullLinearMetadata {
       teams(first: 100) { nodes { id name key } }
       projects(first: 100) { nodes { id name } }
@@ -183,7 +331,7 @@ export async function fetchLinearMetadata(apiKey: string): Promise<LinearMetadat
 }
 
 export async function createLinearIssue(
-  apiKey: string,
+  accessToken: string,
   input: LinearIssueInput
 ): Promise<LinearIssueResult> {
   const data = await linearGraphql<{
@@ -192,7 +340,7 @@ export async function createLinearIssue(
       issue?: LinearIssueResult | null
     }
   }>(
-    apiKey,
+    accessToken,
     `mutation DurabullCreateIssue($input: IssueCreateInput!) {
       issueCreate(input: $input) {
         success

--- a/apps/api/src/lib/linear-client.ts
+++ b/apps/api/src/lib/linear-client.ts
@@ -1,0 +1,221 @@
+const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql'
+
+interface LinearGraphQLError {
+  message?: string
+  extensions?: {
+    code?: string
+    type?: string
+  }
+}
+
+interface LinearGraphQLResponse<T> {
+  data?: T
+  errors?: LinearGraphQLError[]
+}
+
+export class LinearApiError extends Error {
+  status: number
+  retryable: boolean
+  rateLimitResetAt: Date | null
+
+  constructor(
+    message: string,
+    options: { status: number; retryable: boolean; rateLimitResetAt?: Date | null }
+  ) {
+    super(message)
+    this.name = 'LinearApiError'
+    this.status = options.status
+    this.retryable = options.retryable
+    this.rateLimitResetAt = options.rateLimitResetAt ?? null
+  }
+}
+
+export interface LinearIssueInput {
+  teamId: string
+  title: string
+  description: string
+  projectId?: string | null
+  labelIds?: string[]
+  assigneeId?: string | null
+  stateId?: string | null
+  priority?: number | null
+}
+
+export interface LinearIssueResult {
+  id: string
+  identifier: string
+  url: string
+}
+
+export interface LinearTeamSummary {
+  id: string
+  name: string
+  key: string
+}
+
+export interface LinearMetadata {
+  teams: LinearTeamSummary[]
+  projects: Array<{ id: string; name: string }>
+  labels: Array<{ id: string; name: string }>
+  users: Array<{ id: string; name: string; email?: string | null }>
+  states: Array<{ id: string; name: string; teamId: string }>
+}
+
+function parseRateLimitReset(headers: Headers): Date | null {
+  const reset = headers.get('x-ratelimit-reset')
+  if (!reset) return null
+  const numeric = Number(reset)
+  if (!Number.isFinite(numeric)) return null
+  return new Date(numeric > 10_000_000_000 ? numeric : numeric * 1000)
+}
+
+function redactLinearError(message: string): string {
+  return message.replace(/lin_api_[A-Za-z0-9_-]+/g, '[REDACTED_LINEAR_API_KEY]')
+}
+
+async function linearGraphql<T>(
+  apiKey: string,
+  query: string,
+  variables: Record<string, unknown> = {}
+): Promise<T> {
+  let response: Response
+  try {
+    response = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        authorization: apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+    })
+  } catch (error) {
+    throw new LinearApiError(error instanceof Error ? error.message : 'Linear network error', {
+      status: 0,
+      retryable: true,
+    })
+  }
+
+  const rateLimitResetAt = parseRateLimitReset(response.headers)
+  const retryable =
+    response.status === 429 ||
+    response.status === 408 ||
+    response.status >= 500 ||
+    response.status === 0
+
+  let payload: LinearGraphQLResponse<T> | null = null
+  try {
+    payload = (await response.json()) as LinearGraphQLResponse<T>
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    throw new LinearApiError(
+      redactLinearError(
+        payload?.errors?.[0]?.message ?? `Linear request failed (${response.status})`
+      ),
+      { status: response.status, retryable, rateLimitResetAt }
+    )
+  }
+
+  if (payload?.errors?.length) {
+    const code = payload.errors[0]?.extensions?.code ?? payload.errors[0]?.extensions?.type
+    const retryableGraphql = code === 'RATELIMITED' || code === 'INTERNAL_ERROR'
+    throw new LinearApiError(
+      redactLinearError(payload.errors[0]?.message ?? 'Linear GraphQL error'),
+      {
+        status: code === 'AUTHENTICATION_ERROR' ? 401 : 400,
+        retryable: retryableGraphql,
+        rateLimitResetAt,
+      }
+    )
+  }
+
+  if (!payload?.data) {
+    throw new LinearApiError('Linear returned an empty response.', {
+      status: response.status,
+      retryable: true,
+      rateLimitResetAt,
+    })
+  }
+
+  return payload.data
+}
+
+export async function validateLinearApiKey(apiKey: string): Promise<{ organizationName: string }> {
+  const data = await linearGraphql<{ organization: { name: string } }>(
+    apiKey,
+    'query DurabullValidateLinearKey { organization { name } }'
+  )
+
+  return { organizationName: data.organization.name }
+}
+
+export async function fetchLinearMetadata(apiKey: string): Promise<LinearMetadata> {
+  const data = await linearGraphql<{
+    teams: { nodes: LinearTeamSummary[] }
+    projects: { nodes: Array<{ id: string; name: string }> }
+    issueLabels: { nodes: Array<{ id: string; name: string }> }
+    users: { nodes: Array<{ id: string; name: string; email?: string | null }> }
+    workflowStates: { nodes: Array<{ id: string; name: string; team: { id: string } }> }
+  }>(
+    apiKey,
+    `query DurabullLinearMetadata {
+      teams(first: 100) { nodes { id name key } }
+      projects(first: 100) { nodes { id name } }
+      issueLabels(first: 100) { nodes { id name } }
+      users(first: 100) { nodes { id name email } }
+      workflowStates(first: 250) { nodes { id name team { id } } }
+    }`
+  )
+
+  return {
+    teams: data.teams.nodes,
+    projects: data.projects.nodes,
+    labels: data.issueLabels.nodes,
+    users: data.users.nodes,
+    states: data.workflowStates.nodes.map((state) => ({
+      id: state.id,
+      name: state.name,
+      teamId: state.team.id,
+    })),
+  }
+}
+
+export async function createLinearIssue(
+  apiKey: string,
+  input: LinearIssueInput
+): Promise<LinearIssueResult> {
+  const data = await linearGraphql<{
+    issueCreate: {
+      success: boolean
+      issue?: LinearIssueResult | null
+    }
+  }>(
+    apiKey,
+    `mutation DurabullCreateIssue($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { id identifier url }
+      }
+    }`,
+    {
+      input: {
+        teamId: input.teamId,
+        title: input.title,
+        description: input.description,
+        ...(input.projectId ? { projectId: input.projectId } : {}),
+        ...(input.labelIds?.length ? { labelIds: input.labelIds } : {}),
+        ...(input.assigneeId ? { assigneeId: input.assigneeId } : {}),
+        ...(input.stateId ? { stateId: input.stateId } : {}),
+        ...(input.priority ? { priority: input.priority } : {}),
+      },
+    }
+  )
+
+  if (!data.issueCreate.success || !data.issueCreate.issue) {
+    throw new LinearApiError('Linear did not create an issue.', { status: 400, retryable: false })
+  }
+
+  return data.issueCreate.issue
+}

--- a/apps/api/src/lib/linear-oauth.test.ts
+++ b/apps/api/src/lib/linear-oauth.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { env } from '@durabull/env'
+import { buildLinearOauthAuthorizeUrl, getLinearOauthConfig } from './linear-oauth'
+
+const mutableEnv = env as {
+  APP_BASE_URL: string
+  LINEAR_OAUTH_CLIENT_ID?: string
+  LINEAR_OAUTH_CLIENT_SECRET?: string
+  LINEAR_OAUTH_REDIRECT_URI?: string
+}
+
+const originalAppBaseUrl = mutableEnv.APP_BASE_URL
+const originalClientId = mutableEnv.LINEAR_OAUTH_CLIENT_ID
+const originalClientSecret = mutableEnv.LINEAR_OAUTH_CLIENT_SECRET
+const originalRedirectUri = mutableEnv.LINEAR_OAUTH_REDIRECT_URI
+
+describe('Linear OAuth helpers', () => {
+  afterEach(() => {
+    mutableEnv.APP_BASE_URL = originalAppBaseUrl
+    mutableEnv.LINEAR_OAUTH_CLIENT_ID = originalClientId
+    mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = originalClientSecret
+    mutableEnv.LINEAR_OAUTH_REDIRECT_URI = originalRedirectUri
+  })
+
+  it('builds a cloud/self-host compatible callback from APP_BASE_URL by default', () => {
+    mutableEnv.APP_BASE_URL = 'https://durabull.example.com///'
+    mutableEnv.LINEAR_OAUTH_CLIENT_ID = 'client-id'
+    mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = 'client-secret'
+    mutableEnv.LINEAR_OAUTH_REDIRECT_URI = undefined
+
+    expect(getLinearOauthConfig()).toEqual({
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      redirectUri: 'https://durabull.example.com/api/alerts/integrations/linear/callback',
+    })
+  })
+
+  it('allows split-host self-hosting to override the callback URL explicitly', () => {
+    mutableEnv.APP_BASE_URL = 'https://web.example.com'
+    mutableEnv.LINEAR_OAUTH_CLIENT_ID = 'client-id'
+    mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = 'client-secret'
+    mutableEnv.LINEAR_OAUTH_REDIRECT_URI =
+      'https://api.example.com/api/alerts/integrations/linear/callback'
+
+    expect(getLinearOauthConfig().redirectUri).toBe(
+      'https://api.example.com/api/alerts/integrations/linear/callback'
+    )
+  })
+
+  it('builds the Linear authorization URL with required OAuth parameters and least scopes', () => {
+    const authorizationUrl = new URL(
+      buildLinearOauthAuthorizeUrl({
+        clientId: 'client-id',
+        redirectUri: 'https://durabull.example.com/api/alerts/integrations/linear/callback',
+        state: 'opaque-state',
+      })
+    )
+
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      'https://linear.app/oauth/authorize'
+    )
+    expect(authorizationUrl.searchParams.get('client_id')).toBe('client-id')
+    expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(
+      'https://durabull.example.com/api/alerts/integrations/linear/callback'
+    )
+    expect(authorizationUrl.searchParams.get('response_type')).toBe('code')
+    expect(authorizationUrl.searchParams.get('scope')).toBe('read,issues:create')
+    expect(authorizationUrl.searchParams.get('state')).toBe('opaque-state')
+    expect(authorizationUrl.searchParams.get('actor')).toBe('app')
+  })
+})

--- a/apps/api/src/lib/linear-oauth.test.ts
+++ b/apps/api/src/lib/linear-oauth.test.ts
@@ -7,12 +7,14 @@ const mutableEnv = env as {
   LINEAR_OAUTH_CLIENT_ID?: string
   LINEAR_OAUTH_CLIENT_SECRET?: string
   LINEAR_OAUTH_REDIRECT_URI?: string
+  LINEAR_OAUTH_ACTOR: 'user' | 'app'
 }
 
 const originalAppBaseUrl = mutableEnv.APP_BASE_URL
 const originalClientId = mutableEnv.LINEAR_OAUTH_CLIENT_ID
 const originalClientSecret = mutableEnv.LINEAR_OAUTH_CLIENT_SECRET
 const originalRedirectUri = mutableEnv.LINEAR_OAUTH_REDIRECT_URI
+const originalActor = mutableEnv.LINEAR_OAUTH_ACTOR
 
 describe('Linear OAuth helpers', () => {
   afterEach(() => {
@@ -20,6 +22,7 @@ describe('Linear OAuth helpers', () => {
     mutableEnv.LINEAR_OAUTH_CLIENT_ID = originalClientId
     mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = originalClientSecret
     mutableEnv.LINEAR_OAUTH_REDIRECT_URI = originalRedirectUri
+    mutableEnv.LINEAR_OAUTH_ACTOR = originalActor
   })
 
   it('builds a cloud/self-host compatible callback from APP_BASE_URL by default', () => {
@@ -32,6 +35,7 @@ describe('Linear OAuth helpers', () => {
       clientId: 'client-id',
       clientSecret: 'client-secret',
       redirectUri: 'https://durabull.example.com/api/alerts/integrations/linear/callback',
+      actor: 'user',
     })
   })
 
@@ -53,6 +57,7 @@ describe('Linear OAuth helpers', () => {
         clientId: 'client-id',
         redirectUri: 'https://durabull.example.com/api/alerts/integrations/linear/callback',
         state: 'opaque-state',
+        actor: 'user',
       })
     )
 
@@ -67,6 +72,23 @@ describe('Linear OAuth helpers', () => {
     expect(authorizationUrl.searchParams.get('scope')).toBe('read,issues:create')
     expect(authorizationUrl.searchParams.get('state')).toBe('opaque-state')
     expect(authorizationUrl.searchParams.get('prompt')).toBe('consent')
+    expect(authorizationUrl.searchParams.has('actor')).toBe(false)
+  })
+
+  it('can opt into Linear app actor authorization for service-account style installs', () => {
+    mutableEnv.LINEAR_OAUTH_ACTOR = 'app'
+
+    expect(getLinearOauthConfig().actor).toBe('app')
+
+    const authorizationUrl = new URL(
+      buildLinearOauthAuthorizeUrl({
+        clientId: 'client-id',
+        redirectUri: 'https://durabull.example.com/api/alerts/integrations/linear/callback',
+        state: 'opaque-state',
+        actor: 'app',
+      })
+    )
+
     expect(authorizationUrl.searchParams.get('actor')).toBe('app')
   })
 })

--- a/apps/api/src/lib/linear-oauth.test.ts
+++ b/apps/api/src/lib/linear-oauth.test.ts
@@ -66,6 +66,7 @@ describe('Linear OAuth helpers', () => {
     expect(authorizationUrl.searchParams.get('response_type')).toBe('code')
     expect(authorizationUrl.searchParams.get('scope')).toBe('read,issues:create')
     expect(authorizationUrl.searchParams.get('state')).toBe('opaque-state')
+    expect(authorizationUrl.searchParams.get('prompt')).toBe('consent')
     expect(authorizationUrl.searchParams.get('actor')).toBe('app')
   })
 })

--- a/apps/api/src/lib/linear-oauth.ts
+++ b/apps/api/src/lib/linear-oauth.ts
@@ -35,6 +35,7 @@ export function buildLinearOauthAuthorizeUrl(input: {
     response_type: 'code',
     scope: LINEAR_OAUTH_SCOPE,
     state: input.state,
+    prompt: 'consent',
     actor: 'app',
   })
 

--- a/apps/api/src/lib/linear-oauth.ts
+++ b/apps/api/src/lib/linear-oauth.ts
@@ -10,6 +10,7 @@ export function getLinearOauthConfig(): {
   clientId: string
   clientSecret: string
   redirectUri: string
+  actor: 'user' | 'app'
 } {
   const clientId = env.LINEAR_OAUTH_CLIENT_ID?.trim()
   const clientSecret = env.LINEAR_OAUTH_CLIENT_SECRET?.trim()
@@ -21,13 +22,14 @@ export function getLinearOauthConfig(): {
     env.LINEAR_OAUTH_REDIRECT_URI?.trim() ||
     `${env.APP_BASE_URL.replace(/\/+$/, '')}/api/alerts/integrations/linear/callback`
 
-  return { clientId, clientSecret, redirectUri }
+  return { clientId, clientSecret, redirectUri, actor: env.LINEAR_OAUTH_ACTOR }
 }
 
 export function buildLinearOauthAuthorizeUrl(input: {
   clientId: string
   redirectUri: string
   state: string
+  actor: 'user' | 'app'
 }): string {
   const params = new URLSearchParams({
     client_id: input.clientId,
@@ -36,8 +38,11 @@ export function buildLinearOauthAuthorizeUrl(input: {
     scope: LINEAR_OAUTH_SCOPE,
     state: input.state,
     prompt: 'consent',
-    actor: 'app',
   })
+
+  if (input.actor === 'app') {
+    params.set('actor', 'app')
+  }
 
   return `${LINEAR_AUTHORIZATION_URL}?${params.toString()}`
 }

--- a/apps/api/src/lib/linear-oauth.ts
+++ b/apps/api/src/lib/linear-oauth.ts
@@ -1,0 +1,67 @@
+import { decryptSecret, linearIntegrationRepository, type LinearIntegration } from '@durabull/dal'
+import { env } from '@durabull/env'
+import { refreshLinearOauthToken } from './linear-client'
+
+const LINEAR_AUTHORIZATION_URL = 'https://linear.app/oauth/authorize'
+const LINEAR_OAUTH_SCOPE = 'read,issues:create'
+const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000
+
+export function getLinearOauthConfig(): {
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+} {
+  const clientId = env.LINEAR_OAUTH_CLIENT_ID?.trim()
+  const clientSecret = env.LINEAR_OAUTH_CLIENT_SECRET?.trim()
+  if (!clientId || !clientSecret) {
+    throw new Error('LINEAR_OAUTH_CLIENT_ID and LINEAR_OAUTH_CLIENT_SECRET are required.')
+  }
+
+  const redirectUri =
+    env.LINEAR_OAUTH_REDIRECT_URI?.trim() ||
+    `${env.APP_BASE_URL.replace(/\/+$/, '')}/api/alerts/integrations/linear/callback`
+
+  return { clientId, clientSecret, redirectUri }
+}
+
+export function buildLinearOauthAuthorizeUrl(input: {
+  clientId: string
+  redirectUri: string
+  state: string
+}): string {
+  const params = new URLSearchParams({
+    client_id: input.clientId,
+    redirect_uri: input.redirectUri,
+    response_type: 'code',
+    scope: LINEAR_OAUTH_SCOPE,
+    state: input.state,
+    actor: 'app',
+  })
+
+  return `${LINEAR_AUTHORIZATION_URL}?${params.toString()}`
+}
+
+export async function getValidLinearAccessToken(integration: LinearIntegration): Promise<string> {
+  if (integration.accessTokenExpiresAt.getTime() - TOKEN_REFRESH_SKEW_MS > Date.now()) {
+    return decryptSecret(integration.encryptedAccessToken)
+  }
+
+  const { clientId, clientSecret } = getLinearOauthConfig()
+  const token = await refreshLinearOauthToken({
+    refreshToken: decryptSecret(integration.encryptedRefreshToken),
+    clientId,
+    clientSecret,
+  })
+  const refreshed = await linearIntegrationRepository.updateOauthTokens(
+    integration.organizationId,
+    {
+      accessToken: token.accessToken,
+      refreshToken: token.refreshToken,
+      tokenType: token.tokenType,
+      scopes: token.scopes,
+      accessTokenExpiresAt: token.accessTokenExpiresAt,
+    }
+  )
+
+  return decryptSecret(refreshed?.encryptedAccessToken ?? integration.encryptedAccessToken)
+}

--- a/apps/api/src/lib/linear-oauth.ts
+++ b/apps/api/src/lib/linear-oauth.ts
@@ -1,4 +1,4 @@
-import { decryptSecret, linearIntegrationRepository, type LinearIntegration } from '@durabull/dal'
+import { decryptSecret, type LinearIntegration, linearIntegrationRepository } from '@durabull/dal'
 import { env } from '@durabull/env'
 import { refreshLinearOauthToken } from './linear-client'
 
@@ -69,5 +69,5 @@ export async function getValidLinearAccessToken(integration: LinearIntegration):
     }
   )
 
-  return decryptSecret(refreshed?.encryptedAccessToken ?? integration.encryptedAccessToken)
+  return refreshed ? decryptSecret(refreshed.encryptedAccessToken) : token.accessToken
 }

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   alertEventRepository,
   alertRuleRepository,
@@ -335,7 +335,8 @@ describe('global alerts routes', () => {
 
     const response = await app.request('/integrations/linear')
     expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({
+    const body = await response.json()
+    expect(body).toMatchObject({
       integration: {
         connected: true,
         validationStatus: 'valid',
@@ -343,6 +344,12 @@ describe('global alerts routes', () => {
         linearOrganizationName: 'Acme',
       },
     })
+    expect(body.integration).not.toHaveProperty('encryptedAccessToken')
+    expect(body.integration).not.toHaveProperty('encryptedRefreshToken')
+    expect(body.integration).not.toHaveProperty('accessToken')
+    expect(body.integration).not.toHaveProperty('refreshToken')
+    expect(body.integration).not.toHaveProperty('token')
+    expect(body.integration).not.toHaveProperty('secret')
 
     const stored = await linearIntegrationRepository.findByOrganization(TEST_ORG_ID)
     expect(stored?.encryptedAccessToken).not.toContain('linear-access-token')

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -114,11 +114,13 @@ async function seedOrganization() {
   ])
 }
 
-async function createGlobalAlertsRouteApp() {
+async function createGlobalAlertsRouteApp(options: { includeContext?: boolean } = {}) {
   const { default: alertsGlobalRoutes } = await import('./alerts-global')
+  const includeContext = options.includeContext ?? true
+  const app = new Hono()
 
-  return new Hono()
-    .use('*', async (c, next) => {
+  if (includeContext) {
+    app.use('*', async (c, next) => {
       c.set('organizationId', TEST_ORG_ID)
       c.set('user', {
         id: 'user-1',
@@ -130,7 +132,9 @@ async function createGlobalAlertsRouteApp() {
       })
       await next()
     })
-    .route('/', alertsGlobalRoutes)
+  }
+
+  return app.route('/', alertsGlobalRoutes)
 }
 
 describe('global alerts routes', () => {
@@ -340,6 +344,34 @@ describe('global alerts routes', () => {
     expect(stored?.encryptedRefreshToken).not.toContain('linear-refresh-token')
     expect(decryptSecret(stored?.encryptedAccessToken ?? '')).toBe('linear-access-token')
     expect(decryptSecret(stored?.encryptedRefreshToken ?? '')).toBe('linear-refresh-token')
+  })
+
+  it('completes the OAuth callback with only the opaque state when browser session cookies are unavailable', async () => {
+    const app = await createGlobalAlertsRouteApp()
+    const connectResponse = await app.request('/integrations/linear/connect', { method: 'POST' })
+    const connectBody = (await connectResponse.json()) as { authorizationUrl: string }
+    const state = new URL(connectBody.authorizationUrl).searchParams.get('state')
+    expect(state).toBeTruthy()
+
+    const callbackApp = await createGlobalAlertsRouteApp({ includeContext: false })
+    const callbackResponse = await callbackApp.request(
+      `/integrations/linear/callback?code=linear-code&state=${state}`
+    )
+
+    expect(callbackResponse.status).toBe(302)
+    expect(callbackResponse.headers.get('location')).toBe(
+      'https://app.durabull.test/settings?linear=connected'
+    )
+    expect(exchangeLinearOauthCodeMock).toHaveBeenCalledWith({
+      code: 'linear-code',
+      redirectUri: LINEAR_CALLBACK_URL,
+      clientId: 'linear-client-id',
+      clientSecret: 'linear-client-secret',
+    })
+    expect(await linearIntegrationRepository.findByOrganization(TEST_ORG_ID)).toMatchObject({
+      validationStatus: 'valid',
+      linearOrganizationName: 'Acme',
+    })
   })
 
   it('uses the deployment app base URL as the default OAuth callback for cloud and self-hosted installs', async () => {

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -1,12 +1,14 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   alertEventRepository,
   alertRuleRepository,
   closeDb,
+  decryptSecret,
   getDb,
+  linearIntegrationRepository,
   organization,
   redisConnection,
 } from '@durabull/dal'
@@ -19,12 +21,31 @@ const SECOND_CONNECTION_ID = '77777777-7777-4777-8777-777777777777'
 
 const mutableEnv = env as {
   DATABASE_URL?: string
+  DURABULL_SECRET_ENCRYPTION_KEY?: string
 }
 
 const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalSecretKey = mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY
 const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
 
 let tempPgliteDir = ''
+
+const validateLinearApiKeyMock = mock(async () => ({ organizationName: 'Acme' }))
+
+mock.module('../lib/linear-client', () => ({
+  validateLinearApiKey: validateLinearApiKeyMock,
+  fetchLinearMetadata: mock(async () => ({
+    teams: [],
+    projects: [],
+    labels: [],
+    users: [],
+    states: [],
+  })),
+  LinearApiError: class LinearApiError extends Error {
+    status = 400
+    retryable = false
+  },
+}))
 
 async function seedOrganization() {
   const db = await getDb()
@@ -79,6 +100,9 @@ describe('global alerts routes', () => {
     process.env.DURABULL_PGLITE_DIR = tempPgliteDir
     delete process.env.DATABASE_URL
     mutableEnv.DATABASE_URL = undefined
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    validateLinearApiKeyMock.mockClear()
     await closeDb()
     await seedOrganization()
   })
@@ -86,6 +110,7 @@ describe('global alerts routes', () => {
   afterEach(async () => {
     await closeDb()
     mutableEnv.DATABASE_URL = originalDatabaseUrl
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = originalSecretKey
 
     if (originalPgliteDir) {
       process.env.DURABULL_PGLITE_DIR = originalPgliteDir
@@ -212,5 +237,31 @@ describe('global alerts routes', () => {
     expect(await response.json()).toEqual({
       connections: [{ connectionId: FIRST_CONNECTION_ID, count: 2 }],
     })
+  })
+
+  it('stores Linear API keys encrypted and returns only preview metadata', async () => {
+    const app = await createGlobalAlertsRouteApp()
+    const response = await app.request('/integrations/linear', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        apiKey: 'lin_api_super_secret_key',
+        defaultTeamId: 'team-1',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      integration: {
+        keyPreview: 'lin_…_key',
+        validationStatus: 'valid',
+        defaultTeamId: 'team-1',
+      },
+    })
+    expect(validateLinearApiKeyMock).toHaveBeenCalledTimes(1)
+
+    const stored = await linearIntegrationRepository.findByOrganization(TEST_ORG_ID)
+    expect(stored?.encryptedApiKey).not.toContain('lin_api_super_secret_key')
+    expect(decryptSecret(stored?.encryptedApiKey ?? '')).toBe('lin_api_super_secret_key')
   })
 })

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -9,6 +9,7 @@ import {
   decryptSecret,
   getDb,
   linearIntegrationRepository,
+  linearOauthStateRepository,
   organization,
   redisConnection,
 } from '@durabull/dal'
@@ -18,6 +19,7 @@ import { Hono } from 'hono'
 const TEST_ORG_ID = 'alert-global-org'
 const FIRST_CONNECTION_ID = '66666666-6666-4666-8666-666666666666'
 const SECOND_CONNECTION_ID = '77777777-7777-4777-8777-777777777777'
+const LINEAR_CALLBACK_URL = 'https://app.durabull.test/api/alerts/integrations/linear/callback'
 
 const mutableEnv = env as {
   DATABASE_URL?: string
@@ -141,8 +143,7 @@ describe('global alerts routes', () => {
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
     mutableEnv.LINEAR_OAUTH_CLIENT_ID = 'linear-client-id'
     mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = 'linear-client-secret'
-    mutableEnv.LINEAR_OAUTH_REDIRECT_URI =
-      'https://app.durabull.test/api/alerts/integrations/linear/callback'
+    mutableEnv.LINEAR_OAUTH_REDIRECT_URI = LINEAR_CALLBACK_URL
     mutableEnv.APP_BASE_URL = 'https://app.durabull.test'
     exchangeLinearOauthCodeMock.mockClear()
     validateLinearAccessTokenMock.mockClear()
@@ -300,10 +301,10 @@ describe('global alerts routes', () => {
       'https://linear.app/oauth/authorize'
     )
     expect(authorizeUrl.searchParams.get('client_id')).toBe('linear-client-id')
-    expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(
-      'https://app.durabull.test/api/alerts/integrations/linear/callback'
-    )
+    expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(LINEAR_CALLBACK_URL)
     expect(authorizeUrl.searchParams.get('scope')).toBe('read,issues:create')
+    expect(authorizeUrl.searchParams.get('response_type')).toBe('code')
+    expect(authorizeUrl.searchParams.get('actor')).toBe('app')
 
     const state = authorizeUrl.searchParams.get('state')
     expect(state).toBeTruthy()
@@ -317,7 +318,7 @@ describe('global alerts routes', () => {
     )
     expect(exchangeLinearOauthCodeMock).toHaveBeenCalledWith({
       code: 'linear-code',
-      redirectUri: 'https://app.durabull.test/api/alerts/integrations/linear/callback',
+      redirectUri: LINEAR_CALLBACK_URL,
       clientId: 'linear-client-id',
       clientSecret: 'linear-client-secret',
     })
@@ -339,5 +340,148 @@ describe('global alerts routes', () => {
     expect(stored?.encryptedRefreshToken).not.toContain('linear-refresh-token')
     expect(decryptSecret(stored?.encryptedAccessToken ?? '')).toBe('linear-access-token')
     expect(decryptSecret(stored?.encryptedRefreshToken ?? '')).toBe('linear-refresh-token')
+  })
+
+  it('uses the deployment app base URL as the default OAuth callback for cloud and self-hosted installs', async () => {
+    mutableEnv.LINEAR_OAUTH_REDIRECT_URI = undefined
+    mutableEnv.APP_BASE_URL = 'https://self-hosted.example.com///'
+
+    const app = await createGlobalAlertsRouteApp()
+    const response = await app.request('/integrations/linear/connect', { method: 'POST' })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { authorizationUrl: string }
+    const authorizeUrl = new URL(body.authorizationUrl)
+    expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(
+      'https://self-hosted.example.com/api/alerts/integrations/linear/callback'
+    )
+  })
+
+  it('rejects OAuth callbacks with an invalid state before exchanging the authorization code', async () => {
+    const app = await createGlobalAlertsRouteApp()
+    const connectResponse = await app.request('/integrations/linear/connect', { method: 'POST' })
+    const { authorizationUrl } = (await connectResponse.json()) as { authorizationUrl: string }
+    const state = new URL(authorizationUrl).searchParams.get('state')
+
+    const invalidResponse = await app.request(
+      '/integrations/linear/callback?code=linear-code&state=attacker-state'
+    )
+    expect(invalidResponse.status).toBe(400)
+    expect(exchangeLinearOauthCodeMock).not.toHaveBeenCalled()
+
+    const validResponse = await app.request(
+      `/integrations/linear/callback?code=linear-code&state=${state}`
+    )
+    expect(validResponse.status).toBe(302)
+    expect(exchangeLinearOauthCodeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not allow replaying a consumed OAuth state', async () => {
+    const app = await createGlobalAlertsRouteApp()
+    const connectResponse = await app.request('/integrations/linear/connect', { method: 'POST' })
+    const { authorizationUrl } = (await connectResponse.json()) as { authorizationUrl: string }
+    const state = new URL(authorizationUrl).searchParams.get('state')
+
+    const firstResponse = await app.request(
+      `/integrations/linear/callback?code=linear-code&state=${state}`
+    )
+    const replayResponse = await app.request(
+      `/integrations/linear/callback?code=linear-code&state=${state}`
+    )
+
+    expect(firstResponse.status).toBe(302)
+    expect(replayResponse.status).toBe(400)
+    expect(exchangeLinearOauthCodeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects expired OAuth state records', async () => {
+    const app = await createGlobalAlertsRouteApp()
+    await linearOauthStateRepository.create({
+      organizationId: TEST_ORG_ID,
+      userId: 'user-1',
+      state: 'expired-state',
+      redirectUri: LINEAR_CALLBACK_URL,
+      expiresAt: new Date(Date.now() - 1_000),
+    })
+
+    const response = await app.request(
+      '/integrations/linear/callback?code=linear-code&state=expired-state'
+    )
+
+    expect(response.status).toBe(400)
+    expect(exchangeLinearOauthCodeMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a setup error when Linear OAuth client credentials are missing', async () => {
+    mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = undefined
+
+    const app = await createGlobalAlertsRouteApp()
+    const response = await app.request('/integrations/linear/connect', { method: 'POST' })
+
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({
+      error: 'LINEAR_OAUTH_CLIENT_ID and LINEAR_OAUTH_CLIENT_SECRET are required.',
+    })
+  })
+
+  it('refreshes expired access tokens before fetching Linear metadata and persists rotated tokens', async () => {
+    await linearIntegrationRepository.upsertOauth({
+      organizationId: TEST_ORG_ID,
+      accessToken: 'expired-linear-access-token',
+      refreshToken: 'old-linear-refresh-token',
+      tokenType: 'Bearer',
+      scopes: 'read issues:create',
+      accessTokenExpiresAt: new Date(Date.now() - 60_000),
+      validationStatus: 'valid',
+      lastValidatedAt: new Date(),
+    })
+
+    const app = await createGlobalAlertsRouteApp()
+    const response = await app.request('/integrations/linear/metadata')
+
+    expect(response.status).toBe(200)
+    expect(refreshLinearOauthTokenMock).toHaveBeenCalledWith({
+      refreshToken: 'old-linear-refresh-token',
+      clientId: 'linear-client-id',
+      clientSecret: 'linear-client-secret',
+    })
+    expect(fetchLinearMetadataMock).toHaveBeenCalledWith('refreshed-linear-access-token')
+
+    const stored = await linearIntegrationRepository.findByOrganization(TEST_ORG_ID)
+    expect(decryptSecret(stored?.encryptedAccessToken ?? '')).toBe('refreshed-linear-access-token')
+    expect(decryptSecret(stored?.encryptedRefreshToken ?? '')).toBe(
+      'refreshed-linear-refresh-token'
+    )
+  })
+
+  it('revokes stored OAuth tokens on disconnect without exposing token values', async () => {
+    await linearIntegrationRepository.upsertOauth({
+      organizationId: TEST_ORG_ID,
+      accessToken: 'linear-access-token-to-revoke',
+      refreshToken: 'linear-refresh-token-to-revoke',
+      tokenType: 'Bearer',
+      scopes: 'read issues:create',
+      accessTokenExpiresAt: new Date(Date.now() + 60 * 60_000),
+      validationStatus: 'valid',
+      lastValidatedAt: new Date(),
+    })
+
+    const app = await createGlobalAlertsRouteApp()
+    const response = await app.request('/integrations/linear', { method: 'DELETE' })
+
+    expect(response.status).toBe(200)
+    expect(revokeLinearOauthTokenMock).toHaveBeenCalledWith({
+      token: 'linear-refresh-token-to-revoke',
+      tokenTypeHint: 'refresh_token',
+      clientId: 'linear-client-id',
+      clientSecret: 'linear-client-secret',
+    })
+    expect(revokeLinearOauthTokenMock).toHaveBeenCalledWith({
+      token: 'linear-access-token-to-revoke',
+      tokenTypeHint: 'access_token',
+      clientId: 'linear-client-id',
+      clientSecret: 'linear-client-secret',
+    })
+    expect(await linearIntegrationRepository.findByOrganization(TEST_ORG_ID)).toBeNull()
   })
 })

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -27,6 +27,7 @@ const mutableEnv = env as {
   LINEAR_OAUTH_CLIENT_ID?: string
   LINEAR_OAUTH_CLIENT_SECRET?: string
   LINEAR_OAUTH_REDIRECT_URI?: string
+  LINEAR_OAUTH_ACTOR: 'user' | 'app'
   APP_BASE_URL: string
 }
 
@@ -35,6 +36,7 @@ const originalSecretKey = mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY
 const originalLinearClientId = mutableEnv.LINEAR_OAUTH_CLIENT_ID
 const originalLinearClientSecret = mutableEnv.LINEAR_OAUTH_CLIENT_SECRET
 const originalLinearRedirectUri = mutableEnv.LINEAR_OAUTH_REDIRECT_URI
+const originalLinearActor = mutableEnv.LINEAR_OAUTH_ACTOR
 const originalAppBaseUrl = mutableEnv.APP_BASE_URL
 const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
 
@@ -148,6 +150,7 @@ describe('global alerts routes', () => {
     mutableEnv.LINEAR_OAUTH_CLIENT_ID = 'linear-client-id'
     mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = 'linear-client-secret'
     mutableEnv.LINEAR_OAUTH_REDIRECT_URI = LINEAR_CALLBACK_URL
+    mutableEnv.LINEAR_OAUTH_ACTOR = 'user'
     mutableEnv.APP_BASE_URL = 'https://app.durabull.test'
     exchangeLinearOauthCodeMock.mockClear()
     validateLinearAccessTokenMock.mockClear()
@@ -165,6 +168,7 @@ describe('global alerts routes', () => {
     mutableEnv.LINEAR_OAUTH_CLIENT_ID = originalLinearClientId
     mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = originalLinearClientSecret
     mutableEnv.LINEAR_OAUTH_REDIRECT_URI = originalLinearRedirectUri
+    mutableEnv.LINEAR_OAUTH_ACTOR = originalLinearActor
     mutableEnv.APP_BASE_URL = originalAppBaseUrl
 
     if (originalPgliteDir) {
@@ -309,7 +313,7 @@ describe('global alerts routes', () => {
     expect(authorizeUrl.searchParams.get('scope')).toBe('read,issues:create')
     expect(authorizeUrl.searchParams.get('response_type')).toBe('code')
     expect(authorizeUrl.searchParams.get('prompt')).toBe('consent')
-    expect(authorizeUrl.searchParams.get('actor')).toBe('app')
+    expect(authorizeUrl.searchParams.has('actor')).toBe(false)
 
     const state = authorizeUrl.searchParams.get('state')
     expect(state).toBeTruthy()
@@ -388,6 +392,18 @@ describe('global alerts routes', () => {
     expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(
       'https://self-hosted.example.com/api/alerts/integrations/linear/callback'
     )
+  })
+
+  it('only sends Linear app actor authorization when explicitly configured', async () => {
+    mutableEnv.LINEAR_OAUTH_ACTOR = 'app'
+
+    const app = await createGlobalAlertsRouteApp()
+    const response = await app.request('/integrations/linear/connect', { method: 'POST' })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { authorizationUrl: string }
+    const authorizeUrl = new URL(body.authorizationUrl)
+    expect(authorizeUrl.searchParams.get('actor')).toBe('app')
   })
 
   it('rejects OAuth callbacks with an invalid state before exchanging the authorization code', async () => {

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -308,6 +308,7 @@ describe('global alerts routes', () => {
     expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(LINEAR_CALLBACK_URL)
     expect(authorizeUrl.searchParams.get('scope')).toBe('read,issues:create')
     expect(authorizeUrl.searchParams.get('response_type')).toBe('code')
+    expect(authorizeUrl.searchParams.get('prompt')).toBe('consent')
     expect(authorizeUrl.searchParams.get('actor')).toBe('app')
 
     const state = authorizeUrl.searchParams.get('state')

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -22,25 +22,54 @@ const SECOND_CONNECTION_ID = '77777777-7777-4777-8777-777777777777'
 const mutableEnv = env as {
   DATABASE_URL?: string
   DURABULL_SECRET_ENCRYPTION_KEY?: string
+  LINEAR_OAUTH_CLIENT_ID?: string
+  LINEAR_OAUTH_CLIENT_SECRET?: string
+  LINEAR_OAUTH_REDIRECT_URI?: string
+  APP_BASE_URL: string
 }
 
 const originalDatabaseUrl = mutableEnv.DATABASE_URL
 const originalSecretKey = mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY
+const originalLinearClientId = mutableEnv.LINEAR_OAUTH_CLIENT_ID
+const originalLinearClientSecret = mutableEnv.LINEAR_OAUTH_CLIENT_SECRET
+const originalLinearRedirectUri = mutableEnv.LINEAR_OAUTH_REDIRECT_URI
+const originalAppBaseUrl = mutableEnv.APP_BASE_URL
 const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
 
 let tempPgliteDir = ''
 
-const validateLinearApiKeyMock = mock(async () => ({ organizationName: 'Acme' }))
+const exchangeLinearOauthCodeMock = mock(async () => ({
+  accessToken: 'linear-access-token',
+  refreshToken: 'linear-refresh-token',
+  tokenType: 'Bearer',
+  expiresIn: 86_399,
+  scopes: 'read issues:create',
+  accessTokenExpiresAt: new Date(Date.now() + 60 * 60_000),
+}))
+const validateLinearAccessTokenMock = mock(async () => ({ organizationName: 'Acme' }))
+const fetchLinearMetadataMock = mock(async () => ({
+  teams: [],
+  projects: [],
+  labels: [],
+  users: [],
+  states: [],
+}))
+const revokeLinearOauthTokenMock = mock(async () => undefined)
+const refreshLinearOauthTokenMock = mock(async () => ({
+  accessToken: 'refreshed-linear-access-token',
+  refreshToken: 'refreshed-linear-refresh-token',
+  tokenType: 'Bearer',
+  expiresIn: 86_399,
+  scopes: 'read issues:create',
+  accessTokenExpiresAt: new Date(Date.now() + 60 * 60_000),
+}))
 
 mock.module('../lib/linear-client', () => ({
-  validateLinearApiKey: validateLinearApiKeyMock,
-  fetchLinearMetadata: mock(async () => ({
-    teams: [],
-    projects: [],
-    labels: [],
-    users: [],
-    states: [],
-  })),
+  exchangeLinearOauthCode: exchangeLinearOauthCodeMock,
+  validateLinearAccessToken: validateLinearAccessTokenMock,
+  fetchLinearMetadata: fetchLinearMetadataMock,
+  revokeLinearOauthToken: revokeLinearOauthTokenMock,
+  refreshLinearOauthToken: refreshLinearOauthTokenMock,
   LinearApiError: class LinearApiError extends Error {
     status = 400
     retryable = false
@@ -89,6 +118,14 @@ async function createGlobalAlertsRouteApp() {
   return new Hono()
     .use('*', async (c, next) => {
       c.set('organizationId', TEST_ORG_ID)
+      c.set('user', {
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'Test User',
+        emailVerified: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
       await next()
     })
     .route('/', alertsGlobalRoutes)
@@ -102,7 +139,16 @@ describe('global alerts routes', () => {
     mutableEnv.DATABASE_URL = undefined
     mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY =
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-    validateLinearApiKeyMock.mockClear()
+    mutableEnv.LINEAR_OAUTH_CLIENT_ID = 'linear-client-id'
+    mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = 'linear-client-secret'
+    mutableEnv.LINEAR_OAUTH_REDIRECT_URI =
+      'https://app.durabull.test/api/alerts/integrations/linear/callback'
+    mutableEnv.APP_BASE_URL = 'https://app.durabull.test'
+    exchangeLinearOauthCodeMock.mockClear()
+    validateLinearAccessTokenMock.mockClear()
+    fetchLinearMetadataMock.mockClear()
+    revokeLinearOauthTokenMock.mockClear()
+    refreshLinearOauthTokenMock.mockClear()
     await closeDb()
     await seedOrganization()
   })
@@ -111,6 +157,10 @@ describe('global alerts routes', () => {
     await closeDb()
     mutableEnv.DATABASE_URL = originalDatabaseUrl
     mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = originalSecretKey
+    mutableEnv.LINEAR_OAUTH_CLIENT_ID = originalLinearClientId
+    mutableEnv.LINEAR_OAUTH_CLIENT_SECRET = originalLinearClientSecret
+    mutableEnv.LINEAR_OAUTH_REDIRECT_URI = originalLinearRedirectUri
+    mutableEnv.APP_BASE_URL = originalAppBaseUrl
 
     if (originalPgliteDir) {
       process.env.DURABULL_PGLITE_DIR = originalPgliteDir
@@ -239,29 +289,55 @@ describe('global alerts routes', () => {
     })
   })
 
-  it('stores Linear API keys encrypted and returns only preview metadata', async () => {
+  it('stores Linear OAuth tokens encrypted and returns only connection metadata', async () => {
     const app = await createGlobalAlertsRouteApp()
-    const response = await app.request('/integrations/linear', {
-      method: 'PUT',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        apiKey: 'lin_api_super_secret_key',
-        defaultTeamId: 'team-1',
-      }),
-    })
+    const connectResponse = await app.request('/integrations/linear/connect', { method: 'POST' })
 
+    expect(connectResponse.status).toBe(200)
+    const connectBody = (await connectResponse.json()) as { authorizationUrl: string }
+    const authorizeUrl = new URL(connectBody.authorizationUrl)
+    expect(`${authorizeUrl.origin}${authorizeUrl.pathname}`).toBe(
+      'https://linear.app/oauth/authorize'
+    )
+    expect(authorizeUrl.searchParams.get('client_id')).toBe('linear-client-id')
+    expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(
+      'https://app.durabull.test/api/alerts/integrations/linear/callback'
+    )
+    expect(authorizeUrl.searchParams.get('scope')).toBe('read,issues:create')
+
+    const state = authorizeUrl.searchParams.get('state')
+    expect(state).toBeTruthy()
+
+    const callbackResponse = await app.request(
+      `/integrations/linear/callback?code=linear-code&state=${state}`
+    )
+    expect(callbackResponse.status).toBe(302)
+    expect(callbackResponse.headers.get('location')).toBe(
+      'https://app.durabull.test/settings?linear=connected'
+    )
+    expect(exchangeLinearOauthCodeMock).toHaveBeenCalledWith({
+      code: 'linear-code',
+      redirectUri: 'https://app.durabull.test/api/alerts/integrations/linear/callback',
+      clientId: 'linear-client-id',
+      clientSecret: 'linear-client-secret',
+    })
+    expect(validateLinearAccessTokenMock).toHaveBeenCalledWith('linear-access-token')
+
+    const response = await app.request('/integrations/linear')
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject({
       integration: {
-        keyPreview: 'lin_…_key',
+        connected: true,
         validationStatus: 'valid',
-        defaultTeamId: 'team-1',
+        scopes: 'read issues:create',
+        linearOrganizationName: 'Acme',
       },
     })
-    expect(validateLinearApiKeyMock).toHaveBeenCalledTimes(1)
 
     const stored = await linearIntegrationRepository.findByOrganization(TEST_ORG_ID)
-    expect(stored?.encryptedApiKey).not.toContain('lin_api_super_secret_key')
-    expect(decryptSecret(stored?.encryptedApiKey ?? '')).toBe('lin_api_super_secret_key')
+    expect(stored?.encryptedAccessToken).not.toContain('linear-access-token')
+    expect(stored?.encryptedRefreshToken).not.toContain('linear-refresh-token')
+    expect(decryptSecret(stored?.encryptedAccessToken ?? '')).toBe('linear-access-token')
+    expect(decryptSecret(stored?.encryptedRefreshToken ?? '')).toBe('linear-refresh-token')
   })
 })

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -141,12 +141,14 @@ const app = new Hono()
     })
 
     if (env.NODE_ENV !== 'production') {
+      const safeAuthorizationUrl = new URL(authorizationUrl)
+      safeAuthorizationUrl.search = ''
       console.info('[linear-oauth] starting authorization', {
         organizationId,
         userId: user.id,
         redirectUri: config.redirectUri,
         actor: config.actor,
-        authorizationUrl,
+        authorizationUrl: safeAuthorizationUrl.toString(),
       })
     }
 

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import {
   alertDeliveryRepository,
   alertEventRepository,
@@ -7,8 +8,7 @@ import {
 } from '@durabull/dal'
 import { env } from '@durabull/env'
 import { zValidator } from '@hono/zod-validator'
-import { randomBytes } from 'node:crypto'
-import { Hono, type Context } from 'hono'
+import { type Context, Hono } from 'hono'
 import { z } from 'zod'
 import {
   exchangeLinearOauthCode,
@@ -257,9 +257,14 @@ const app = new Hono()
       await linearIntegrationRepository.markValidationStatus(organizationId, 'valid')
       return c.json({ ok: true, organizationName: result.organizationName })
     } catch (error) {
-      await linearIntegrationRepository.markValidationStatus(organizationId, 'invalid')
       if (error instanceof LinearApiError) {
-        return c.json({ error: error.message }, error.status === 401 ? 401 : 400)
+        if (!error.retryable) {
+          await linearIntegrationRepository.markValidationStatus(organizationId, 'invalid')
+        }
+        return c.json(
+          { error: error.message },
+          error.retryable ? 503 : error.status === 401 ? 401 : 400
+        )
       }
       throw error
     }

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -137,6 +137,7 @@ const app = new Hono()
       clientId: config.clientId,
       redirectUri: config.redirectUri,
       state,
+      actor: config.actor,
     })
 
     if (env.NODE_ENV !== 'production') {
@@ -144,6 +145,7 @@ const app = new Hono()
         organizationId,
         userId: user.id,
         redirectUri: config.redirectUri,
+        actor: config.actor,
         authorizationUrl,
       })
     }

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -1,8 +1,27 @@
-import { alertEventRepository } from '@durabull/dal'
+import {
+  alertDeliveryRepository,
+  alertEventRepository,
+  decryptSecret,
+  linearIntegrationRepository,
+} from '@durabull/dal'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { fetchLinearMetadata, LinearApiError, validateLinearApiKey } from '../lib/linear-client'
 import { requireOrganization } from '../middleware/auth'
+
+const linearDefaultsSchema = z.object({
+  defaultTeamId: z.string().min(1).nullable().optional(),
+  defaultProjectId: z.string().min(1).nullable().optional(),
+  defaultLabelIds: z.array(z.string().min(1)).max(50).optional().default([]),
+  defaultAssigneeId: z.string().min(1).nullable().optional(),
+  defaultStateId: z.string().min(1).nullable().optional(),
+  defaultPriority: z.number().int().min(0).max(4).nullable().optional(),
+})
+
+const putLinearIntegrationSchema = linearDefaultsSchema.extend({
+  apiKey: z.string().min(20).optional(),
+})
 
 const app = new Hono()
   .use('*', requireOrganization)
@@ -28,7 +47,7 @@ const app = new Hono()
         limit,
         status,
       })
-      return c.json({ events })
+      return c.json({ events: await attachDeliveries(events) })
     }
   )
   .get('/summary', async (c) => {
@@ -40,5 +59,148 @@ const app = new Hono()
     const counts = await alertEventRepository.countFiringByOrganization(organizationId)
     return c.json({ connections: counts })
   })
+  .get('/integrations/linear', async (c) => {
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const integration = await linearIntegrationRepository.findByOrganization(organizationId)
+    return c.json({ integration: integration ? serializeLinearIntegration(integration) : null })
+  })
+  .put('/integrations/linear', zValidator('json', putLinearIntegrationSchema), async (c) => {
+    const body = c.req.valid('json')
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const existing = await linearIntegrationRepository.findByOrganization(organizationId)
+    if (!existing && !body.apiKey) {
+      return c.json({ error: 'Linear API key is required.' }, 400)
+    }
+
+    try {
+      let integration = existing
+      if (body.apiKey) {
+        await validateLinearApiKey(body.apiKey)
+        integration = await linearIntegrationRepository.upsert({
+          organizationId,
+          apiKey: body.apiKey,
+          validationStatus: 'valid',
+          lastValidatedAt: new Date(),
+          ...normalizeLinearDefaults(body),
+        })
+      } else if (existing) {
+        integration = await linearIntegrationRepository.updateDefaults(organizationId, {
+          validationStatus: existing.validationStatus,
+          lastValidatedAt: existing.lastValidatedAt,
+          ...normalizeLinearDefaults(body),
+        })
+      }
+
+      return c.json({ integration: integration ? serializeLinearIntegration(integration) : null })
+    } catch (error) {
+      if (error instanceof LinearApiError) {
+        return c.json({ error: error.message }, error.status === 401 ? 401 : 400)
+      }
+      throw error
+    }
+  })
+  .delete('/integrations/linear', async (c) => {
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    await linearIntegrationRepository.delete(organizationId)
+    return c.json({ success: true })
+  })
+  .post('/integrations/linear/test', async (c) => {
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const integration = await linearIntegrationRepository.findByOrganization(organizationId)
+    if (!integration) {
+      return c.json({ error: 'Linear integration is not configured.' }, 404)
+    }
+
+    try {
+      const result = await validateLinearApiKey(decryptSecret(integration.encryptedApiKey))
+      await linearIntegrationRepository.markValidationStatus(organizationId, 'valid')
+      return c.json({ ok: true, organizationName: result.organizationName })
+    } catch (error) {
+      await linearIntegrationRepository.markValidationStatus(organizationId, 'invalid')
+      if (error instanceof LinearApiError) {
+        return c.json({ error: error.message }, error.status === 401 ? 401 : 400)
+      }
+      throw error
+    }
+  })
+  .get('/integrations/linear/metadata', async (c) => {
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const integration = await linearIntegrationRepository.findByOrganization(organizationId)
+    if (!integration || integration.validationStatus !== 'valid') {
+      return c.json({ error: 'Linear integration is not configured or valid.' }, 400)
+    }
+
+    try {
+      const metadata = await fetchLinearMetadata(decryptSecret(integration.encryptedApiKey))
+      return c.json({ metadata })
+    } catch (error) {
+      if (error instanceof LinearApiError) {
+        return c.json({ error: error.message }, error.retryable ? 503 : 400)
+      }
+      throw error
+    }
+  })
+
+function normalizeLinearDefaults(body: z.infer<typeof linearDefaultsSchema>) {
+  return {
+    defaultTeamId: body.defaultTeamId ?? null,
+    defaultProjectId: body.defaultProjectId ?? null,
+    defaultLabelIds: body.defaultLabelIds ?? [],
+    defaultAssigneeId: body.defaultAssigneeId ?? null,
+    defaultStateId: body.defaultStateId ?? null,
+    defaultPriority: body.defaultPriority ?? null,
+  }
+}
+
+async function attachDeliveries<T extends { id: string }>(events: T[]) {
+  return Promise.all(
+    events.map(async (event) => ({
+      ...event,
+      deliveries: await alertDeliveryRepository.listByEvent(event.id),
+    }))
+  )
+}
+
+function serializeLinearIntegration(
+  integration: NonNullable<
+    Awaited<ReturnType<typeof linearIntegrationRepository.findByOrganization>>
+  >
+) {
+  return {
+    id: integration.id,
+    organizationId: integration.organizationId,
+    keyPreview: integration.keyPreview,
+    validationStatus: integration.validationStatus,
+    defaultTeamId: integration.defaultTeamId,
+    defaultProjectId: integration.defaultProjectId,
+    defaultLabelIds: integration.defaultLabelIds,
+    defaultAssigneeId: integration.defaultAssigneeId,
+    defaultStateId: integration.defaultStateId,
+    defaultPriority: integration.defaultPriority,
+    lastValidatedAt: integration.lastValidatedAt,
+    createdAt: integration.createdAt,
+    updatedAt: integration.updatedAt,
+  }
+}
 
 export default app

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -52,7 +52,14 @@ type LinearDefaultsInput = {
 }
 
 const app = new Hono()
-  .use('*', requireOrganization)
+  .use('*', async (c, next) => {
+    if (c.req.path.endsWith('/integrations/linear/callback')) {
+      await next()
+      return
+    }
+
+    return requireOrganization(c, next)
+  })
   .get(
     '/events',
     zValidator(
@@ -139,14 +146,6 @@ const app = new Hono()
     zValidator('query', linearOauthCallbackSchema),
     async (c) => {
       const query = c.req.valid('query')
-      const organizationId = c.get('organizationId')
-      const user = c.get('user')
-      if (!organizationId) {
-        return c.json({ error: 'Organization is required' }, 403)
-      }
-      if (!user) {
-        return c.json({ error: 'User is required' }, 401)
-      }
       if (query.error) {
         return redirectToSettings(c, {
           linear: 'error',
@@ -157,11 +156,7 @@ const app = new Hono()
         return c.json({ error: 'Linear OAuth callback is missing code or state.' }, 400)
       }
 
-      const oauthState = await linearOauthStateRepository.consume({
-        organizationId,
-        userId: user.id,
-        state: query.state,
-      })
+      const oauthState = await linearOauthStateRepository.consumeByState(query.state)
       if (!oauthState) {
         return c.json({ error: 'Linear OAuth state is invalid or expired.' }, 400)
       }
@@ -175,10 +170,12 @@ const app = new Hono()
           clientSecret,
         })
         const validation = await validateLinearAccessToken(token.accessToken)
-        const existing = await linearIntegrationRepository.findByOrganization(organizationId)
+        const existing = await linearIntegrationRepository.findByOrganization(
+          oauthState.organizationId
+        )
 
         await linearIntegrationRepository.upsertOauth({
-          organizationId,
+          organizationId: oauthState.organizationId,
           accessToken: token.accessToken,
           refreshToken: token.refreshToken,
           tokenType: token.tokenType,

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -133,13 +133,22 @@ const app = new Hono()
       expiresAt: new Date(Date.now() + 10 * 60_000),
     })
 
-    return c.json({
-      authorizationUrl: buildLinearOauthAuthorizeUrl({
-        clientId: config.clientId,
-        redirectUri: config.redirectUri,
-        state,
-      }),
+    const authorizationUrl = buildLinearOauthAuthorizeUrl({
+      clientId: config.clientId,
+      redirectUri: config.redirectUri,
+      state,
     })
+
+    if (env.NODE_ENV !== 'production') {
+      console.info('[linear-oauth] starting authorization', {
+        organizationId,
+        userId: user.id,
+        redirectUri: config.redirectUri,
+        authorizationUrl,
+      })
+    }
+
+    return c.json({ authorizationUrl })
   })
   .get(
     '/integrations/linear/callback',

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -3,11 +3,25 @@ import {
   alertEventRepository,
   decryptSecret,
   linearIntegrationRepository,
+  linearOauthStateRepository,
 } from '@durabull/dal'
+import { env } from '@durabull/env'
 import { zValidator } from '@hono/zod-validator'
-import { Hono } from 'hono'
+import { randomBytes } from 'node:crypto'
+import { Hono, type Context } from 'hono'
 import { z } from 'zod'
-import { fetchLinearMetadata, LinearApiError, validateLinearApiKey } from '../lib/linear-client'
+import {
+  exchangeLinearOauthCode,
+  fetchLinearMetadata,
+  LinearApiError,
+  revokeLinearOauthToken,
+  validateLinearAccessToken,
+} from '../lib/linear-client'
+import {
+  buildLinearOauthAuthorizeUrl,
+  getLinearOauthConfig,
+  getValidLinearAccessToken,
+} from '../lib/linear-oauth'
 import { requireOrganization } from '../middleware/auth'
 
 const linearDefaultsSchema = z.object({
@@ -19,9 +33,23 @@ const linearDefaultsSchema = z.object({
   defaultPriority: z.number().int().min(0).max(4).nullable().optional(),
 })
 
-const putLinearIntegrationSchema = linearDefaultsSchema.extend({
-  apiKey: z.string().min(20).optional(),
+const putLinearIntegrationSchema = linearDefaultsSchema
+
+const linearOauthCallbackSchema = z.object({
+  code: z.string().min(1).optional(),
+  state: z.string().min(1).optional(),
+  error: z.string().min(1).optional(),
+  error_description: z.string().min(1).optional(),
 })
+
+type LinearDefaultsInput = {
+  defaultTeamId?: string | null
+  defaultProjectId?: string | null
+  defaultLabelIds?: string[]
+  defaultAssigneeId?: string | null
+  defaultStateId?: string | null
+  defaultPriority?: number | null
+}
 
 const app = new Hono()
   .use('*', requireOrganization)
@@ -68,6 +96,109 @@ const app = new Hono()
     const integration = await linearIntegrationRepository.findByOrganization(organizationId)
     return c.json({ integration: integration ? serializeLinearIntegration(integration) : null })
   })
+  .post('/integrations/linear/connect', async (c) => {
+    const organizationId = c.get('organizationId')
+    const user = c.get('user')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+    if (!user) {
+      return c.json({ error: 'User is required' }, 401)
+    }
+
+    let config: ReturnType<typeof getLinearOauthConfig>
+    try {
+      config = getLinearOauthConfig()
+    } catch (error) {
+      return c.json(
+        { error: error instanceof Error ? error.message : 'Linear OAuth is not configured.' },
+        503
+      )
+    }
+
+    await linearOauthStateRepository.deleteExpired()
+    const state = randomBytes(32).toString('base64url')
+    await linearOauthStateRepository.create({
+      organizationId,
+      userId: user.id,
+      state,
+      redirectUri: config.redirectUri,
+      expiresAt: new Date(Date.now() + 10 * 60_000),
+    })
+
+    return c.json({
+      authorizationUrl: buildLinearOauthAuthorizeUrl({
+        clientId: config.clientId,
+        redirectUri: config.redirectUri,
+        state,
+      }),
+    })
+  })
+  .get(
+    '/integrations/linear/callback',
+    zValidator('query', linearOauthCallbackSchema),
+    async (c) => {
+      const query = c.req.valid('query')
+      const organizationId = c.get('organizationId')
+      const user = c.get('user')
+      if (!organizationId) {
+        return c.json({ error: 'Organization is required' }, 403)
+      }
+      if (!user) {
+        return c.json({ error: 'User is required' }, 401)
+      }
+      if (query.error) {
+        return redirectToSettings(c, {
+          linear: 'error',
+          message: query.error_description ?? query.error,
+        })
+      }
+      if (!query.code || !query.state) {
+        return c.json({ error: 'Linear OAuth callback is missing code or state.' }, 400)
+      }
+
+      const oauthState = await linearOauthStateRepository.consume({
+        organizationId,
+        userId: user.id,
+        state: query.state,
+      })
+      if (!oauthState) {
+        return c.json({ error: 'Linear OAuth state is invalid or expired.' }, 400)
+      }
+
+      try {
+        const { clientId, clientSecret } = getLinearOauthConfig()
+        const token = await exchangeLinearOauthCode({
+          code: query.code,
+          redirectUri: oauthState.redirectUri,
+          clientId,
+          clientSecret,
+        })
+        const validation = await validateLinearAccessToken(token.accessToken)
+        const existing = await linearIntegrationRepository.findByOrganization(organizationId)
+
+        await linearIntegrationRepository.upsertOauth({
+          organizationId,
+          accessToken: token.accessToken,
+          refreshToken: token.refreshToken,
+          tokenType: token.tokenType,
+          scopes: token.scopes,
+          accessTokenExpiresAt: token.accessTokenExpiresAt,
+          linearOrganizationName: validation.organizationName,
+          validationStatus: 'valid',
+          lastValidatedAt: new Date(),
+          ...normalizeLinearDefaults(existing ?? {}),
+        })
+
+        return redirectToSettings(c, { linear: 'connected' })
+      } catch (error) {
+        if (error instanceof LinearApiError) {
+          return redirectToSettings(c, { linear: 'error', message: error.message })
+        }
+        throw error
+      }
+    }
+  )
   .put('/integrations/linear', zValidator('json', putLinearIntegrationSchema), async (c) => {
     const body = c.req.valid('json')
     const organizationId = c.get('organizationId')
@@ -76,36 +207,17 @@ const app = new Hono()
     }
 
     const existing = await linearIntegrationRepository.findByOrganization(organizationId)
-    if (!existing && !body.apiKey) {
-      return c.json({ error: 'Linear API key is required.' }, 400)
+    if (!existing) {
+      return c.json({ error: 'Linear integration is not configured.' }, 404)
     }
 
-    try {
-      let integration = existing
-      if (body.apiKey) {
-        await validateLinearApiKey(body.apiKey)
-        integration = await linearIntegrationRepository.upsert({
-          organizationId,
-          apiKey: body.apiKey,
-          validationStatus: 'valid',
-          lastValidatedAt: new Date(),
-          ...normalizeLinearDefaults(body),
-        })
-      } else if (existing) {
-        integration = await linearIntegrationRepository.updateDefaults(organizationId, {
-          validationStatus: existing.validationStatus,
-          lastValidatedAt: existing.lastValidatedAt,
-          ...normalizeLinearDefaults(body),
-        })
-      }
+    const integration = await linearIntegrationRepository.updateDefaults(organizationId, {
+      validationStatus: existing.validationStatus,
+      lastValidatedAt: existing.lastValidatedAt,
+      ...normalizeLinearDefaults(body),
+    })
 
-      return c.json({ integration: integration ? serializeLinearIntegration(integration) : null })
-    } catch (error) {
-      if (error instanceof LinearApiError) {
-        return c.json({ error: error.message }, error.status === 401 ? 401 : 400)
-      }
-      throw error
-    }
+    return c.json({ integration: integration ? serializeLinearIntegration(integration) : null })
   })
   .delete('/integrations/linear', async (c) => {
     const organizationId = c.get('organizationId')
@@ -113,6 +225,10 @@ const app = new Hono()
       return c.json({ error: 'Organization is required' }, 403)
     }
 
+    const integration = await linearIntegrationRepository.findByOrganization(organizationId)
+    if (integration) {
+      await revokeLinearIntegrationTokens(integration)
+    }
     await linearIntegrationRepository.delete(organizationId)
     return c.json({ success: true })
   })
@@ -128,7 +244,8 @@ const app = new Hono()
     }
 
     try {
-      const result = await validateLinearApiKey(decryptSecret(integration.encryptedApiKey))
+      const accessToken = await getValidLinearAccessToken(integration)
+      const result = await validateLinearAccessToken(accessToken)
       await linearIntegrationRepository.markValidationStatus(organizationId, 'valid')
       return c.json({ ok: true, organizationName: result.organizationName })
     } catch (error) {
@@ -151,7 +268,8 @@ const app = new Hono()
     }
 
     try {
-      const metadata = await fetchLinearMetadata(decryptSecret(integration.encryptedApiKey))
+      const accessToken = await getValidLinearAccessToken(integration)
+      const metadata = await fetchLinearMetadata(accessToken)
       return c.json({ metadata })
     } catch (error) {
       if (error instanceof LinearApiError) {
@@ -161,7 +279,7 @@ const app = new Hono()
     }
   })
 
-function normalizeLinearDefaults(body: z.infer<typeof linearDefaultsSchema>) {
+function normalizeLinearDefaults(body: LinearDefaultsInput) {
   return {
     defaultTeamId: body.defaultTeamId ?? null,
     defaultProjectId: body.defaultProjectId ?? null,
@@ -169,6 +287,44 @@ function normalizeLinearDefaults(body: z.infer<typeof linearDefaultsSchema>) {
     defaultAssigneeId: body.defaultAssigneeId ?? null,
     defaultStateId: body.defaultStateId ?? null,
     defaultPriority: body.defaultPriority ?? null,
+  }
+}
+
+function settingsRedirectUrl(params: Record<string, string>): string {
+  const url = new URL('/settings', env.APP_BASE_URL)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value)
+  }
+  return url.toString()
+}
+
+function redirectToSettings(c: Context, params: Record<string, string>) {
+  return c.redirect(settingsRedirectUrl(params), 302)
+}
+
+async function revokeLinearIntegrationTokens(
+  integration: NonNullable<
+    Awaited<ReturnType<typeof linearIntegrationRepository.findByOrganization>>
+  >
+) {
+  try {
+    const { clientId, clientSecret } = getLinearOauthConfig()
+    await Promise.allSettled([
+      revokeLinearOauthToken({
+        token: decryptSecret(integration.encryptedRefreshToken),
+        tokenTypeHint: 'refresh_token',
+        clientId,
+        clientSecret,
+      }),
+      revokeLinearOauthToken({
+        token: decryptSecret(integration.encryptedAccessToken),
+        tokenTypeHint: 'access_token',
+        clientId,
+        clientSecret,
+      }),
+    ])
+  } catch {
+    // Deletion should remain possible if Linear OAuth credentials were rotated or removed.
   }
 }
 
@@ -189,8 +345,11 @@ function serializeLinearIntegration(
   return {
     id: integration.id,
     organizationId: integration.organizationId,
-    keyPreview: integration.keyPreview,
+    connected: true,
     validationStatus: integration.validationStatus,
+    scopes: integration.scopes,
+    accessTokenExpiresAt: integration.accessTokenExpiresAt,
+    linearOrganizationName: integration.linearOrganizationName,
     defaultTeamId: integration.defaultTeamId,
     defaultProjectId: integration.defaultProjectId,
     defaultLabelIds: integration.defaultLabelIds,

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   alertCheckCursorRepository,
   alertEventRepository,
@@ -132,6 +132,31 @@ describe('alerts routes', () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toMatchObject({
       error: expect.stringContaining('Invalid config'),
+    })
+  })
+
+  it('rejects multiple Linear notification channels', async () => {
+    const app = await createAlertsRouteApp()
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Too many Linear routes',
+        type: 'job_failed',
+        queueName: 'email-send',
+        config: { maxIssuesPerPoll: 10 },
+        notificationChannels: [
+          { type: 'linear', target: 'org-default', teamId: 'team-1' },
+          { type: 'linear', target: 'org-default', teamId: 'team-2' },
+        ],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Only one Linear notification channel is supported per rule.',
     })
   })
 
@@ -303,7 +328,19 @@ describe('alerts routes', () => {
       type: rule.type,
       status: 'firing',
       summary: 'Needs action',
-      context: {},
+      context: { jobId: 'job-1' },
+      firedAt: new Date(),
+    })
+
+    await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      type: rule.type,
+      status: 'firing',
+      summary: 'Different job',
+      context: { jobId: 'job-2' },
       firedAt: new Date(),
     })
 
@@ -312,6 +349,17 @@ describe('alerts routes', () => {
     const listResponse = await app.request('/events?status=firing')
     expect(listResponse.status).toBe(200)
     expect(await listResponse.json()).toMatchObject({
+      events: [
+        expect.objectContaining({ status: 'firing' }),
+        expect.objectContaining({ status: 'firing' }),
+      ],
+    })
+
+    const filteredResponse = await app.request(
+      '/events?status=firing&queueName=email-send&jobId=job-1'
+    )
+    expect(filteredResponse.status).toBe(200)
+    expect(await filteredResponse.json()).toMatchObject({
       events: [expect.objectContaining({ id: event.id, status: 'firing' })],
     })
 

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -359,9 +359,9 @@ describe('alerts routes', () => {
       '/events?status=firing&queueName=email-send&jobId=job-1'
     )
     expect(filteredResponse.status).toBe(200)
-    expect(await filteredResponse.json()).toMatchObject({
-      events: [expect.objectContaining({ id: event.id, status: 'firing' })],
-    })
+    const filteredBody = (await filteredResponse.json()) as { events: unknown[] }
+    expect(filteredBody.events).toHaveLength(1)
+    expect(filteredBody.events[0]).toMatchObject({ id: event.id, status: 'firing' })
 
     const resolveResponse = await app.request(`/events/${event.id}/resolve`, { method: 'POST' })
     expect(resolveResponse.status).toBe(200)

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -1,7 +1,9 @@
 import {
   alertCheckCursorRepository,
+  alertDeliveryRepository,
   alertEventRepository,
   alertRuleRepository,
+  linearIntegrationRepository,
   redisDiscoveredQueueRepository,
 } from '@durabull/dal'
 import { zValidator } from '@hono/zod-validator'
@@ -10,13 +12,27 @@ import { z } from 'zod'
 import { evaluateRule, type CursorState, type QueueSnapshot } from '../lib/alert-evaluator'
 import { getQueue } from '../lib/redis'
 
-const alertTypeSchema = z.enum(['failure_threshold', 'failure_rate', 'queue_stalled'])
+const alertTypeSchema = z.enum(['failure_threshold', 'failure_rate', 'queue_stalled', 'job_failed'])
 const queueFilterModeSchema = z.enum(['include', 'exclude'])
 const alertEventStatusSchema = z.enum(['firing', 'resolved', 'suppressed'])
-const notificationChannelSchema = z.object({
-  type: z.enum(['email']),
+const emailNotificationChannelSchema = z.object({
+  type: z.literal('email'),
   target: z.string().email(),
 })
+const linearNotificationChannelSchema = z.object({
+  type: z.literal('linear'),
+  target: z.literal('org-default'),
+  teamId: z.string().min(1).optional(),
+  projectId: z.string().min(1).optional(),
+  labelIds: z.array(z.string().min(1)).max(50).optional(),
+  assigneeId: z.string().min(1).optional(),
+  stateId: z.string().min(1).optional(),
+  priority: z.number().int().min(0).max(4).optional(),
+})
+const notificationChannelSchema = z.discriminatedUnion('type', [
+  emailNotificationChannelSchema,
+  linearNotificationChannelSchema,
+])
 
 const createRuleSchema = z.object({
   name: z.string().min(1).max(200),
@@ -65,6 +81,13 @@ const app = new Hono()
     if (configError) {
       return c.json({ error: configError }, 400)
     }
+    const channelError = await validateNotificationChannels(
+      body.notificationChannels,
+      organizationId
+    )
+    if (channelError) {
+      return c.json({ error: channelError }, 400)
+    }
 
     const count = await alertRuleRepository.countByConnection(connectionId, organizationId)
     if (count >= 50) {
@@ -98,6 +121,15 @@ const app = new Hono()
       const configError = validateAlertConfig(nextType, nextConfig)
       if (configError) {
         return c.json({ error: configError }, 400)
+      }
+    }
+    if (body.notificationChannels !== undefined) {
+      const channelError = await validateNotificationChannels(
+        body.notificationChannels,
+        organizationId
+      )
+      if (channelError) {
+        return c.json({ error: channelError }, 400)
       }
     }
 
@@ -221,7 +253,7 @@ const app = new Hono()
         limit,
         status,
       })
-      return c.json({ events })
+      return c.json({ events: await attachDeliveries(events) })
     }
   )
   .post('/events/:eventId/resolve', async (c) => {
@@ -238,6 +270,15 @@ const app = new Hono()
 
     return c.json({ event })
   })
+
+async function attachDeliveries<T extends { id: string }>(events: T[]) {
+  return Promise.all(
+    events.map(async (event) => ({
+      ...event,
+      deliveries: await alertDeliveryRepository.listByEvent(event.id),
+    }))
+  )
+}
 
 function validateAlertConfig(type: string, config: Record<string, unknown>): string | null {
   switch (type) {
@@ -265,9 +306,33 @@ function validateAlertConfig(type: string, config: Record<string, unknown>): str
       const result = schema.safeParse(config)
       return result.success ? null : `Invalid config: ${result.error.message}`
     }
+    case 'job_failed': {
+      const schema = z.object({
+        maxIssuesPerPoll: z.number().int().min(1).max(500).optional(),
+      })
+      const result = schema.safeParse(config)
+      return result.success ? null : `Invalid config: ${result.error.message}`
+    }
     default:
       return `Unknown alert type: ${type}`
   }
+}
+
+async function validateNotificationChannels(
+  channels: z.infer<typeof notificationChannelSchema>[],
+  organizationId: string
+): Promise<string | null> {
+  if (!channels.some((channel) => channel.type === 'linear')) return null
+
+  const integration = await linearIntegrationRepository.findByOrganization(organizationId)
+  if (!integration || integration.validationStatus !== 'valid') {
+    return 'Linear integration must be configured and valid before Linear alert routing can be enabled.'
+  }
+
+  const missingTeam = channels.some(
+    (channel) => channel.type === 'linear' && !channel.teamId && !integration.defaultTeamId
+  )
+  return missingTeam ? 'Linear alert routing requires a teamId or organization default team.' : null
 }
 
 export default app

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -9,7 +9,7 @@ import {
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { evaluateRule, type CursorState, type QueueSnapshot } from '../lib/alert-evaluator'
+import { type CursorState, evaluateRule, type QueueSnapshot } from '../lib/alert-evaluator'
 import { getQueue } from '../lib/redis'
 
 const alertTypeSchema = z.enum(['failure_threshold', 'failure_rate', 'queue_stalled', 'job_failed'])
@@ -238,10 +238,12 @@ const app = new Hono()
         offset: z.coerce.number().int().min(0).default(0),
         limit: z.coerce.number().int().min(1).max(100).default(20),
         status: alertEventStatusSchema.optional(),
+        queueName: z.string().min(1).optional(),
+        jobId: z.string().min(1).optional(),
       })
     ),
     async (c) => {
-      const { offset, limit, status } = c.req.valid('query')
+      const { offset, limit, status, queueName, jobId } = c.req.valid('query')
       const connectionId = c.get('connectionId')
       const organizationId = c.get('organizationId')
       if (!organizationId) {
@@ -252,6 +254,8 @@ const app = new Hono()
         offset,
         limit,
         status,
+        queueName,
+        jobId,
       })
       return c.json({ events: await attachDeliveries(events) })
     }
@@ -322,15 +326,19 @@ async function validateNotificationChannels(
   channels: z.infer<typeof notificationChannelSchema>[],
   organizationId: string
 ): Promise<string | null> {
-  if (!channels.some((channel) => channel.type === 'linear')) return null
+  const linearChannels = channels.filter((channel) => channel.type === 'linear')
+  if (linearChannels.length > 1) {
+    return 'Only one Linear notification channel is supported per rule.'
+  }
+  if (linearChannels.length === 0) return null
 
   const integration = await linearIntegrationRepository.findByOrganization(organizationId)
   if (!integration || integration.validationStatus !== 'valid') {
     return 'Linear integration must be configured and valid before Linear alert routing can be enabled.'
   }
 
-  const missingTeam = channels.some(
-    (channel) => channel.type === 'linear' && !channel.teamId && !integration.defaultTeamId
+  const missingTeam = linearChannels.some(
+    (channel) => !channel.teamId && !integration.defaultTeamId
   )
   return missingTeam ? 'Linear alert routing requires a teamId or organization default team.' : null
 }

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -56,6 +56,18 @@ description: Complete runtime environment variable reference for local and produ
 
 > **Note:** The web app receives PostHog configuration from the API at `/api/app/config`. You only need to set the server-side `POSTHOG_KEY` and `POSTHOG_HOST` variables — no `VITE_` prefix is required. Set `POSTHOG_HOST` to PostHog's ingestion domain (for example `https://us.i.posthog.com`), not your own app `/ingest` URL. The API reverse-proxies analytics traffic through `/ingest` to bypass ad blockers.
 
+### Linear OAuth callback
+
+For Linear alert integrations, register this callback URL in your Linear OAuth application:
+
+```txt
+https://your-domain.example/api/alerts/integrations/linear/callback
+```
+
+Durabull derives that URL from `APP_BASE_URL` by default. Set `LINEAR_OAUTH_REDIRECT_URI`
+explicitly when your self-hosted API is served from a different public origin than the web app.
+The redirect URI configured in Linear must exactly match the value Durabull sends during OAuth.
+
 ## Anonymous Usage Telemetry
 
 Durabull collects anonymous/pseudonymous usage telemetry in production and self-hosted usage to

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -72,6 +72,9 @@ By default, Durabull uses Linear's user actor OAuth flow and omits the `actor` a
 parameter. Set `LINEAR_OAUTH_ACTOR=app` only when the Linear application is configured for app
 actor authorization and you want alert-created issues attributed to the app.
 
+For the full connection, alert delivery, retry, and idempotency model, see
+[Linear Integration](/documentation/integrations/linear).
+
 ## Anonymous Usage Telemetry
 
 Durabull collects anonymous/pseudonymous usage telemetry in production and self-hosted usage to

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -31,6 +31,7 @@ description: Complete runtime environment variable reference for local and produ
 | `DATABASE_URL` | Optional | Enables PostgreSQL mode when set |
 | `REDIS_URL` | Optional | Generic Redis URL used by scripts/defaults |
 | `DURABULL_REDIS_URL_ENCRYPTION_KEY` | Required when persisting connections | 32-byte key (hex/base64) used to encrypt Redis connection URLs at rest |
+| `DURABULL_SECRET_ENCRYPTION_KEY` | Required for Linear alert integrations | 32-byte key (hex/base64) used to encrypt third-party API credentials at rest |
 | `DURABULL_PGLITE_DIR` | Optional | Override PGlite data directory |
 
 ## Connection Mode
@@ -85,6 +86,7 @@ VITE_PUBLIC_APP_URL=https://your-domain.example
 DURABULL_AUTHLESS=false
 BETTER_AUTH_SECRET=<long-random-secret>
 DURABULL_REDIS_URL_ENCRYPTION_KEY=<openssl-rand-hex-32>
+DURABULL_SECRET_ENCRYPTION_KEY=<openssl-rand-hex-32>
 DURABULL_ENV_CONNECTIONS=true
 DURABULL_REDIS_URL_MAIN=redis://...
 DURABULL_REDIS_URL_MAIN_ENVIRONMENT=production

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -51,6 +51,7 @@ description: Complete runtime environment variable reference for local and produ
 | `LINEAR_OAUTH_CLIENT_ID` | Required for Linear alert integrations | Linear OAuth application client ID |
 | `LINEAR_OAUTH_CLIENT_SECRET` | Required for Linear alert integrations | Linear OAuth application client secret |
 | `LINEAR_OAUTH_REDIRECT_URI` | Optional | Explicit Linear OAuth callback URL; defaults to `${APP_BASE_URL}/api/alerts/integrations/linear/callback` |
+| `LINEAR_OAUTH_ACTOR` | Optional | Linear OAuth actor mode: `user` by default, or `app` for service-account style app actor authorization |
 | `POSTHOG_KEY` | Optional | PostHog project API key |
 | `POSTHOG_HOST` | Optional | PostHog upstream host for the reverse proxy (defaults to `https://us.i.posthog.com`) |
 
@@ -67,6 +68,9 @@ https://your-domain.example/api/alerts/integrations/linear/callback
 Durabull derives that URL from `APP_BASE_URL` by default. Set `LINEAR_OAUTH_REDIRECT_URI`
 explicitly when your self-hosted API is served from a different public origin than the web app.
 The redirect URI configured in Linear must exactly match the value Durabull sends during OAuth.
+By default, Durabull uses Linear's user actor OAuth flow and omits the `actor` authorize
+parameter. Set `LINEAR_OAUTH_ACTOR=app` only when the Linear application is configured for app
+actor authorization and you want alert-created issues attributed to the app.
 
 ## Anonymous Usage Telemetry
 

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -31,7 +31,7 @@ description: Complete runtime environment variable reference for local and produ
 | `DATABASE_URL` | Optional | Enables PostgreSQL mode when set |
 | `REDIS_URL` | Optional | Generic Redis URL used by scripts/defaults |
 | `DURABULL_REDIS_URL_ENCRYPTION_KEY` | Required when persisting connections | 32-byte key (hex/base64) used to encrypt Redis connection URLs at rest |
-| `DURABULL_SECRET_ENCRYPTION_KEY` | Required for Linear alert integrations | 32-byte key (hex/base64) used to encrypt third-party API credentials at rest |
+| `DURABULL_SECRET_ENCRYPTION_KEY` | Required for Linear alert integrations | 32-byte key (hex/base64) used to encrypt third-party OAuth tokens at rest |
 | `DURABULL_PGLITE_DIR` | Optional | Override PGlite data directory |
 
 ## Connection Mode
@@ -48,6 +48,9 @@ description: Complete runtime environment variable reference for local and produ
 | Variable | Required | Purpose |
 | --- | --- | --- |
 | `RESEND_API_KEY` | Optional | Invitation email delivery |
+| `LINEAR_OAUTH_CLIENT_ID` | Required for Linear alert integrations | Linear OAuth application client ID |
+| `LINEAR_OAUTH_CLIENT_SECRET` | Required for Linear alert integrations | Linear OAuth application client secret |
+| `LINEAR_OAUTH_REDIRECT_URI` | Optional | Explicit Linear OAuth callback URL; defaults to `${APP_BASE_URL}/api/alerts/integrations/linear/callback` |
 | `POSTHOG_KEY` | Optional | PostHog project API key |
 | `POSTHOG_HOST` | Optional | PostHog upstream host for the reverse proxy (defaults to `https://us.i.posthog.com`) |
 

--- a/apps/docs/content/documentation/index.mdx
+++ b/apps/docs/content/documentation/index.mdx
@@ -63,6 +63,11 @@ If you are new, follow this order:
   [Queue and Scheduled Job Naming Best Practices](/documentation/workflows/naming-best-practices),
   [Log Formatting and Highlighting](/documentation/workflows/log-formatting-and-highlighting)
 
+### Integrations
+
+- Alert routing:
+  [Linear Integration](/documentation/integrations/linear)
+
 ### Operations and Reference
 
 - Incident playbook:

--- a/apps/docs/content/documentation/integrations/linear.mdx
+++ b/apps/docs/content/documentation/integrations/linear.mdx
@@ -1,0 +1,226 @@
+---
+title: Linear Integration
+description: Connect Linear to Durabull alerts so queue and job failures create actionable Linear issues.
+---
+
+The Linear integration turns Durabull alert events into Linear issues. It is designed for
+teams that want failed BullMQ work to land in their existing incident, triage, or engineering
+backlog without wiring Linear calls into every worker.
+
+Durabull owns the integration from the outside of your queue system. Your BullMQ workers do
+not need to import Durabull packages or change their failure handling.
+
+## What It Does
+
+When an alert rule routes to Linear, Durabull can create Linear issues for:
+
+- job failures from `job_failed` alert rules
+- queue failure thresholds
+- queue failure-rate alerts
+- stalled queue alerts
+
+For job-failed alerts, Durabull records a durable mapping between the failed BullMQ job and
+the Linear issue. That keeps repeated alert processing from creating a new Linear issue for
+the same failed job.
+
+## How It Works
+
+<div className="not-prose my-6 overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950 p-4">
+  <div className="flex min-w-[760px] items-center gap-3 text-sm">
+    <div className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-3 text-center text-zinc-100">
+      BullMQ queue
+    </div>
+    <div className="text-zinc-500">-&gt;</div>
+    <div className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-3 text-center text-zinc-100">
+      Alert monitor
+    </div>
+    <div className="text-zinc-500">-&gt;</div>
+    <div className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-3 text-center text-zinc-100">
+      Alert rule
+    </div>
+    <div className="text-zinc-500">-&gt;</div>
+    <div className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-3 text-center text-zinc-100">
+      Alert event
+    </div>
+    <div className="text-zinc-500">-&gt;</div>
+    <div className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-3 text-center text-zinc-100">
+      Delivery outbox
+    </div>
+    <div className="text-zinc-500">-&gt;</div>
+    <div className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-3 text-center text-zinc-100">
+      Linear issue
+    </div>
+  </div>
+  <div className="mt-4 flex min-w-[760px] items-center justify-center gap-3 text-sm">
+    <div className="rounded-md border border-emerald-900/70 bg-emerald-950/50 px-4 py-3 text-center text-emerald-100">
+      Job-to-issue mapping keeps later retries tied to the same Linear issue
+    </div>
+  </div>
+</div>
+
+At a high level:
+
+1. A BullMQ job fails or a queue crosses an alert threshold.
+2. Durabull's alert monitor polls the connected Redis/BullMQ data.
+3. Enabled alert rules decide whether an alert should fire.
+4. Durabull persists an alert event in its database.
+5. Durabull creates delivery records for the configured notification channels.
+6. A Linear delivery claims one outbox record, loads a valid Linear OAuth token, and creates
+   a Linear issue through the Linear GraphQL API.
+7. The delivery row stores the Linear issue id, identifier, URL, and provider metadata.
+8. For job-failed alerts, Durabull stores a job-to-issue mapping so later retries or poll
+   cycles reuse the same Linear issue.
+
+## Setup Requirements
+
+Self-hosted deployments need these environment variables:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `DURABULL_SECRET_ENCRYPTION_KEY` | Yes | Encrypts Linear OAuth access and refresh tokens at rest. |
+| `APP_BASE_URL` | Recommended | Used to derive the default Linear OAuth callback URL and issue deep links. |
+| `LINEAR_OAUTH_CLIENT_ID` | Yes | Linear OAuth application client ID. |
+| `LINEAR_OAUTH_CLIENT_SECRET` | Yes | Linear OAuth application client secret. |
+| `LINEAR_OAUTH_REDIRECT_URI` | Optional | Overrides the default callback URL when API and app origins differ. |
+| `LINEAR_OAUTH_ACTOR` | Optional | Defaults to user actor OAuth. Set to `app` only for app actor authorization. |
+
+Create a 32-byte secret for `DURABULL_SECRET_ENCRYPTION_KEY`:
+
+```bash
+openssl rand -hex 32
+```
+
+Register this callback URL in Linear:
+
+```txt
+https://your-domain.example/api/alerts/integrations/linear/callback
+```
+
+By default, Durabull derives that callback from `APP_BASE_URL`. If your self-hosted API is
+served from a different public origin than the web app, set `LINEAR_OAUTH_REDIRECT_URI`
+explicitly and register that exact URL in Linear.
+
+## OAuth Flow
+
+Durabull uses Linear OAuth 2.0 instead of storing user-supplied API keys.
+
+The connection flow:
+
+1. An organization admin starts the Linear connection from Durabull settings.
+2. Durabull creates an opaque, expiring OAuth state value.
+3. The user authorizes Durabull in Linear with `read` and `issues:create` scopes.
+4. Linear redirects back to Durabull's callback URL.
+5. Durabull validates and consumes the OAuth state before exchanging the code.
+6. Durabull validates the access token against Linear.
+7. Durabull stores encrypted access and refresh tokens with Linear organization metadata.
+
+Access tokens are refreshed automatically before Linear metadata lookup and issue creation
+when Durabull detects that the stored token is expired.
+
+Disconnecting Linear deletes Durabull's local integration state and attempts to revoke the
+Linear refresh and access tokens.
+
+## Configuring Linear Defaults
+
+After OAuth is connected, Durabull can store organization-level defaults for Linear issue
+creation:
+
+- default team
+- project
+- labels
+- assignee
+- workflow state
+- priority
+
+Alert rules can override these defaults for an individual Linear notification channel. A
+Linear team is always required, either from the alert channel or from the organization default.
+
+## Creating Linear Alert Rules
+
+To send alerts to Linear:
+
+1. Connect Linear in settings.
+2. Choose default Linear routing values.
+3. Create or edit an alert rule.
+4. Add a Linear notification channel.
+5. Select the team or rely on the configured default team.
+6. Save the rule.
+
+For job-specific issues, use the `job_failed` rule type. Durabull scans failed jobs in the
+matching BullMQ queues and creates one alert event per failed job subject.
+
+## Delivery, Retry, and Idempotency
+
+Durabull uses a database-backed delivery outbox for Linear notifications.
+
+Each alert event can have one or more delivery rows. A delivery row moves through these
+states:
+
+| State | Meaning |
+| --- | --- |
+| `pending` | The delivery has been created and is ready to send. |
+| `claimed` | A worker is currently processing the delivery. |
+| `delivered` | The target provider accepted the notification. |
+| `failed` | The delivery failed. It may retry later or remain failed for operator review. |
+
+The outbox gives Durabull a safe place to retry transient failures. Rate limits and clear
+network retry cases are scheduled with backoff. Non-retryable configuration and validation
+errors remain failed until an operator fixes the integration or alert channel.
+
+For job-failed Linear alerts, Durabull uses three persistence layers to avoid duplicates:
+
+| Layer | Purpose |
+| --- | --- |
+| Alert event dedupe | Keeps one alert event per rule and failed job subject. |
+| Delivery outbox dedupe | Keeps one delivery row per event, channel, and target. |
+| Linear job issue mapping | Keeps one Linear issue per organization, connection, queue, and job id. |
+
+Linear issue creation does not use a provider-side idempotency key. Durabull compensates by
+checking its local job-to-issue mapping before calling Linear, then recording the Linear issue
+after a successful create.
+
+If a Linear issue may have been created but Durabull cannot prove it persisted the local
+mapping, Durabull stops automatic retry for that delivery. That protects teams from duplicate
+Linear issues and leaves a clear manual reconciliation error for operators.
+
+## What Gets Stored
+
+Durabull stores:
+
+- encrypted Linear OAuth access and refresh tokens
+- Linear organization metadata
+- default Linear routing settings
+- alert events and alert delivery state
+- Linear issue id, identifier, and URL for delivered notifications
+- job-to-issue mappings for job-failed alerts
+
+Durabull does not store a plain text Linear API key for this integration.
+
+## Troubleshooting
+
+If Linear connection fails:
+
+- verify `LINEAR_OAUTH_CLIENT_ID` and `LINEAR_OAUTH_CLIENT_SECRET`
+- confirm the Linear callback URL exactly matches Durabull's callback URL
+- confirm `APP_BASE_URL` is the public app origin, or set `LINEAR_OAUTH_REDIRECT_URI`
+- confirm `DURABULL_SECRET_ENCRYPTION_KEY` is set before connecting Linear
+
+If alert rules save but no Linear issue appears:
+
+- confirm the alert rule includes a Linear notification channel
+- confirm Linear is connected for the organization
+- confirm a Linear team is configured on the channel or as the organization default
+- check the alert event delivery status and last error in Durabull
+- fix any non-retryable integration error, then trigger a new alert or retry the failed job
+
+If duplicate BullMQ failures appear:
+
+- confirm the jobs have stable BullMQ job ids
+- confirm the alert rule is a `job_failed` rule when you expect one issue per job
+- check whether multiple alert rules intentionally target the same queue and job
+
+## Related Docs
+
+- [Environment Variables](/documentation/getting-started/environment-variables)
+- [Job Lifecycle and Debugging](/documentation/workflows/job-lifecycle-and-debugging)
+- [Troubleshooting](/documentation/operations/troubleshooting)

--- a/apps/docs/content/documentation/meta.json
+++ b/apps/docs/content/documentation/meta.json
@@ -29,6 +29,8 @@
     "workflows/team-and-invitations",
     "workflows/naming-best-practices",
     "workflows/log-formatting-and-highlighting",
+    "---Integrations---",
+    "integrations/linear",
     "---Reference---",
     "reference/http-api",
     "---Operations---",

--- a/apps/web/src/components/alerts/alert-events-table.test.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.test.tsx
@@ -34,6 +34,7 @@ function createEvent(overrides: Partial<AlertEventRecord> = {}): AlertEventRecor
     firedAt: '2026-03-24T10:00:00.000Z',
     resolvedAt: null,
     notificationSentAt: null,
+    deliveries: [],
     ...overrides,
   }
 }

--- a/apps/web/src/components/alerts/alert-events-table.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.tsx
@@ -103,9 +103,7 @@ export function AlertEventsTable({
                   </div>
                 </TableCell>
                 <TableCell>
-                  <span className="text-xs text-muted-foreground">
-                    {event.notificationSentAt ? 'Delivered' : 'Not sent'}
-                  </span>
+                  <DeliverySummary event={event} />
                 </TableCell>
                 <TableCell className="text-xs text-muted-foreground">
                   {formatAlertDate(event.firedAt)}
@@ -148,5 +146,39 @@ export function AlertEventsTable({
         </TableBody>
       </Table>
     </div>
+  )
+}
+
+function DeliverySummary({ event }: { event: AlertEventRecord }) {
+  const linearDelivery = event.deliveries.find(
+    (delivery) => delivery.channelType === 'linear' && delivery.externalUrl
+  )
+  if (linearDelivery?.externalUrl) {
+    return (
+      <a
+        href={linearDelivery.externalUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+      >
+        {linearDelivery.externalIdentifier ?? 'Linear issue'}
+        <ArrowUpRight className="h-3 w-3" />
+      </a>
+    )
+  }
+
+  if (event.deliveries.length > 0) {
+    const delivered = event.deliveries.filter((delivery) => delivery.status === 'delivered').length
+    return (
+      <span className="text-xs text-muted-foreground">
+        {delivered}/{event.deliveries.length} delivered
+      </span>
+    )
+  }
+
+  return (
+    <span className="text-xs text-muted-foreground">
+      {event.notificationSentAt ? 'Delivered' : 'Not sent'}
+    </span>
   )
 }

--- a/apps/web/src/components/alerts/alert-primitives.tsx
+++ b/apps/web/src/components/alerts/alert-primitives.tsx
@@ -30,6 +30,12 @@ const ALERT_TYPE_META: Record<
     icon: Siren,
     description: 'Fires when work is backing up and the queue stops completing jobs.',
   },
+  job_failed: {
+    label: 'Job Failed',
+    shortLabel: 'Job',
+    icon: BellRing,
+    description: 'Creates a deduplicated incident for each failed job id.',
+  },
 }
 
 export function getAlertTypeMeta(type: AlertRuleType) {

--- a/apps/web/src/components/alerts/alert-rule-builder-page.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.tsx
@@ -462,6 +462,42 @@ export function AlertRuleBuilderPage({
                         placeholder="Project ID"
                       />
                       <Input
+                        aria-label={`Linear labels override ${index + 1}`}
+                        value={route.labelIds?.join(', ') ?? ''}
+                        onChange={(event) => {
+                          const notificationRoutes = draft.notificationRoutes.slice()
+                          notificationRoutes[index] = {
+                            ...route,
+                            labelIds: event.target.value
+                              .split(',')
+                              .map((label) => label.trim())
+                              .filter(Boolean),
+                          }
+                          updateDraft({ notificationRoutes })
+                        }}
+                        placeholder="Label IDs"
+                      />
+                      <Input
+                        aria-label={`Linear assignee override ${index + 1}`}
+                        value={route.assigneeId ?? ''}
+                        onChange={(event) => {
+                          const notificationRoutes = draft.notificationRoutes.slice()
+                          notificationRoutes[index] = { ...route, assigneeId: event.target.value }
+                          updateDraft({ notificationRoutes })
+                        }}
+                        placeholder="Assignee ID"
+                      />
+                      <Input
+                        aria-label={`Linear state override ${index + 1}`}
+                        value={route.stateId ?? ''}
+                        onChange={(event) => {
+                          const notificationRoutes = draft.notificationRoutes.slice()
+                          notificationRoutes[index] = { ...route, stateId: event.target.value }
+                          updateDraft({ notificationRoutes })
+                        }}
+                        placeholder="State ID"
+                      />
+                      <Input
                         aria-label={`Linear priority override ${index + 1}`}
                         value={route.priority ?? ''}
                         onChange={(event) => {

--- a/apps/web/src/components/alerts/alert-rule-builder-page.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import {
   createAlertRuleDraft,
+  createLinearNotificationRouteDraft,
   createNotificationRouteDraft,
   normalizeNotificationEmails,
   serializeAlertRuleDraftsForMode,
@@ -40,6 +41,7 @@ interface AlertRuleBuilderPageProps {
   onTest?: () => Promise<AlertTestResult>
   isSaving?: boolean
   isTesting?: boolean
+  linearIntegrationConfigured?: boolean
 }
 
 const RULE_TYPE_EXAMPLES: Record<
@@ -66,6 +68,11 @@ const RULE_TYPE_EXAMPLES: Record<
     example: 'Example: "If jobs are waiting but completions stop for 10 minutes, page the owner."',
     note: 'Best for stuck consumers, dead workers, or downstream systems that quietly halt throughput.',
   },
+  job_failed: {
+    headline: 'Create one Linear issue per failed job',
+    example: 'Example: "When a job fails, create exactly one Linear issue for that job id."',
+    note: 'Best when every failed job needs product or engineering follow-up without duplicate issues.',
+  },
 }
 
 export function AlertRuleBuilderPage({
@@ -79,6 +86,7 @@ export function AlertRuleBuilderPage({
   onTest,
   isSaving = false,
   isTesting = false,
+  linearIntegrationConfigured = false,
 }: AlertRuleBuilderPageProps) {
   const [draft, setDraft] = useState<AlertRuleDraft>(() => createAlertRuleDraft(rule))
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -133,8 +141,9 @@ export function AlertRuleBuilderPage({
   }
 
   const activeRecipients = normalizeNotificationEmails(
-    draft.notificationRoutes.map((route) => route.target)
+    draft.notificationRoutes.filter((route) => route.type === 'email').map((route) => route.target)
   )
+  const activeLinearRoutes = draft.notificationRoutes.filter((route) => route.type === 'linear')
 
   async function handleSubmit() {
     const validationError = validateAlertRuleDraft(draft)
@@ -238,40 +247,42 @@ export function AlertRuleBuilderPage({
           description="Choose the failure model you want Durabull to evaluate in the background."
         >
           <div className="grid gap-3 lg:grid-cols-3">
-            {(['failure_threshold', 'failure_rate', 'queue_stalled'] as const).map((type) => {
-              const meta = getAlertTypeMeta(type)
-              const isActive = draft.type === type
+            {(['failure_threshold', 'failure_rate', 'queue_stalled', 'job_failed'] as const).map(
+              (type) => {
+                const meta = getAlertTypeMeta(type)
+                const isActive = draft.type === type
 
-              return (
-                <button
-                  key={type}
-                  type="button"
-                  className={cn(
-                    'border px-4 py-4 text-left transition-colors',
-                    isActive
-                      ? 'border-foreground bg-foreground text-background'
-                      : 'border-border/70 bg-background hover:border-foreground/40'
-                  )}
-                  onClick={() => updateDraft({ type })}
-                  data-testid={`alert-rule-type-${type}`}
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-semibold">{meta.label}</span>
-                    {isActive ? (
-                      <span className="text-xs uppercase tracking-wide">Selected</span>
-                    ) : null}
-                  </div>
-                  <p
+                return (
+                  <button
+                    key={type}
+                    type="button"
                     className={cn(
-                      'mt-3 text-sm leading-6',
-                      isActive ? 'text-background/80' : 'text-muted-foreground'
+                      'border px-4 py-4 text-left transition-colors',
+                      isActive
+                        ? 'border-foreground bg-foreground text-background'
+                        : 'border-border/70 bg-background hover:border-foreground/40'
                     )}
+                    onClick={() => updateDraft({ type })}
+                    data-testid={`alert-rule-type-${type}`}
                   >
-                    {meta.description}
-                  </p>
-                </button>
-              )
-            })}
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-semibold">{meta.label}</span>
+                      {isActive ? (
+                        <span className="text-xs uppercase tracking-wide">Selected</span>
+                      ) : null}
+                    </div>
+                    <p
+                      className={cn(
+                        'mt-3 text-sm leading-6',
+                        isActive ? 'text-background/80' : 'text-muted-foreground'
+                      )}
+                    >
+                      {meta.description}
+                    </p>
+                  </button>
+                )
+              }
+            )}
           </div>
 
           <div className="mt-4 border border-border/70 bg-muted/10 px-4 py-4">
@@ -375,12 +386,25 @@ export function AlertRuleBuilderPage({
               />
             </div>
           ) : null}
+
+          {draft.type === 'job_failed' ? (
+            <div className="grid gap-6 md:grid-cols-2">
+              <NumberField
+                id="alert-job-failed-max-issues"
+                label="Max issues per poll"
+                value={draft.jobFailedMaxIssuesPerPoll}
+                onChange={(value) => updateDraft({ jobFailedMaxIssuesPerPoll: value })}
+                helper="Caps how many failed jobs Durabull will turn into Linear issues during one monitor tick."
+                example="Default: 100, maximum: 500"
+              />
+            </div>
+          ) : null}
         </BuilderSection>
 
         <BuilderSection
           step="05"
           title="Notification routing"
-          description="Add multiple destinations for incident delivery. Email works today; Slack and Linear are shown for future routing coverage."
+          description="Add multiple destinations for incident delivery. Linear uses the organization integration defaults unless this rule overrides them."
         >
           <div className="space-y-3">
             <div className="grid grid-cols-[140px_minmax(0,1fr)_auto] gap-3 border-b border-border/70 pb-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
@@ -394,20 +418,58 @@ export function AlertRuleBuilderPage({
                 key={route.id}
                 className="grid grid-cols-[140px_minmax(0,1fr)_auto] items-center gap-3"
               >
-                <div className="inline-flex items-center gap-2 text-sm font-medium">
-                  <Mail className="h-4 w-4 text-muted-foreground" />
-                  Email
-                </div>
-                <Input
-                  value={route.target}
-                  onChange={(event) => {
-                    const notificationRoutes = draft.notificationRoutes.slice()
-                    notificationRoutes[index] = { ...route, target: event.target.value }
-                    updateDraft({ notificationRoutes })
-                  }}
-                  placeholder="oncall@example.com"
-                  data-testid={`alert-rule-email-${index}`}
-                />
+                {route.type === 'email' ? (
+                  <>
+                    <div className="inline-flex items-center gap-2 text-sm font-medium">
+                      <Mail className="h-4 w-4 text-muted-foreground" />
+                      Email
+                    </div>
+                    <Input
+                      value={route.target}
+                      onChange={(event) => {
+                        const notificationRoutes = draft.notificationRoutes.slice()
+                        notificationRoutes[index] = { ...route, target: event.target.value }
+                        updateDraft({ notificationRoutes })
+                      }}
+                      placeholder="oncall@example.com"
+                      data-testid={`alert-rule-email-${index}`}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <div className="inline-flex items-center gap-2 text-sm font-medium">Linear</div>
+                    <div className="grid gap-2 md:grid-cols-3">
+                      <Input
+                        value={route.teamId ?? ''}
+                        onChange={(event) => {
+                          const notificationRoutes = draft.notificationRoutes.slice()
+                          notificationRoutes[index] = { ...route, teamId: event.target.value }
+                          updateDraft({ notificationRoutes })
+                        }}
+                        placeholder="Team ID (optional)"
+                        data-testid={`alert-rule-linear-team-${index}`}
+                      />
+                      <Input
+                        value={route.projectId ?? ''}
+                        onChange={(event) => {
+                          const notificationRoutes = draft.notificationRoutes.slice()
+                          notificationRoutes[index] = { ...route, projectId: event.target.value }
+                          updateDraft({ notificationRoutes })
+                        }}
+                        placeholder="Project ID"
+                      />
+                      <Input
+                        value={route.priority ?? ''}
+                        onChange={(event) => {
+                          const notificationRoutes = draft.notificationRoutes.slice()
+                          notificationRoutes[index] = { ...route, priority: event.target.value }
+                          updateDraft({ notificationRoutes })
+                        }}
+                        placeholder="Priority 0-4"
+                      />
+                    </div>
+                  </>
+                )}
                 <Button
                   type="button"
                   variant="ghost"
@@ -423,7 +485,7 @@ export function AlertRuleBuilderPage({
                           : [createNotificationRouteDraft()],
                     })
                   }}
-                  aria-label={`Remove email route ${index + 1}`}
+                  aria-label={`Remove ${route.type} route ${index + 1}`}
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
@@ -445,8 +507,24 @@ export function AlertRuleBuilderPage({
               <Plus className="mr-1.5 h-4 w-4" />
               Add email route
             </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                updateDraft({
+                  notificationRoutes: [
+                    ...draft.notificationRoutes,
+                    createLinearNotificationRouteDraft(),
+                  ],
+                })
+              }
+              disabled={!linearIntegrationConfigured || activeLinearRoutes.length >= 1}
+            >
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add Linear route
+            </Button>
             <span className="text-sm text-muted-foreground">
-              Up to 10 active email destinations per rule.
+              Up to 10 email destinations and one Linear destination per rule.
             </span>
           </div>
 
@@ -456,10 +534,18 @@ export function AlertRuleBuilderPage({
                 label="Slack"
                 description="Post incidents to channel-based on-call flows."
               />
-              <ComingSoonRoute
-                label="Linear"
-                description="Open issues directly from alert policy routing."
-              />
+              <div className="border border-border/70 bg-background/50 px-4 py-4">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm font-medium">Linear</span>
+                  <Badge variant={linearIntegrationConfigured ? 'success' : 'secondary'}>
+                    {linearIntegrationConfigured ? 'Configured' : 'Setup required'}
+                  </Badge>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  Open issues directly from alert policy routing with org defaults or rule
+                  overrides.
+                </p>
+              </div>
             </div>
           </div>
         </BuilderSection>
@@ -531,7 +617,10 @@ export function AlertRuleBuilderPage({
               }
             />
             <SummaryRow label="Rules on save" value="1" />
-            <SummaryRow label="Recipients" value={String(activeRecipients.length)} />
+            <SummaryRow
+              label="Routes"
+              value={String(activeRecipients.length + activeLinearRoutes.length)}
+            />
           </div>
         </FlatPanel>
 

--- a/apps/web/src/components/alerts/alert-rule-builder-page.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.tsx
@@ -441,6 +441,7 @@ export function AlertRuleBuilderPage({
                     <div className="inline-flex items-center gap-2 text-sm font-medium">Linear</div>
                     <div className="grid gap-2 md:grid-cols-3">
                       <Input
+                        aria-label={`Linear team override ${index + 1}`}
                         value={route.teamId ?? ''}
                         onChange={(event) => {
                           const notificationRoutes = draft.notificationRoutes.slice()
@@ -451,6 +452,7 @@ export function AlertRuleBuilderPage({
                         data-testid={`alert-rule-linear-team-${index}`}
                       />
                       <Input
+                        aria-label={`Linear project override ${index + 1}`}
                         value={route.projectId ?? ''}
                         onChange={(event) => {
                           const notificationRoutes = draft.notificationRoutes.slice()
@@ -460,6 +462,7 @@ export function AlertRuleBuilderPage({
                         placeholder="Project ID"
                       />
                       <Input
+                        aria-label={`Linear priority override ${index + 1}`}
                         value={route.priority ?? ''}
                         onChange={(event) => {
                           const notificationRoutes = draft.notificationRoutes.slice()

--- a/apps/web/src/components/alerts/alert-rule-builder-page.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.tsx
@@ -3,19 +3,19 @@ import { BellRing, ChevronLeft, ChevronRight, Mail, Plus, TestTube2, Trash2 } fr
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import {
+  AlertStatusBadge,
+  AlertTypeBadge,
+  getAlertTypeMeta,
+} from '@/components/alerts/alert-primitives'
+import {
+  type AlertRuleDraft,
   createAlertRuleDraft,
   createLinearNotificationRouteDraft,
   createNotificationRouteDraft,
   normalizeNotificationEmails,
   serializeAlertRuleDraftsForMode,
   validateAlertRuleDraft,
-  type AlertRuleDraft,
 } from '@/components/alerts/alert-rule-form'
-import {
-  AlertStatusBadge,
-  AlertTypeBadge,
-  getAlertTypeMeta,
-} from '@/components/alerts/alert-primitives'
 import { QueueMultiSelect } from '@/components/alerts/queue-multi-select'
 import { useAppTopBar } from '@/components/app-top-bar'
 import { Badge } from '@/components/ui/badge'
@@ -144,6 +144,7 @@ export function AlertRuleBuilderPage({
     draft.notificationRoutes.filter((route) => route.type === 'email').map((route) => route.target)
   )
   const activeLinearRoutes = draft.notificationRoutes.filter((route) => route.type === 'linear')
+  const routeLimitReached = draft.notificationRoutes.length >= 10
 
   async function handleSubmit() {
     const validationError = validateAlertRuleDraft(draft)
@@ -497,12 +498,13 @@ export function AlertRuleBuilderPage({
             <Button
               type="button"
               variant="outline"
-              onClick={() =>
+              onClick={() => {
+                if (routeLimitReached) return
                 updateDraft({
                   notificationRoutes: [...draft.notificationRoutes, createNotificationRouteDraft()],
                 })
-              }
-              disabled={activeRecipients.length >= 10}
+              }}
+              disabled={routeLimitReached}
             >
               <Plus className="mr-1.5 h-4 w-4" />
               Add email route
@@ -510,21 +512,24 @@ export function AlertRuleBuilderPage({
             <Button
               type="button"
               variant="outline"
-              onClick={() =>
+              onClick={() => {
+                if (routeLimitReached || activeLinearRoutes.length >= 1) return
                 updateDraft({
                   notificationRoutes: [
                     ...draft.notificationRoutes,
                     createLinearNotificationRouteDraft(),
                   ],
                 })
+              }}
+              disabled={
+                !linearIntegrationConfigured || routeLimitReached || activeLinearRoutes.length >= 1
               }
-              disabled={!linearIntegrationConfigured || activeLinearRoutes.length >= 1}
             >
               <Plus className="mr-1.5 h-4 w-4" />
               Add Linear route
             </Button>
             <span className="text-sm text-muted-foreground">
-              Up to 10 email destinations and one Linear destination per rule.
+              Up to 10 total destinations and one Linear destination per rule.
             </span>
           </div>
 

--- a/apps/web/src/components/alerts/alert-rule-form.test.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.test.ts
@@ -282,6 +282,42 @@ describe('alert rule form helpers', () => {
     })
   })
 
+  it('serializes Linear priority zero as an explicit value', () => {
+    const payload = serializeAlertRuleDraft({
+      ...createAlertRuleDraft(),
+      name: 'Create Linear issues',
+      queueFilterMode: 'exclude',
+      type: 'job_failed',
+      notificationRoutes: [
+        {
+          ...createLinearNotificationRouteDraft(),
+          priority: '0',
+        },
+      ],
+    })
+
+    expect(payload.notificationChannels).toEqual([
+      { type: 'linear', target: 'org-default', priority: 0 },
+    ])
+  })
+
+  it('rejects non-whole Linear priority values', () => {
+    const error = validateAlertRuleDraft({
+      ...createAlertRuleDraft(),
+      name: 'Create Linear issues',
+      queueFilterMode: 'exclude',
+      type: 'job_failed',
+      notificationRoutes: [
+        {
+          ...createLinearNotificationRouteDraft(),
+          priority: '1.5',
+        },
+      ],
+    })
+
+    expect(error).toBe('Linear priority must be a whole number between 0 and 4.')
+  })
+
   it('rejects out-of-range job failed poll caps', () => {
     const error = validateAlertRuleDraft({
       ...createAlertRuleDraft(),

--- a/apps/web/src/components/alerts/alert-rule-form.test.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.test.ts
@@ -301,6 +301,35 @@ describe('alert rule form helpers', () => {
     ])
   })
 
+  it('trims blank Linear overrides before serialization', () => {
+    const payload = serializeAlertRuleDraft({
+      ...createAlertRuleDraft(),
+      name: 'Create Linear issues',
+      queueFilterMode: 'exclude',
+      type: 'job_failed',
+      notificationRoutes: [
+        {
+          ...createLinearNotificationRouteDraft(),
+          teamId: '   ',
+          projectId: ' project-1 ',
+          labelIds: [' label-1 ', '  '],
+          assigneeId: ' user-1 ',
+          stateId: '',
+        },
+      ],
+    })
+
+    expect(payload.notificationChannels).toEqual([
+      {
+        type: 'linear',
+        target: 'org-default',
+        projectId: 'project-1',
+        labelIds: ['label-1'],
+        assigneeId: 'user-1',
+      },
+    ])
+  })
+
   it('rejects non-whole Linear priority values', () => {
     const error = validateAlertRuleDraft({
       ...createAlertRuleDraft(),

--- a/apps/web/src/components/alerts/alert-rule-form.test.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   createAlertRuleDraft,
+  createLinearNotificationRouteDraft,
   normalizeNotificationEmails,
   normalizeQueueNames,
   serializeAlertRuleDraft,
@@ -254,6 +255,43 @@ describe('alert rule form helpers', () => {
         stalledMinutes: 12,
       },
     })
+  })
+
+  it('serializes job failed rules and Linear notification routes', () => {
+    const payload = serializeAlertRuleDraft({
+      ...createAlertRuleDraft(),
+      name: 'Create Linear issues',
+      queueFilterMode: 'exclude',
+      type: 'job_failed',
+      jobFailedMaxIssuesPerPoll: '250',
+      notificationRoutes: [
+        createLinearNotificationRouteDraft(),
+        { id: 'route-1', type: 'email', target: 'ops@example.com' },
+      ],
+    })
+
+    expect(payload).toMatchObject({
+      type: 'job_failed',
+      config: {
+        maxIssuesPerPoll: 250,
+      },
+      notificationChannels: [
+        { type: 'email', target: 'ops@example.com' },
+        { type: 'linear', target: 'org-default' },
+      ],
+    })
+  })
+
+  it('rejects out-of-range job failed poll caps', () => {
+    const error = validateAlertRuleDraft({
+      ...createAlertRuleDraft(),
+      name: 'Too many issues',
+      queueFilterMode: 'exclude',
+      type: 'job_failed',
+      jobFailedMaxIssuesPerPoll: '501',
+    })
+
+    expect(error).toBe('Max Linear issues per poll must be a whole number between 1 and 500.')
   })
 
   it('normalizes notification emails and queue names by trimming and deduping', () => {

--- a/apps/web/src/components/alerts/alert-rule-form.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.ts
@@ -226,6 +226,15 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
   }
 }
 
+function trimOrUndefined(value?: string): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function trimStringArray(values?: string[]): string[] {
+  return values?.map((value) => value.trim()).filter(Boolean) ?? []
+}
+
 export function serializeAlertRuleDraft(draft: AlertRuleDraft): AlertRuleMutationInput {
   const type = draft.type
   const baseName = draft.name.trim()
@@ -243,11 +252,17 @@ export function serializeAlertRuleDraft(draft: AlertRuleDraft): AlertRuleMutatio
       .map((route) => ({
         type: 'linear' as const,
         target: 'org-default' as const,
-        ...(route.teamId ? { teamId: route.teamId } : {}),
-        ...(route.projectId ? { projectId: route.projectId } : {}),
-        ...(route.labelIds?.length ? { labelIds: route.labelIds } : {}),
-        ...(route.assigneeId ? { assigneeId: route.assigneeId } : {}),
-        ...(route.stateId ? { stateId: route.stateId } : {}),
+        ...(trimOrUndefined(route.teamId) ? { teamId: trimOrUndefined(route.teamId) } : {}),
+        ...(trimOrUndefined(route.projectId)
+          ? { projectId: trimOrUndefined(route.projectId) }
+          : {}),
+        ...(trimStringArray(route.labelIds).length
+          ? { labelIds: trimStringArray(route.labelIds) }
+          : {}),
+        ...(trimOrUndefined(route.assigneeId)
+          ? { assigneeId: trimOrUndefined(route.assigneeId) }
+          : {}),
+        ...(trimOrUndefined(route.stateId) ? { stateId: trimOrUndefined(route.stateId) } : {}),
         ...(route.priority?.trim()
           ? { priority: parseWholeNumber(route.priority) ?? undefined }
           : {}),

--- a/apps/web/src/components/alerts/alert-rule-form.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.ts
@@ -10,8 +10,14 @@ const emailSchema = z.string().email()
 
 export interface NotificationRouteDraft {
   id: string
-  type: 'email'
+  type: 'email' | 'linear'
   target: string
+  teamId?: string
+  projectId?: string
+  labelIds?: string[]
+  assigneeId?: string
+  stateId?: string
+  priority?: string
 }
 
 export interface AlertRuleDraft {
@@ -28,6 +34,7 @@ export interface AlertRuleDraft {
   failureRateWindowMinutes: string
   failureRateMinSample: string
   stalledMinutes: string
+  jobFailedMaxIssuesPerPoll: string
 }
 
 export function createAlertRuleDraft(rule?: AlertRuleRecord | null): AlertRuleDraft {
@@ -62,6 +69,7 @@ export function createAlertRuleDraft(rule?: AlertRuleRecord | null): AlertRuleDr
     failureRateWindowMinutes: stringifyNumber(config.windowMinutes, 15),
     failureRateMinSample: stringifyNumber(config.minSample, 100),
     stalledMinutes: stringifyNumber(config.stalledMinutes, 10),
+    jobFailedMaxIssuesPerPoll: stringifyNumber(config.maxIssuesPerPoll, 100),
   }
 }
 
@@ -70,13 +78,29 @@ function extractNotificationRoutes(rule?: AlertRuleRecord | null): NotificationR
     return [createNotificationRouteDraft()]
   }
 
-  const emails = rule.notificationChannels
-    .map((channel) => (typeof channel.target === 'string' ? channel.target : ''))
-    .filter(Boolean)
+  const routes = rule.notificationChannels.flatMap((channel, index) => {
+    if (channel.type === 'email' && typeof channel.target === 'string') {
+      return [createNotificationRouteDraft(index + 1, channel.target)]
+    }
+    if (channel.type === 'linear') {
+      return [
+        {
+          id: `linear-route-${index + 1}`,
+          type: 'linear' as const,
+          target: 'org-default',
+          teamId: channel.teamId,
+          projectId: channel.projectId,
+          labelIds: channel.labelIds ?? [],
+          assigneeId: channel.assigneeId,
+          stateId: channel.stateId,
+          priority: channel.priority !== undefined ? String(channel.priority) : '',
+        },
+      ]
+    }
+    return []
+  })
 
-  return emails.length > 0
-    ? emails.map((email, index) => createNotificationRouteDraft(index + 1, email))
-    : [createNotificationRouteDraft()]
+  return routes.length > 0 ? routes : [createNotificationRouteDraft()]
 }
 
 export function createNotificationRouteDraft(sequence = 0, target = ''): NotificationRouteDraft {
@@ -87,6 +111,19 @@ export function createNotificationRouteDraft(sequence = 0, target = ''): Notific
         : `email-route-${Math.random().toString(36).slice(2, 10)}`,
     type: 'email',
     target,
+  }
+}
+
+export function createLinearNotificationRouteDraft(sequence = 0): NotificationRouteDraft {
+  return {
+    id:
+      sequence > 0
+        ? `linear-route-${sequence}`
+        : `linear-route-${Math.random().toString(36).slice(2, 10)}`,
+    type: 'linear',
+    target: 'org-default',
+    labelIds: [],
+    priority: '',
   }
 }
 
@@ -121,9 +158,8 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
     return 'Choose at least one queue or switch to "all except" mode.'
   }
 
-  const notificationEmails = normalizeNotificationEmails(
-    draft.notificationRoutes.map((route) => route.target)
-  )
+  const emailRoutes = draft.notificationRoutes.filter((route) => route.type === 'email')
+  const notificationEmails = normalizeNotificationEmails(emailRoutes.map((route) => route.target))
   if (notificationEmails.length > 10) {
     return 'You can configure up to 10 notification email recipients.'
   }
@@ -132,6 +168,13 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
     const result = emailSchema.safeParse(email)
     if (!result.success) {
       return `Invalid notification email: ${email}`
+    }
+  }
+
+  for (const route of draft.notificationRoutes.filter((item) => item.type === 'linear')) {
+    const priority = route.priority?.trim() ? parseWholeNumber(route.priority) : null
+    if (priority !== null && (priority < 0 || priority > 4)) {
+      return 'Linear priority must be between 0 and 4.'
     }
   }
 
@@ -169,6 +212,13 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
       }
       return null
     }
+    case 'job_failed': {
+      const maxIssuesPerPoll = parseWholeNumber(draft.jobFailedMaxIssuesPerPoll)
+      if (!maxIssuesPerPoll || maxIssuesPerPoll < 1 || maxIssuesPerPoll > 500) {
+        return 'Max Linear issues per poll must be a whole number between 1 and 500.'
+      }
+      return null
+    }
     default:
       return 'Unsupported alert type.'
   }
@@ -177,12 +227,28 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
 export function serializeAlertRuleDraft(draft: AlertRuleDraft): AlertRuleMutationInput {
   const type = draft.type
   const baseName = draft.name.trim()
-  const notificationChannels = normalizeNotificationEmails(
-    draft.notificationRoutes.map((route) => route.target)
-  ).map((target) => ({
-    type: 'email' as const,
-    target,
-  }))
+  const notificationChannels = [
+    ...normalizeNotificationEmails(
+      draft.notificationRoutes
+        .filter((route) => route.type === 'email')
+        .map((route) => route.target)
+    ).map((target) => ({
+      type: 'email' as const,
+      target,
+    })),
+    ...draft.notificationRoutes
+      .filter((route) => route.type === 'linear')
+      .map((route) => ({
+        type: 'linear' as const,
+        target: 'org-default' as const,
+        ...(route.teamId ? { teamId: route.teamId } : {}),
+        ...(route.projectId ? { projectId: route.projectId } : {}),
+        ...(route.labelIds?.length ? { labelIds: route.labelIds } : {}),
+        ...(route.assigneeId ? { assigneeId: route.assigneeId } : {}),
+        ...(route.stateId ? { stateId: route.stateId } : {}),
+        ...(route.priority?.trim() ? { priority: Number(route.priority) } : {}),
+      })),
+  ]
   const config = buildAlertRuleConfig(type, draft)
   const cooldownMinutes = parseWholeNumber(draft.cooldownMinutes) ?? 30
 
@@ -236,6 +302,10 @@ function buildAlertRuleConfig(type: AlertRuleType, draft: AlertRuleDraft): Recor
     case 'queue_stalled':
       return {
         stalledMinutes: parseWholeNumber(draft.stalledMinutes) ?? 10,
+      }
+    case 'job_failed':
+      return {
+        maxIssuesPerPoll: parseWholeNumber(draft.jobFailedMaxIssuesPerPoll) ?? 100,
       }
     default:
       return {}

--- a/apps/web/src/components/alerts/alert-rule-form.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.ts
@@ -172,9 +172,11 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
   }
 
   for (const route of draft.notificationRoutes.filter((item) => item.type === 'linear')) {
-    const priority = route.priority?.trim() ? parseWholeNumber(route.priority) : null
-    if (priority !== null && (priority < 0 || priority > 4)) {
-      return 'Linear priority must be between 0 and 4.'
+    if (route.priority?.trim()) {
+      const priority = parseWholeNumber(route.priority)
+      if (priority === null || priority < 0 || priority > 4) {
+        return 'Linear priority must be a whole number between 0 and 4.'
+      }
     }
   }
 
@@ -246,7 +248,9 @@ export function serializeAlertRuleDraft(draft: AlertRuleDraft): AlertRuleMutatio
         ...(route.labelIds?.length ? { labelIds: route.labelIds } : {}),
         ...(route.assigneeId ? { assigneeId: route.assigneeId } : {}),
         ...(route.stateId ? { stateId: route.stateId } : {}),
-        ...(route.priority?.trim() ? { priority: Number(route.priority) } : {}),
+        ...(route.priority?.trim()
+          ? { priority: parseWholeNumber(route.priority) ?? undefined }
+          : {}),
       })),
   ]
   const config = buildAlertRuleConfig(type, draft)

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useActiveOrganization } from '@/hooks/use-organization'
 import { api, handleRes, type InferResponseType } from '@/lib/api'
 
 type ConnectionAlertsEndpoint = (typeof api.c)[':connectionId']['alerts']
@@ -169,8 +170,10 @@ export const alertKeys = {
   summary: () => ['alerts', 'summary'] as const,
   globalEvents: (filters: AlertEventFilterOptions = {}) =>
     ['alerts', 'global-events', filters] as const,
-  linearIntegration: () => ['alerts', 'integrations', 'linear'] as const,
-  linearMetadata: () => ['alerts', 'integrations', 'linear', 'metadata'] as const,
+  linearIntegration: (organizationId?: string | null) =>
+    ['alerts', 'integrations', 'linear', organizationId ?? 'unknown'] as const,
+  linearMetadata: (organizationId?: string | null) =>
+    ['alerts', 'integrations', 'linear', organizationId ?? 'unknown', 'metadata'] as const,
   connectionRules: (connectionId: string) =>
     ['alerts', 'connection', connectionId, 'rules'] as const,
   connectionEvents: (connectionId: string, filters: AlertEventFilterOptions = {}) =>
@@ -521,8 +524,11 @@ function normalizeLinearIntegration(value: unknown): LinearIntegrationRecord | n
 }
 
 export function useLinearIntegration() {
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
+
   return useQuery({
-    queryKey: alertKeys.linearIntegration(),
+    queryKey: alertKeys.linearIntegration(organizationId),
     queryFn: async () => {
       const res = await api.alerts.integrations.linear.$get()
       const data = await handleRes<LinearIntegrationResponse>(res)
@@ -532,8 +538,11 @@ export function useLinearIntegration() {
 }
 
 export function useLinearMetadata(enabled: boolean) {
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
+
   return useQuery({
-    queryKey: alertKeys.linearMetadata(),
+    queryKey: alertKeys.linearMetadata(organizationId),
     queryFn: async () => {
       const res = await api.alerts.integrations.linear.metadata.$get()
       const data = await handleRes<LinearMetadataResponse>(res)
@@ -545,6 +554,8 @@ export function useLinearMetadata(enabled: boolean) {
 
 export function useConnectLinearIntegration() {
   const queryClient = useQueryClient()
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
 
   return useMutation({
     mutationFn: async () => {
@@ -552,13 +563,15 @@ export function useConnectLinearIntegration() {
       return handleRes<LinearConnectResponse>(res)
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() })
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration(organizationId) })
     },
   })
 }
 
 export function useSaveLinearIntegration() {
   const queryClient = useQueryClient()
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
 
   return useMutation({
     mutationFn: async (input: {
@@ -574,8 +587,8 @@ export function useSaveLinearIntegration() {
       return { integration: normalizeLinearIntegration(data.integration) }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() })
-      queryClient.invalidateQueries({ queryKey: alertKeys.linearMetadata() })
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration(organizationId) })
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearMetadata(organizationId) })
       queryClient.invalidateQueries({ queryKey: ['alerts', 'connection'] })
     },
   })
@@ -583,6 +596,8 @@ export function useSaveLinearIntegration() {
 
 export function useDeleteLinearIntegration() {
   const queryClient = useQueryClient()
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
 
   return useMutation({
     mutationFn: async () => {
@@ -590,8 +605,8 @@ export function useDeleteLinearIntegration() {
       return handleRes<{ success: boolean }>(res)
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() })
-      queryClient.invalidateQueries({ queryKey: alertKeys.linearMetadata() })
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration(organizationId) })
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearMetadata(organizationId) })
       queryClient.invalidateQueries({ queryKey: ['alerts', 'connection'] })
     },
   })
@@ -599,12 +614,15 @@ export function useDeleteLinearIntegration() {
 
 export function useTestLinearIntegration() {
   const queryClient = useQueryClient()
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
 
   return useMutation({
     mutationFn: async () => {
       const res = await api.alerts.integrations.linear.test.$post()
       return handleRes<{ ok: boolean; organizationName: string }>(res)
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration(organizationId) }),
   })
 }

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -35,6 +35,10 @@ type LinearIntegrationResponse = InferResponseType<
   (typeof api.alerts.integrations.linear)['$get'],
   200
 >
+type LinearConnectResponse = InferResponseType<
+  (typeof api.alerts.integrations.linear.connect)['$post'],
+  200
+>
 type LinearMetadataResponse = InferResponseType<
   (typeof api.alerts.integrations.linear.metadata)['$get'],
   200
@@ -103,8 +107,11 @@ export interface AlertEventRecord {
 
 export interface LinearIntegrationRecord {
   id: string
-  keyPreview: string
+  connected: boolean
   validationStatus: 'valid' | 'invalid' | 'unknown'
+  scopes: string
+  linearOrganizationName?: string | null
+  accessTokenExpiresAt?: string | Date | null
   defaultTeamId?: string | null
   defaultProjectId?: string | null
   defaultLabelIds: string[]
@@ -480,13 +487,20 @@ function normalizeLinearIntegration(value: unknown): LinearIntegrationRecord | n
   if (!isRecord(value)) return null
   return {
     id: typeof value.id === 'string' ? value.id : '',
-    keyPreview: typeof value.keyPreview === 'string' ? value.keyPreview : '',
+    connected: value.connected !== false,
     validationStatus:
       value.validationStatus === 'valid' ||
       value.validationStatus === 'invalid' ||
       value.validationStatus === 'unknown'
         ? value.validationStatus
         : 'unknown',
+    scopes: typeof value.scopes === 'string' ? value.scopes : '',
+    linearOrganizationName:
+      typeof value.linearOrganizationName === 'string' ? value.linearOrganizationName : null,
+    accessTokenExpiresAt:
+      typeof value.accessTokenExpiresAt === 'string' || value.accessTokenExpiresAt instanceof Date
+        ? value.accessTokenExpiresAt
+        : null,
     defaultTeamId: typeof value.defaultTeamId === 'string' ? value.defaultTeamId : null,
     defaultProjectId: typeof value.defaultProjectId === 'string' ? value.defaultProjectId : null,
     defaultLabelIds: normalizeStringArray(value.defaultLabelIds),
@@ -523,12 +537,25 @@ export function useLinearMetadata(enabled: boolean) {
   })
 }
 
+export function useConnectLinearIntegration() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      const res = await api.alerts.integrations.linear.connect.$post()
+      return handleRes<LinearConnectResponse>(res)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() })
+    },
+  })
+}
+
 export function useSaveLinearIntegration() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (input: {
-      apiKey?: string
       defaultTeamId?: string | null
       defaultProjectId?: string | null
       defaultLabelIds?: string[]

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -160,6 +160,8 @@ export interface AlertEventFilterOptions {
   status?: AlertEventStatus
   limit?: number
   offset?: number
+  queueName?: string
+  jobId?: string
 }
 
 export const alertKeys = {
@@ -381,6 +383,8 @@ export function useConnectionAlertEvents(
     limit: filters.limit ?? 100,
     offset: filters.offset ?? 0,
     status: filters.status,
+    queueName: filters.queueName,
+    jobId: filters.jobId,
   } satisfies AlertEventFilterOptions
 
   return useQuery({
@@ -392,6 +396,8 @@ export function useConnectionAlertEvents(
           limit: String(normalizedFilters.limit),
           offset: String(normalizedFilters.offset),
           ...(normalizedFilters.status ? { status: normalizedFilters.status } : {}),
+          ...(normalizedFilters.queueName ? { queueName: normalizedFilters.queueName } : {}),
+          ...(normalizedFilters.jobId ? { jobId: normalizedFilters.jobId } : {}),
         },
       })
       const data = await handleRes<ConnectionAlertEventsResponse>(res)

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -31,15 +31,41 @@ type TestAlertRuleResponse = InferResponseType<
   ConnectionAlertsEndpoint['rules'][':ruleId']['test']['$post'],
   200
 >
+type LinearIntegrationResponse = InferResponseType<
+  (typeof api.alerts.integrations.linear)['$get'],
+  200
+>
+type LinearMetadataResponse = InferResponseType<
+  (typeof api.alerts.integrations.linear.metadata)['$get'],
+  200
+>
 
 export type AlertSummaryConnection = AlertSummaryResponse['connections'][number]
-export type AlertRuleType = 'failure_threshold' | 'failure_rate' | 'queue_stalled'
+export type AlertRuleType = 'failure_threshold' | 'failure_rate' | 'queue_stalled' | 'job_failed'
 export type QueueFilterMode = 'include' | 'exclude'
 export type AlertEventStatus = 'firing' | 'resolved' | 'suppressed'
 
-export interface AlertNotificationChannel {
-  type: 'email'
+export type AlertNotificationChannel =
+  | { type: 'email'; target: string }
+  | {
+      type: 'linear'
+      target: 'org-default'
+      teamId?: string
+      projectId?: string
+      labelIds?: string[]
+      assigneeId?: string
+      stateId?: string
+      priority?: number
+    }
+
+export interface AlertDeliveryRecord {
+  id: string
+  channelType: 'email' | 'linear'
+  status: 'pending' | 'claimed' | 'delivered' | 'failed'
   target: string
+  externalIdentifier?: string | null
+  externalUrl?: string | null
+  lastError?: string | null
 }
 
 export interface AlertRuleRecord {
@@ -72,6 +98,28 @@ export interface AlertEventRecord {
   firedAt: string | Date
   resolvedAt?: string | Date | null
   notificationSentAt?: string | Date | null
+  deliveries: AlertDeliveryRecord[]
+}
+
+export interface LinearIntegrationRecord {
+  id: string
+  keyPreview: string
+  validationStatus: 'valid' | 'invalid' | 'unknown'
+  defaultTeamId?: string | null
+  defaultProjectId?: string | null
+  defaultLabelIds: string[]
+  defaultAssigneeId?: string | null
+  defaultStateId?: string | null
+  defaultPriority?: number | null
+  lastValidatedAt?: string | Date | null
+}
+
+export interface LinearMetadataRecord {
+  teams: Array<{ id: string; name: string; key: string }>
+  projects: Array<{ id: string; name: string }>
+  labels: Array<{ id: string; name: string }>
+  users: Array<{ id: string; name: string; email?: string | null }>
+  states: Array<{ id: string; name: string; teamId: string }>
 }
 
 export interface AlertTestResult {
@@ -112,6 +160,8 @@ export const alertKeys = {
   summary: () => ['alerts', 'summary'] as const,
   globalEvents: (filters: AlertEventFilterOptions = {}) =>
     ['alerts', 'global-events', filters] as const,
+  linearIntegration: () => ['alerts', 'integrations', 'linear'] as const,
+  linearMetadata: () => ['alerts', 'integrations', 'linear', 'metadata'] as const,
   connectionRules: (connectionId: string) =>
     ['alerts', 'connection', connectionId, 'rules'] as const,
   connectionEvents: (connectionId: string, filters: AlertEventFilterOptions = {}) =>
@@ -123,7 +173,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isAlertRuleType(value: unknown): value is AlertRuleType {
-  return value === 'failure_threshold' || value === 'failure_rate' || value === 'queue_stalled'
+  return (
+    value === 'failure_threshold' ||
+    value === 'failure_rate' ||
+    value === 'queue_stalled' ||
+    value === 'job_failed'
+  )
 }
 
 function isAlertEventStatus(value: unknown): value is AlertEventStatus {
@@ -133,8 +188,22 @@ function isAlertEventStatus(value: unknown): value is AlertEventStatus {
 function normalizeNotificationChannels(value: unknown): AlertNotificationChannel[] {
   if (!Array.isArray(value)) return []
 
-  return value.flatMap((entry) => {
+  return value.flatMap((entry): AlertNotificationChannel[] => {
     if (!isRecord(entry)) return []
+    if (entry.type === 'linear' && entry.target === 'org-default') {
+      return [
+        {
+          type: 'linear',
+          target: 'org-default',
+          teamId: typeof entry.teamId === 'string' ? entry.teamId : undefined,
+          projectId: typeof entry.projectId === 'string' ? entry.projectId : undefined,
+          labelIds: normalizeStringArray(entry.labelIds),
+          assigneeId: typeof entry.assigneeId === 'string' ? entry.assigneeId : undefined,
+          stateId: typeof entry.stateId === 'string' ? entry.stateId : undefined,
+          priority: typeof entry.priority === 'number' ? entry.priority : undefined,
+        },
+      ]
+    }
     if (entry.type !== 'email' || typeof entry.target !== 'string') return []
     return [{ type: 'email', target: entry.target }]
   })
@@ -205,7 +274,34 @@ function normalizeAlertEvent(value: unknown): AlertEventRecord {
       typeof source.notificationSentAt === 'string' || source.notificationSentAt instanceof Date
         ? source.notificationSentAt
         : null,
+    deliveries: normalizeAlertDeliveries(source.deliveries),
   }
+}
+
+function normalizeAlertDeliveries(value: unknown): AlertDeliveryRecord[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) return []
+    if (entry.channelType !== 'email' && entry.channelType !== 'linear') return []
+    return [
+      {
+        id: typeof entry.id === 'string' ? entry.id : '',
+        channelType: entry.channelType,
+        status:
+          entry.status === 'pending' ||
+          entry.status === 'claimed' ||
+          entry.status === 'delivered' ||
+          entry.status === 'failed'
+            ? entry.status
+            : 'pending',
+        target: typeof entry.target === 'string' ? entry.target : '',
+        externalIdentifier:
+          typeof entry.externalIdentifier === 'string' ? entry.externalIdentifier : null,
+        externalUrl: typeof entry.externalUrl === 'string' ? entry.externalUrl : null,
+        lastError: typeof entry.lastError === 'string' ? entry.lastError : null,
+      },
+    ]
+  })
 }
 
 function invalidateAlertQueries(queryClient: QueryClient, connectionId?: string) {
@@ -377,5 +473,105 @@ export function useTestAlertRule(connectionId: string | undefined) {
       const data = await handleRes<TestAlertRuleResponse>(res)
       return data as AlertTestResult
     },
+  })
+}
+
+function normalizeLinearIntegration(value: unknown): LinearIntegrationRecord | null {
+  if (!isRecord(value)) return null
+  return {
+    id: typeof value.id === 'string' ? value.id : '',
+    keyPreview: typeof value.keyPreview === 'string' ? value.keyPreview : '',
+    validationStatus:
+      value.validationStatus === 'valid' ||
+      value.validationStatus === 'invalid' ||
+      value.validationStatus === 'unknown'
+        ? value.validationStatus
+        : 'unknown',
+    defaultTeamId: typeof value.defaultTeamId === 'string' ? value.defaultTeamId : null,
+    defaultProjectId: typeof value.defaultProjectId === 'string' ? value.defaultProjectId : null,
+    defaultLabelIds: normalizeStringArray(value.defaultLabelIds),
+    defaultAssigneeId: typeof value.defaultAssigneeId === 'string' ? value.defaultAssigneeId : null,
+    defaultStateId: typeof value.defaultStateId === 'string' ? value.defaultStateId : null,
+    defaultPriority: typeof value.defaultPriority === 'number' ? value.defaultPriority : null,
+    lastValidatedAt:
+      typeof value.lastValidatedAt === 'string' || value.lastValidatedAt instanceof Date
+        ? value.lastValidatedAt
+        : null,
+  }
+}
+
+export function useLinearIntegration() {
+  return useQuery({
+    queryKey: alertKeys.linearIntegration(),
+    queryFn: async () => {
+      const res = await api.alerts.integrations.linear.$get()
+      const data = await handleRes<LinearIntegrationResponse>(res)
+      return { integration: normalizeLinearIntegration(data.integration) }
+    },
+  })
+}
+
+export function useLinearMetadata(enabled: boolean) {
+  return useQuery({
+    queryKey: alertKeys.linearMetadata(),
+    queryFn: async () => {
+      const res = await api.alerts.integrations.linear.metadata.$get()
+      const data = await handleRes<LinearMetadataResponse>(res)
+      return data.metadata as LinearMetadataRecord
+    },
+    enabled,
+  })
+}
+
+export function useSaveLinearIntegration() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: {
+      apiKey?: string
+      defaultTeamId?: string | null
+      defaultProjectId?: string | null
+      defaultLabelIds?: string[]
+      defaultAssigneeId?: string | null
+      defaultStateId?: string | null
+      defaultPriority?: number | null
+    }) => {
+      const res = await api.alerts.integrations.linear.$put({ json: input })
+      const data = await handleRes<LinearIntegrationResponse>(res)
+      return { integration: normalizeLinearIntegration(data.integration) }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() })
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearMetadata() })
+      queryClient.invalidateQueries({ queryKey: ['alerts', 'connection'] })
+    },
+  })
+}
+
+export function useDeleteLinearIntegration() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      const res = await api.alerts.integrations.linear.$delete()
+      return handleRes<{ success: boolean }>(res)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() })
+      queryClient.invalidateQueries({ queryKey: alertKeys.linearMetadata() })
+      queryClient.invalidateQueries({ queryKey: ['alerts', 'connection'] })
+    },
+  })
+}
+
+export function useTestLinearIntegration() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      const res = await api.alerts.integrations.linear.test.$post()
+      return handleRes<{ ok: boolean; organizationName: string }>(res)
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: alertKeys.linearIntegration() }),
   })
 }

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.test.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.test.tsx
@@ -142,6 +142,13 @@ vi.mock('@/hooks/use-alerts', () => ({
     mutateAsync: testRuleMutateAsyncMock,
     isPending: false,
   }),
+  useLinearIntegration: () => ({
+    data: {
+      integration: {
+        validationStatus: 'valid',
+      },
+    },
+  }),
 }))
 
 vi.mock('sonner', () => ({

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
@@ -2,7 +2,12 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { AlertRuleBuilderPage } from '@/components/alerts/alert-rule-builder-page'
 import { useConnection } from '@/components/connection-provider'
-import { useConnectionAlertRules, useTestAlertRule, useUpdateAlertRule } from '@/hooks/use-alerts'
+import {
+  useConnectionAlertRules,
+  useLinearIntegration,
+  useTestAlertRule,
+  useUpdateAlertRule,
+} from '@/hooks/use-alerts'
 import { useQueues } from '@/hooks/use-queues'
 
 export const Route = createFileRoute('/$orgSlug/c/$connectionId/alerts/$ruleId')({
@@ -17,6 +22,7 @@ export function EditAlertRuleRoute() {
   const queuesQuery = useQueues()
   const updateRuleMutation = useUpdateAlertRule(connectionId)
   const testRuleMutation = useTestAlertRule(connectionId)
+  const linearIntegrationQuery = useLinearIntegration()
   const rule = (rulesQuery.data?.rules ?? []).find((candidate) => candidate.id === ruleId) ?? null
 
   if (rulesQuery.isLoading) {
@@ -45,6 +51,9 @@ export function EditAlertRuleRoute() {
       rule={rule}
       isSaving={updateRuleMutation.isPending}
       isTesting={testRuleMutation.isPending}
+      linearIntegrationConfigured={
+        linearIntegrationQuery.data?.integration?.validationStatus === 'valid'
+      }
       onSave={async (inputs) => {
         const [input] = inputs
         if (!input) {

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.test.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.test.tsx
@@ -98,6 +98,13 @@ vi.mock('@/hooks/use-alerts', () => ({
     mutateAsync: createRuleMutateAsyncMock,
     isPending: false,
   }),
+  useLinearIntegration: () => ({
+    data: {
+      integration: {
+        validationStatus: 'valid',
+      },
+    },
+  }),
 }))
 
 vi.mock('sonner', () => ({

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { AlertRuleBuilderPage } from '@/components/alerts/alert-rule-builder-page'
 import { useConnection } from '@/components/connection-provider'
-import { useCreateAlertRule } from '@/hooks/use-alerts'
+import { useCreateAlertRule, useLinearIntegration } from '@/hooks/use-alerts'
 import { useQueues } from '@/hooks/use-queues'
 
 export const Route = createFileRoute('/$orgSlug/c/$connectionId/alerts/new')({
@@ -15,6 +15,7 @@ export function CreateAlertRuleRoute() {
   const { currentConnection } = useConnection()
   const queuesQuery = useQueues()
   const createRuleMutation = useCreateAlertRule(connectionId)
+  const linearIntegrationQuery = useLinearIntegration()
 
   return (
     <AlertRuleBuilderPage
@@ -25,6 +26,9 @@ export function CreateAlertRuleRoute() {
       connectionName={currentConnection?.name}
       availableQueues={(queuesQuery.data?.queues ?? []).map((queue) => queue.name)}
       isSaving={createRuleMutation.isPending}
+      linearIntegrationConfigured={
+        linearIntegrationQuery.data?.integration?.validationStatus === 'valid'
+      }
       onSave={async (inputs) => {
         for (const input of inputs) {
           await createRuleMutation.mutateAsync(input)

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -77,7 +77,11 @@ function JobDetailPage() {
 
   const { data: job, isLoading, error } = useJob(queueName, jobId)
   const { data: logsData } = useJobLogs(queueName, jobId)
-  const alertEventsQuery = useConnectionAlertEvents(connectionId, { limit: 100 })
+  const alertEventsQuery = useConnectionAlertEvents(connectionId, {
+    queueName,
+    jobId,
+    limit: 20,
+  })
 
   const retryMutation = useRetryJobs()
   const removeMutation = useRemoveJobs()
@@ -133,7 +137,6 @@ function JobDetailPage() {
 
   const linearIssueLinks = useMemo(() => {
     return (alertEventsQuery.data?.events ?? []).flatMap((event) => {
-      if (event.queueName !== queueName || event.context.jobId !== jobId) return []
       return event.deliveries
         .filter((delivery) => delivery.channelType === 'linear' && delivery.externalUrl)
         .map((delivery) => ({
@@ -142,7 +145,7 @@ function JobDetailPage() {
           url: delivery.externalUrl ?? '',
         }))
     })
-  }, [alertEventsQuery.data?.events, jobId, queueName])
+  }, [alertEventsQuery.data?.events])
 
   const handleRemove = useCallback(
     (removeScheduler = false) => {

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   Copy,
   CopyPlus,
+  ExternalLink,
   FileJson2,
   History,
   Info,
@@ -43,6 +44,7 @@ import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { useConnectionAlertEvents } from '@/hooks/use-alerts'
 import { useJob, useJobLogs, useRemoveJobs, useRetryJobs } from '@/hooks/use-queues'
 import { cn, formatDate, formatDuration, getTimezoneAbbreviation } from '@/lib/utils'
 
@@ -75,6 +77,7 @@ function JobDetailPage() {
 
   const { data: job, isLoading, error } = useJob(queueName, jobId)
   const { data: logsData } = useJobLogs(queueName, jobId)
+  const alertEventsQuery = useConnectionAlertEvents(connectionId, { limit: 100 })
 
   const retryMutation = useRetryJobs()
   const removeMutation = useRemoveJobs()
@@ -127,6 +130,19 @@ function JobDetailPage() {
   }, [connectionId, jobId, navigate, orgSlug, queueName, retryMutation])
 
   const isScheduledJob = jobId.startsWith('repeat:')
+
+  const linearIssueLinks = useMemo(() => {
+    return (alertEventsQuery.data?.events ?? []).flatMap((event) => {
+      if (event.queueName !== queueName || event.context.jobId !== jobId) return []
+      return event.deliveries
+        .filter((delivery) => delivery.channelType === 'linear' && delivery.externalUrl)
+        .map((delivery) => ({
+          id: delivery.id,
+          label: delivery.externalIdentifier ?? 'Linear issue',
+          url: delivery.externalUrl ?? '',
+        }))
+    })
+  }, [alertEventsQuery.data?.events, jobId, queueName])
 
   const handleRemove = useCallback(
     (removeScheduler = false) => {
@@ -409,6 +425,27 @@ function JobDetailPage() {
           </CardContent>
         </Card>
       )}
+
+      {linearIssueLinks.length > 0 ? (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+              <ExternalLink className="h-4 w-4" />
+              Linked Linear issues
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-2">
+            {linearIssueLinks.map((issue) => (
+              <Button key={issue.id} asChild variant="outline" size="sm">
+                <a href={issue.url} target="_blank" rel="noreferrer">
+                  {issue.label}
+                  <ExternalLink className="ml-2 h-3.5 w-3.5" />
+                </a>
+              </Button>
+            ))}
+          </CardContent>
+        </Card>
+      ) : null}
 
       {/* Tabs */}
       <Tabs

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -40,6 +40,13 @@ vi.mock('@/hooks/use-app-config', () => ({
   }),
 }))
 
+vi.mock('@/hooks/use-alerts', () => ({
+  useLinearIntegration: () => ({ data: { integration: null } }),
+  useSaveLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useTestLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
 vi.mock('@/hooks/use-auth', () => ({
   linkSocial: vi.fn(),
   listAccounts: mocks.listAccounts,

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@/hooks/use-app-config', () => ({
 
 vi.mock('@/hooks/use-alerts', () => ({
   useLinearIntegration: () => ({ data: { integration: null } }),
+  useConnectLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useSaveLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDeleteLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useTestLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -1,8 +1,26 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  connectLinearIntegrationMutateAsync: vi.fn(),
+  deleteLinearIntegrationMutateAsync: vi.fn(),
+  linearIntegration: null as null | {
+    id: string
+    connected: boolean
+    validationStatus: 'valid' | 'invalid' | 'unknown'
+    scopes: string
+    linearOrganizationName: string | null
+    defaultTeamId: string | null
+    defaultProjectId: string | null
+    defaultLabelIds: string[]
+    defaultAssigneeId: string | null
+    defaultStateId: string | null
+    defaultPriority: number | null
+    lastValidatedAt: string | null
+  },
   listAccounts: vi.fn(),
+  saveLinearIntegrationMutateAsync: vi.fn(),
+  testLinearIntegrationMutateAsync: vi.fn(),
   trackEvent: vi.fn(),
 }))
 
@@ -41,11 +59,23 @@ vi.mock('@/hooks/use-app-config', () => ({
 }))
 
 vi.mock('@/hooks/use-alerts', () => ({
-  useLinearIntegration: () => ({ data: { integration: null } }),
-  useConnectLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useSaveLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useDeleteLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useTestLinearIntegration: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useLinearIntegration: () => ({ data: { integration: mocks.linearIntegration } }),
+  useConnectLinearIntegration: () => ({
+    mutateAsync: mocks.connectLinearIntegrationMutateAsync,
+    isPending: false,
+  }),
+  useSaveLinearIntegration: () => ({
+    mutateAsync: mocks.saveLinearIntegrationMutateAsync,
+    isPending: false,
+  }),
+  useDeleteLinearIntegration: () => ({
+    mutateAsync: mocks.deleteLinearIntegrationMutateAsync,
+    isPending: false,
+  }),
+  useTestLinearIntegration: () => ({
+    mutateAsync: mocks.testLinearIntegrationMutateAsync,
+    isPending: false,
+  }),
 }))
 
 vi.mock('@/hooks/use-auth', () => ({
@@ -73,8 +103,17 @@ import { Route } from '@/routes/settings'
 
 describe('SettingsPage', () => {
   beforeEach(() => {
+    window.sessionStorage.clear()
+    mocks.connectLinearIntegrationMutateAsync.mockReset()
+    mocks.connectLinearIntegrationMutateAsync.mockResolvedValue({
+      authorizationUrl: 'https://linear.app/oauth/authorize?state=test',
+    })
+    mocks.deleteLinearIntegrationMutateAsync.mockReset()
+    mocks.linearIntegration = null
     mocks.listAccounts.mockReset()
     mocks.listAccounts.mockResolvedValue({ data: [] })
+    mocks.saveLinearIntegrationMutateAsync.mockReset()
+    mocks.testLinearIntegrationMutateAsync.mockReset()
     mocks.trackEvent.mockReset()
   })
 
@@ -84,5 +123,55 @@ describe('SettingsPage', () => {
     render(<Component />)
 
     expect(screen.getByText('Durabull v1.2.3-test')).toBeInTheDocument()
+  })
+
+  it('allows entering a Linear team before starting OAuth and starts the connect flow', async () => {
+    const Component = Route.options.component as () => React.ReactNode
+    mocks.connectLinearIntegrationMutateAsync.mockImplementation(() => new Promise(() => {}))
+
+    render(<Component />)
+
+    const teamInput = screen.getByRole('textbox', { name: /default linear team id/i })
+    fireEvent.change(teamInput, { target: { value: 'team-123' } })
+    expect(teamInput).toHaveValue('team-123')
+
+    const connectButton = screen.getByRole('button', { name: /connect linear/i })
+    expect(connectButton).toBeEnabled()
+    fireEvent.click(connectButton)
+
+    await waitFor(() => expect(mocks.connectLinearIntegrationMutateAsync).toHaveBeenCalledTimes(1))
+    expect(window.sessionStorage.getItem('durabull.linear.pendingDefaultTeamId')).toBe('team-123')
+  })
+
+  it('saves a team entered before OAuth after Linear returns connected', async () => {
+    window.sessionStorage.setItem('durabull.linear.pendingDefaultTeamId', 'team-456')
+    mocks.linearIntegration = {
+      id: 'linear-1',
+      connected: true,
+      validationStatus: 'valid',
+      scopes: 'read issues:create',
+      linearOrganizationName: 'Acme',
+      defaultTeamId: null,
+      defaultProjectId: null,
+      defaultLabelIds: [],
+      defaultAssigneeId: null,
+      defaultStateId: null,
+      defaultPriority: null,
+      lastValidatedAt: null,
+    }
+    mocks.saveLinearIntegrationMutateAsync.mockResolvedValue({
+      integration: mocks.linearIntegration,
+    })
+    const Component = Route.options.component as () => React.ReactNode
+
+    render(<Component />)
+
+    await waitFor(() =>
+      expect(mocks.saveLinearIntegrationMutateAsync).toHaveBeenCalledWith({
+        defaultTeamId: 'team-456',
+      })
+    )
+    expect(screen.getByRole('textbox', { name: /default linear team id/i })).toHaveValue('team-456')
+    expect(window.sessionStorage.getItem('durabull.linear.pendingDefaultTeamId')).toBeNull()
   })
 })

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -125,26 +125,24 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Durabull v1.2.3-test')).toBeInTheDocument()
   })
 
-  it('allows entering a Linear team before starting OAuth and starts the connect flow', async () => {
+  it('only shows the Linear connect action before OAuth is configured', async () => {
     const Component = Route.options.component as () => React.ReactNode
     mocks.connectLinearIntegrationMutateAsync.mockImplementation(() => new Promise(() => {}))
 
     render(<Component />)
 
-    const teamInput = screen.getByRole('textbox', { name: /default linear team id/i })
-    fireEvent.change(teamInput, { target: { value: 'team-123' } })
-    expect(teamInput).toHaveValue('team-123')
+    expect(
+      screen.queryByRole('textbox', { name: /default linear team id/i })
+    ).not.toBeInTheDocument()
 
     const connectButton = screen.getByRole('button', { name: /connect linear/i })
     expect(connectButton).toBeEnabled()
     fireEvent.click(connectButton)
 
     await waitFor(() => expect(mocks.connectLinearIntegrationMutateAsync).toHaveBeenCalledTimes(1))
-    expect(window.sessionStorage.getItem('durabull.linear.pendingDefaultTeamId')).toBe('team-123')
   })
 
-  it('saves a team entered before OAuth after Linear returns connected', async () => {
-    window.sessionStorage.setItem('durabull.linear.pendingDefaultTeamId', 'team-456')
+  it('shows and saves Linear team defaults only after Linear is connected', async () => {
     mocks.linearIntegration = {
       id: 'linear-1',
       connected: true,
@@ -166,12 +164,15 @@ describe('SettingsPage', () => {
 
     render(<Component />)
 
+    const teamInput = screen.getByRole('textbox', { name: /default linear team id/i })
+    expect(teamInput).toHaveValue('')
+    fireEvent.change(teamInput, { target: { value: 'team-456' } })
+    fireEvent.click(screen.getByRole('button', { name: /save defaults/i }))
+
     await waitFor(() =>
       expect(mocks.saveLinearIntegrationMutateAsync).toHaveBeenCalledWith({
         defaultTeamId: 'team-456',
       })
     )
-    expect(screen.getByRole('textbox', { name: /default linear team id/i })).toHaveValue('team-456')
-    expect(window.sessionStorage.getItem('durabull.linear.pendingDefaultTeamId')).toBeNull()
   })
 })

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/dialog'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
+  useConnectLinearIntegration,
   useDeleteLinearIntegration,
   useLinearIntegration,
   useSaveLinearIntegration,
@@ -83,11 +84,11 @@ function SettingsPage() {
   const { user, isLoading: sessionLoading } = useAuth()
   const { config } = useAppConfig()
   const linearIntegrationQuery = useLinearIntegration()
+  const connectLinearIntegration = useConnectLinearIntegration()
   const saveLinearIntegration = useSaveLinearIntegration()
   const deleteLinearIntegration = useDeleteLinearIntegration()
   const testLinearIntegration = useTestLinearIntegration()
   const [accounts, setAccounts] = useState<LinkedAccount[]>([])
-  const [linearApiKey, setLinearApiKey] = useState('')
   const [linearTeamId, setLinearTeamId] = useState('')
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(true)
   const [linkingProvider, setLinkingProvider] = useState<ProviderId | null>(null)
@@ -317,7 +318,7 @@ function SettingsPage() {
             <div>
               <CardTitle className="text-base">Linear alerts</CardTitle>
               <CardDescription>
-                Store an encrypted Linear API key and default team for issue creation.
+                Connect Linear with OAuth and choose defaults for alert-created issues.
               </CardDescription>
             </div>
           </div>
@@ -333,42 +334,53 @@ function SettingsPage() {
                   : 'Needs attention'
                 : 'Not configured'}
             </Badge>
-            {linearIntegration?.keyPreview ? (
+            {linearIntegration?.linearOrganizationName ? (
+              <span className="text-xs text-muted-foreground">
+                {linearIntegration.linearOrganizationName}
+              </span>
+            ) : null}
+            {linearIntegration?.scopes ? (
               <span className="font-mono text-xs text-muted-foreground">
-                {linearIntegration.keyPreview}
+                {linearIntegration.scopes}
               </span>
             ) : null}
           </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            <input
-              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-              type="password"
-              value={linearApiKey}
-              onChange={(event) => setLinearApiKey(event.target.value)}
-              placeholder={linearIntegration ? 'Rotate API key' : 'Linear API key'}
-            />
+          <div className="grid gap-3 md:grid-cols-[1fr_auto]">
             <input
               className="h-10 rounded-md border border-input bg-background px-3 text-sm"
               value={linearTeamId}
               onChange={(event) => setLinearTeamId(event.target.value)}
               placeholder="Default Linear team ID"
+              disabled={!linearIntegration}
             />
+            {!linearIntegration ? (
+              <Button
+                type="button"
+                onClick={async () => {
+                  const result = await connectLinearIntegration.mutateAsync()
+                  window.location.assign(result.authorizationUrl)
+                }}
+                disabled={connectLinearIntegration.isPending}
+              >
+                {connectLinearIntegration.isPending ? 'Connecting...' : 'Connect Linear'}
+              </Button>
+            ) : null}
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              onClick={async () => {
-                await saveLinearIntegration.mutateAsync({
-                  ...(linearApiKey.trim() ? { apiKey: linearApiKey.trim() } : {}),
-                  defaultTeamId: linearTeamId.trim() || null,
-                })
-                setLinearApiKey('')
-                toast.success('Linear integration saved')
-              }}
-              disabled={saveLinearIntegration.isPending || (!linearIntegration && !linearApiKey)}
-            >
-              {saveLinearIntegration.isPending ? 'Saving...' : 'Save Linear settings'}
-            </Button>
+            {linearIntegration ? (
+              <Button
+                type="button"
+                onClick={async () => {
+                  await saveLinearIntegration.mutateAsync({
+                    defaultTeamId: linearTeamId.trim() || null,
+                  })
+                  toast.success('Linear defaults saved')
+                }}
+                disabled={saveLinearIntegration.isPending}
+              >
+                {saveLinearIntegration.isPending ? 'Saving...' : 'Save defaults'}
+              </Button>
+            ) : null}
             {linearIntegration ? (
               <Button
                 type="button"
@@ -390,7 +402,6 @@ function SettingsPage() {
                 variant="destructive"
                 onClick={async () => {
                   await deleteLinearIntegration.mutateAsync()
-                  setLinearApiKey('')
                   setLinearTeamId('')
                   toast.success('Linear integration removed')
                 }}
@@ -401,8 +412,8 @@ function SettingsPage() {
             ) : null}
           </div>
           <p className="text-sm text-muted-foreground">
-            The key is encrypted at rest and never returned by the API. Rules can override Linear
-            fields, but the default team is used when no rule-level team is set.
+            OAuth tokens are encrypted at rest and never returned by the API. Rules can override
+            Linear fields, but the default team is used when no rule-level team is set.
           </p>
         </CardContent>
       </Card>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -28,6 +28,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  useDeleteLinearIntegration,
+  useLinearIntegration,
+  useSaveLinearIntegration,
+  useTestLinearIntegration,
+} from '@/hooks/use-alerts'
 import { useAppConfig } from '@/hooks/use-app-config'
 import { linkSocial, listAccounts, unlinkAccount, useAuth } from '@/hooks/use-auth'
 import { APP_BUILD_INFO } from '@/lib/app-version'
@@ -76,7 +82,13 @@ interface LinkedAccount {
 function SettingsPage() {
   const { user, isLoading: sessionLoading } = useAuth()
   const { config } = useAppConfig()
+  const linearIntegrationQuery = useLinearIntegration()
+  const saveLinearIntegration = useSaveLinearIntegration()
+  const deleteLinearIntegration = useDeleteLinearIntegration()
+  const testLinearIntegration = useTestLinearIntegration()
   const [accounts, setAccounts] = useState<LinkedAccount[]>([])
+  const [linearApiKey, setLinearApiKey] = useState('')
+  const [linearTeamId, setLinearTeamId] = useState('')
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(true)
   const [linkingProvider, setLinkingProvider] = useState<ProviderId | null>(null)
   const [unlinkingAccount, setUnlinkingAccount] = useState<LinkedAccount | null>(null)
@@ -99,6 +111,12 @@ function SettingsPage() {
   )
 
   useAppTopBar(topBarConfig)
+
+  const linearIntegration = linearIntegrationQuery.data?.integration ?? null
+
+  useEffect(() => {
+    setLinearTeamId(linearIntegration?.defaultTeamId ?? '')
+  }, [linearIntegration?.defaultTeamId])
 
   // Fetch linked accounts
   useEffect(() => {
@@ -289,6 +307,103 @@ function SettingsPage() {
               })}
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b bg-muted/30">
+          <div className="flex items-center gap-2">
+            <Link2 className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <CardTitle className="text-base">Linear alerts</CardTitle>
+              <CardDescription>
+                Store an encrypted Linear API key and default team for issue creation.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4 p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant={linearIntegration?.validationStatus === 'valid' ? 'success' : 'secondary'}
+            >
+              {linearIntegration
+                ? linearIntegration.validationStatus === 'valid'
+                  ? 'Valid'
+                  : 'Needs attention'
+                : 'Not configured'}
+            </Badge>
+            {linearIntegration?.keyPreview ? (
+              <span className="font-mono text-xs text-muted-foreground">
+                {linearIntegration.keyPreview}
+              </span>
+            ) : null}
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <input
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+              type="password"
+              value={linearApiKey}
+              onChange={(event) => setLinearApiKey(event.target.value)}
+              placeholder={linearIntegration ? 'Rotate API key' : 'Linear API key'}
+            />
+            <input
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+              value={linearTeamId}
+              onChange={(event) => setLinearTeamId(event.target.value)}
+              placeholder="Default Linear team ID"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              onClick={async () => {
+                await saveLinearIntegration.mutateAsync({
+                  ...(linearApiKey.trim() ? { apiKey: linearApiKey.trim() } : {}),
+                  defaultTeamId: linearTeamId.trim() || null,
+                })
+                setLinearApiKey('')
+                toast.success('Linear integration saved')
+              }}
+              disabled={saveLinearIntegration.isPending || (!linearIntegration && !linearApiKey)}
+            >
+              {saveLinearIntegration.isPending ? 'Saving...' : 'Save Linear settings'}
+            </Button>
+            {linearIntegration ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={async () => {
+                  const result = await testLinearIntegration.mutateAsync()
+                  toast.success('Linear connection verified', {
+                    description: result.organizationName,
+                  })
+                }}
+                disabled={testLinearIntegration.isPending}
+              >
+                {testLinearIntegration.isPending ? 'Testing...' : 'Test connection'}
+              </Button>
+            ) : null}
+            {linearIntegration ? (
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={async () => {
+                  await deleteLinearIntegration.mutateAsync()
+                  setLinearApiKey('')
+                  setLinearTeamId('')
+                  toast.success('Linear integration removed')
+                }}
+                disabled={deleteLinearIntegration.isPending}
+              >
+                Remove
+              </Button>
+            ) : null}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            The key is encrypted at rest and never returned by the API. Rules can override Linear
+            fields, but the default team is used when no rule-level team is set.
+          </p>
         </CardContent>
       </Card>
 

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -13,7 +13,7 @@ import {
   Settings,
   Shield,
 } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useAppTopBar } from '@/components/app-top-bar'
 import { Badge } from '@/components/ui/badge'
@@ -67,7 +67,6 @@ const providers = [
 ] as const
 
 type ProviderId = (typeof providers)[number]['id']
-const LINEAR_PENDING_TEAM_STORAGE_KEY = 'durabull.linear.pendingDefaultTeamId'
 
 // Account type from better-auth
 interface LinkedAccount {
@@ -95,7 +94,6 @@ function SettingsPage() {
   const [linkingProvider, setLinkingProvider] = useState<ProviderId | null>(null)
   const [unlinkingAccount, setUnlinkingAccount] = useState<LinkedAccount | null>(null)
   const [isUnlinking, setIsUnlinking] = useState(false)
-  const appliedPendingLinearTeam = useRef(false)
   const topBarConfig = useMemo(
     () => ({
       left: (
@@ -120,28 +118,6 @@ function SettingsPage() {
   useEffect(() => {
     setLinearTeamId(linearIntegration?.defaultTeamId ?? '')
   }, [linearIntegration?.defaultTeamId])
-
-  useEffect(() => {
-    if (!linearIntegration || appliedPendingLinearTeam.current) return
-    const pendingTeamId = window.sessionStorage.getItem(LINEAR_PENDING_TEAM_STORAGE_KEY)
-    if (pendingTeamId === null) return
-
-    appliedPendingLinearTeam.current = true
-    window.sessionStorage.removeItem(LINEAR_PENDING_TEAM_STORAGE_KEY)
-    setLinearTeamId(pendingTeamId)
-
-    if (pendingTeamId === (linearIntegration.defaultTeamId ?? '')) return
-
-    saveLinearIntegration
-      .mutateAsync({ defaultTeamId: pendingTeamId || null })
-      .then(() => toast.success('Linear defaults saved'))
-      .catch((error) => {
-        console.error('Failed to save Linear defaults after OAuth:', error)
-        toast.error('Linear connected, but defaults were not saved', {
-          description: getErrorMessage(error, 'Save the default team again.'),
-        })
-      })
-  }, [linearIntegration, saveLinearIntegration])
 
   // Fetch linked accounts
   useEffect(() => {
@@ -369,25 +345,11 @@ function SettingsPage() {
               </span>
             ) : null}
           </div>
-          <div className="grid gap-3 md:grid-cols-[1fr_auto]">
-            <input
-              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-              value={linearTeamId}
-              onChange={(event) => setLinearTeamId(event.target.value)}
-              placeholder="Default Linear team ID"
-              aria-label="Default Linear team ID"
-            />
-            {!linearIntegration ? (
+          {!linearIntegration ? (
+            <div>
               <Button
                 type="button"
                 onClick={async () => {
-                  const pendingTeamId = linearTeamId.trim()
-                  if (pendingTeamId) {
-                    window.sessionStorage.setItem(LINEAR_PENDING_TEAM_STORAGE_KEY, pendingTeamId)
-                  } else {
-                    window.sessionStorage.removeItem(LINEAR_PENDING_TEAM_STORAGE_KEY)
-                  }
-
                   try {
                     const result = await connectLinearIntegration.mutateAsync()
                     window.location.assign(result.authorizationUrl)
@@ -405,8 +367,18 @@ function SettingsPage() {
               >
                 {connectLinearIntegration.isPending ? 'Connecting...' : 'Connect Linear'}
               </Button>
-            ) : null}
-          </div>
+            </div>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+              <input
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                value={linearTeamId}
+                onChange={(event) => setLinearTeamId(event.target.value)}
+                placeholder="Default Linear team ID"
+                aria-label="Default Linear team ID"
+              />
+            </div>
+          )}
           <div className="flex flex-wrap gap-2">
             {linearIntegration ? (
               <Button

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -13,7 +13,7 @@ import {
   Settings,
   Shield,
 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useAppTopBar } from '@/components/app-top-bar'
 import { Badge } from '@/components/ui/badge'
@@ -67,6 +67,7 @@ const providers = [
 ] as const
 
 type ProviderId = (typeof providers)[number]['id']
+const LINEAR_PENDING_TEAM_STORAGE_KEY = 'durabull.linear.pendingDefaultTeamId'
 
 // Account type from better-auth
 interface LinkedAccount {
@@ -94,6 +95,7 @@ function SettingsPage() {
   const [linkingProvider, setLinkingProvider] = useState<ProviderId | null>(null)
   const [unlinkingAccount, setUnlinkingAccount] = useState<LinkedAccount | null>(null)
   const [isUnlinking, setIsUnlinking] = useState(false)
+  const appliedPendingLinearTeam = useRef(false)
   const topBarConfig = useMemo(
     () => ({
       left: (
@@ -118,6 +120,28 @@ function SettingsPage() {
   useEffect(() => {
     setLinearTeamId(linearIntegration?.defaultTeamId ?? '')
   }, [linearIntegration?.defaultTeamId])
+
+  useEffect(() => {
+    if (!linearIntegration || appliedPendingLinearTeam.current) return
+    const pendingTeamId = window.sessionStorage.getItem(LINEAR_PENDING_TEAM_STORAGE_KEY)
+    if (pendingTeamId === null) return
+
+    appliedPendingLinearTeam.current = true
+    window.sessionStorage.removeItem(LINEAR_PENDING_TEAM_STORAGE_KEY)
+    setLinearTeamId(pendingTeamId)
+
+    if (pendingTeamId === (linearIntegration.defaultTeamId ?? '')) return
+
+    saveLinearIntegration
+      .mutateAsync({ defaultTeamId: pendingTeamId || null })
+      .then(() => toast.success('Linear defaults saved'))
+      .catch((error) => {
+        console.error('Failed to save Linear defaults after OAuth:', error)
+        toast.error('Linear connected, but defaults were not saved', {
+          description: getErrorMessage(error, 'Save the default team again.'),
+        })
+      })
+  }, [linearIntegration, saveLinearIntegration])
 
   // Fetch linked accounts
   useEffect(() => {
@@ -351,14 +375,31 @@ function SettingsPage() {
               value={linearTeamId}
               onChange={(event) => setLinearTeamId(event.target.value)}
               placeholder="Default Linear team ID"
-              disabled={!linearIntegration}
+              aria-label="Default Linear team ID"
             />
             {!linearIntegration ? (
               <Button
                 type="button"
                 onClick={async () => {
-                  const result = await connectLinearIntegration.mutateAsync()
-                  window.location.assign(result.authorizationUrl)
+                  const pendingTeamId = linearTeamId.trim()
+                  if (pendingTeamId) {
+                    window.sessionStorage.setItem(LINEAR_PENDING_TEAM_STORAGE_KEY, pendingTeamId)
+                  } else {
+                    window.sessionStorage.removeItem(LINEAR_PENDING_TEAM_STORAGE_KEY)
+                  }
+
+                  try {
+                    const result = await connectLinearIntegration.mutateAsync()
+                    window.location.assign(result.authorizationUrl)
+                  } catch (error) {
+                    console.error('Failed to start Linear OAuth:', error)
+                    toast.error('Failed to start Linear connection', {
+                      description: getErrorMessage(
+                        error,
+                        'Check the Linear OAuth configuration and try again.'
+                      ),
+                    })
+                  }
                 }}
                 disabled={connectLinearIntegration.isPending}
               >
@@ -541,6 +582,10 @@ function SettingsPage() {
       </Dialog>
     </div>
   )
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  return error instanceof Error && error.message ? error.message : fallback
 }
 
 interface AccountRowProps {

--- a/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
+++ b/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
@@ -8,8 +8,12 @@ CREATE TABLE "linear_integration" (
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
   "organization_id" text NOT NULL,
-  "encrypted_api_key" text NOT NULL,
-  "key_preview" text NOT NULL,
+  "encrypted_access_token" text NOT NULL,
+  "encrypted_refresh_token" text NOT NULL,
+  "token_type" text DEFAULT 'Bearer' NOT NULL,
+  "scopes" text NOT NULL,
+  "access_token_expires_at" timestamp with time zone NOT NULL,
+  "linear_organization_name" text,
   "validation_status" text DEFAULT 'unknown' NOT NULL,
   "default_team_id" text,
   "default_project_id" text,
@@ -22,6 +26,22 @@ CREATE TABLE "linear_integration" (
   CONSTRAINT "linear_integration_organization_id_organization_id_fk"
     FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade
 );
+--> statement-breakpoint
+CREATE TABLE "linear_oauth_state" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "organization_id" text NOT NULL,
+  "user_id" text NOT NULL,
+  "state_hash" text NOT NULL,
+  "redirect_uri" text NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  CONSTRAINT "linear_oauth_state_state_hash_unique" UNIQUE("state_hash"),
+  CONSTRAINT "linear_oauth_state_organization_id_organization_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX "linear_oauth_state_expires_at_idx" ON "linear_oauth_state" ("expires_at");
 --> statement-breakpoint
 CREATE TABLE "alert_delivery" (
   "id" uuid PRIMARY KEY NOT NULL,

--- a/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
+++ b/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
@@ -1,0 +1,80 @@
+ALTER TABLE "alert_event" ADD COLUMN "dedupe_key" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "alert_event_rule_dedupe_key_idx"
+  ON "alert_event" ("alert_rule_id", "dedupe_key");
+--> statement-breakpoint
+CREATE TABLE "linear_integration" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "organization_id" text NOT NULL,
+  "encrypted_api_key" text NOT NULL,
+  "key_preview" text NOT NULL,
+  "validation_status" text DEFAULT 'unknown' NOT NULL,
+  "default_team_id" text,
+  "default_project_id" text,
+  "default_label_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "default_assignee_id" text,
+  "default_state_id" text,
+  "default_priority" integer,
+  "last_validated_at" timestamp with time zone,
+  CONSTRAINT "linear_integration_organization_id_unique" UNIQUE("organization_id"),
+  CONSTRAINT "linear_integration_organization_id_organization_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE "alert_delivery" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "alert_event_id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "channel_type" text NOT NULL,
+  "target" text NOT NULL,
+  "status" text DEFAULT 'pending' NOT NULL,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "next_retry_at" timestamp with time zone,
+  "claimed_at" timestamp with time zone,
+  "last_error" text,
+  "provider_metadata" jsonb DEFAULT '{}'::jsonb,
+  "external_id" text,
+  "external_identifier" text,
+  "external_url" text,
+  CONSTRAINT "alert_delivery_alert_event_id_alert_event_id_fk"
+    FOREIGN KEY ("alert_event_id") REFERENCES "alert_event"("id") ON DELETE cascade,
+  CONSTRAINT "alert_delivery_organization_id_organization_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX "alert_delivery_event_id_idx" ON "alert_delivery" ("alert_event_id");
+--> statement-breakpoint
+CREATE INDEX "alert_delivery_org_status_retry_idx"
+  ON "alert_delivery" ("organization_id", "status", "next_retry_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "alert_delivery_event_channel_target_idx"
+  ON "alert_delivery" ("alert_event_id", "channel_type", "target");
+--> statement-breakpoint
+CREATE TABLE "linear_job_issue" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "organization_id" text NOT NULL,
+  "connection_id" uuid NOT NULL,
+  "queue_name" text NOT NULL,
+  "job_id" text NOT NULL,
+  "alert_event_id" uuid NOT NULL,
+  "linear_issue_id" text NOT NULL,
+  "linear_issue_identifier" text NOT NULL,
+  "linear_issue_url" text NOT NULL,
+  CONSTRAINT "linear_job_issue_organization_id_organization_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade,
+  CONSTRAINT "linear_job_issue_connection_id_redis_connection_id_fk"
+    FOREIGN KEY ("connection_id") REFERENCES "redis_connection"("id") ON DELETE cascade,
+  CONSTRAINT "linear_job_issue_alert_event_id_alert_event_id_fk"
+    FOREIGN KEY ("alert_event_id") REFERENCES "alert_event"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX "linear_job_issue_alert_event_id_idx" ON "linear_job_issue" ("alert_event_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "linear_job_issue_job_unique_idx"
+  ON "linear_job_issue" ("organization_id", "connection_id", "queue_name", "job_id");

--- a/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
+++ b/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
@@ -82,19 +82,14 @@ CREATE TABLE "linear_job_issue" (
   "connection_id" uuid NOT NULL,
   "queue_name" text NOT NULL,
   "job_id" text NOT NULL,
-  "alert_event_id" uuid NOT NULL,
   "linear_issue_id" text NOT NULL,
   "linear_issue_identifier" text NOT NULL,
   "linear_issue_url" text NOT NULL,
   CONSTRAINT "linear_job_issue_organization_id_organization_id_fk"
     FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade,
   CONSTRAINT "linear_job_issue_connection_id_redis_connection_id_fk"
-    FOREIGN KEY ("connection_id") REFERENCES "redis_connection"("id") ON DELETE cascade,
-  CONSTRAINT "linear_job_issue_alert_event_id_alert_event_id_fk"
-    FOREIGN KEY ("alert_event_id") REFERENCES "alert_event"("id") ON DELETE cascade
+    FOREIGN KEY ("connection_id") REFERENCES "redis_connection"("id") ON DELETE cascade
 );
---> statement-breakpoint
-CREATE INDEX "linear_job_issue_alert_event_id_idx" ON "linear_job_issue" ("alert_event_id");
 --> statement-breakpoint
 CREATE UNIQUE INDEX "linear_job_issue_job_unique_idx"
   ON "linear_job_issue" ("organization_id", "connection_id", "queue_name", "job_id");

--- a/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
+++ b/packages/dal/src/db/migrations/20260505120000_linear_alert_channel/migration.sql
@@ -98,3 +98,21 @@ CREATE INDEX "linear_job_issue_alert_event_id_idx" ON "linear_job_issue" ("alert
 --> statement-breakpoint
 CREATE UNIQUE INDEX "linear_job_issue_job_unique_idx"
   ON "linear_job_issue" ("organization_id", "connection_id", "queue_name", "job_id");
+--> statement-breakpoint
+CREATE TABLE "linear_job_issue_event" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "linear_job_issue_id" uuid NOT NULL,
+  "alert_event_id" uuid NOT NULL,
+  CONSTRAINT "linear_job_issue_event_linear_job_issue_id_fk"
+    FOREIGN KEY ("linear_job_issue_id") REFERENCES "linear_job_issue"("id") ON DELETE cascade,
+  CONSTRAINT "linear_job_issue_event_alert_event_id_fk"
+    FOREIGN KEY ("alert_event_id") REFERENCES "alert_event"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX "linear_job_issue_event_alert_event_id_idx"
+  ON "linear_job_issue_event" ("alert_event_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "linear_job_issue_event_unique_idx"
+  ON "linear_job_issue_event" ("linear_job_issue_id", "alert_event_id");

--- a/packages/dal/src/db/schemas/alert-delivery/schema.ts
+++ b/packages/dal/src/db/schemas/alert-delivery/schema.ts
@@ -1,0 +1,56 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core'
+import { alertEvent } from '../alert-event/schema'
+import { baseColumns } from '../common'
+import { organization } from '../organization/schema'
+
+export const alertDeliveryStatuses = ['pending', 'claimed', 'delivered', 'failed'] as const
+export type AlertDeliveryStatus = (typeof alertDeliveryStatuses)[number]
+
+export const alertDeliveryChannelTypes = ['email', 'linear'] as const
+export type AlertDeliveryChannelType = (typeof alertDeliveryChannelTypes)[number]
+
+export const alertDelivery = pgTable(
+  'alert_delivery',
+  {
+    ...baseColumns,
+    alertEventId: uuid('alert_event_id')
+      .notNull()
+      .references(() => alertEvent.id, { onDelete: 'cascade' }),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    channelType: text('channel_type').$type<AlertDeliveryChannelType>().notNull(),
+    target: text('target').notNull(),
+    status: text('status').$type<AlertDeliveryStatus>().notNull().default('pending'),
+    attemptCount: integer('attempt_count').notNull().default(0),
+    nextRetryAt: timestamp('next_retry_at', { withTimezone: true }),
+    claimedAt: timestamp('claimed_at', { withTimezone: true }),
+    lastError: text('last_error'),
+    providerMetadata: jsonb('provider_metadata').$type<Record<string, unknown>>().default({}),
+    externalId: text('external_id'),
+    externalIdentifier: text('external_identifier'),
+    externalUrl: text('external_url'),
+  },
+  (table) => ({
+    eventIdx: index('alert_delivery_event_id_idx').on(table.alertEventId),
+    orgStatusRetryIdx: index('alert_delivery_org_status_retry_idx').on(
+      table.organizationId,
+      table.status,
+      table.nextRetryAt
+    ),
+    eventChannelTargetIdx: uniqueIndex('alert_delivery_event_channel_target_idx').on(
+      table.alertEventId,
+      table.channelType,
+      table.target
+    ),
+  })
+)

--- a/packages/dal/src/db/schemas/alert-delivery/types.ts
+++ b/packages/dal/src/db/schemas/alert-delivery/types.ts
@@ -1,0 +1,5 @@
+import type { alertDelivery } from './schema'
+
+export type AlertDelivery = typeof alertDelivery.$inferSelect
+export type NewAlertDelivery = typeof alertDelivery.$inferInsert
+export type { AlertDeliveryChannelType, AlertDeliveryStatus } from './schema'

--- a/packages/dal/src/db/schemas/alert-event/schema.ts
+++ b/packages/dal/src/db/schemas/alert-event/schema.ts
@@ -1,4 +1,4 @@
-import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
 import { alertRule } from '../alert-rule/schema'
 import { baseColumns } from '../common'
 import { organization } from '../organization/schema'
@@ -25,6 +25,7 @@ export const alertEvent = pgTable(
     status: text('status').$type<AlertEventStatus>().notNull().default('firing'),
     summary: text('summary').notNull(),
     context: jsonb('context'),
+    dedupeKey: text('dedupe_key'),
     firedAt: timestamp('fired_at', { withTimezone: true }).notNull(),
     resolvedAt: timestamp('resolved_at', { withTimezone: true }),
     notificationSentAt: timestamp('notification_sent_at', { withTimezone: true }),
@@ -36,6 +37,10 @@ export const alertEvent = pgTable(
       table.connectionId,
       table.queueName,
       table.status
+    ),
+    ruleDedupeIdx: uniqueIndex('alert_event_rule_dedupe_key_idx').on(
+      table.alertRuleId,
+      table.dedupeKey
     ),
   })
 )

--- a/packages/dal/src/db/schemas/alert-rule/schema.ts
+++ b/packages/dal/src/db/schemas/alert-rule/schema.ts
@@ -3,7 +3,12 @@ import { baseColumns } from '../common'
 import { organization } from '../organization/schema'
 import { redisConnection } from '../redis-connection/schema'
 
-export const alertRuleTypes = ['failure_threshold', 'failure_rate', 'queue_stalled'] as const
+export const alertRuleTypes = [
+  'failure_threshold',
+  'failure_rate',
+  'queue_stalled',
+  'job_failed',
+] as const
 export type AlertRuleType = (typeof alertRuleTypes)[number]
 
 export const queueFilterModes = ['include', 'exclude'] as const

--- a/packages/dal/src/db/schemas/index.ts
+++ b/packages/dal/src/db/schemas/index.ts
@@ -3,6 +3,15 @@
 // Alert Check Cursor schema exports
 export { alertCheckCursor } from './alert-check-cursor/schema'
 export type { AlertCheckCursor, NewAlertCheckCursor } from './alert-check-cursor/types'
+// Alert Delivery schema exports
+export {
+  alertDelivery,
+  type AlertDeliveryChannelType,
+  alertDeliveryChannelTypes,
+  type AlertDeliveryStatus,
+  alertDeliveryStatuses,
+} from './alert-delivery/schema'
+export type { AlertDelivery, NewAlertDelivery } from './alert-delivery/types'
 // Alert Event schema exports
 export { type AlertEventStatus, alertEvent, alertEventStatuses } from './alert-event/schema'
 export type { AlertEvent, NewAlertEvent } from './alert-event/types'
@@ -45,6 +54,18 @@ export type {
   NewRedisDiscoveredQueue,
   RedisDiscoveredQueue,
 } from './redis-discovered-queue/types'
+// Linear integration schema exports
+export {
+  type LinearIntegrationValidationStatus,
+  linearIntegration,
+  linearIntegrationValidationStatuses,
+} from './linear-integration/schema'
+export type {
+  LinearIntegration,
+  NewLinearIntegration,
+} from './linear-integration/types'
+export { linearJobIssue } from './linear-job-issue/schema'
+export type { LinearJobIssue, NewLinearJobIssue } from './linear-job-issue/types'
 // Relations v2 - single consolidated relations object
 export { relations } from './relations'
 // Telemetry installation schema exports

--- a/packages/dal/src/db/schemas/index.ts
+++ b/packages/dal/src/db/schemas/index.ts
@@ -5,10 +5,10 @@ export { alertCheckCursor } from './alert-check-cursor/schema'
 export type { AlertCheckCursor, NewAlertCheckCursor } from './alert-check-cursor/types'
 // Alert Delivery schema exports
 export {
-  alertDelivery,
   type AlertDeliveryChannelType,
-  alertDeliveryChannelTypes,
   type AlertDeliveryStatus,
+  alertDelivery,
+  alertDeliveryChannelTypes,
   alertDeliveryStatuses,
 } from './alert-delivery/schema'
 export type { AlertDelivery, NewAlertDelivery } from './alert-delivery/types'
@@ -28,6 +28,25 @@ export type {
   NewAuthSession,
   NewAuthVerification,
 } from './auth/types'
+// Linear integration schema exports
+export {
+  type LinearIntegrationValidationStatus,
+  linearIntegration,
+  linearIntegrationValidationStatuses,
+} from './linear-integration/schema'
+export type {
+  LinearIntegration,
+  NewLinearIntegration,
+} from './linear-integration/types'
+export { linearJobIssue } from './linear-job-issue/schema'
+export type { LinearJobIssue, NewLinearJobIssue } from './linear-job-issue/types'
+export { linearJobIssueEvent } from './linear-job-issue-event/schema'
+export type {
+  LinearJobIssueEvent,
+  NewLinearJobIssueEvent,
+} from './linear-job-issue-event/types'
+export { linearOauthState } from './linear-oauth-state/schema'
+export type { LinearOauthState, NewLinearOauthState } from './linear-oauth-state/types'
 // Organization schema exports
 export { invitation, member, organization } from './organization/schema'
 export type {
@@ -54,20 +73,6 @@ export type {
   NewRedisDiscoveredQueue,
   RedisDiscoveredQueue,
 } from './redis-discovered-queue/types'
-// Linear integration schema exports
-export {
-  type LinearIntegrationValidationStatus,
-  linearIntegration,
-  linearIntegrationValidationStatuses,
-} from './linear-integration/schema'
-export type {
-  LinearIntegration,
-  NewLinearIntegration,
-} from './linear-integration/types'
-export { linearOauthState } from './linear-oauth-state/schema'
-export type { LinearOauthState, NewLinearOauthState } from './linear-oauth-state/types'
-export { linearJobIssue } from './linear-job-issue/schema'
-export type { LinearJobIssue, NewLinearJobIssue } from './linear-job-issue/types'
 // Relations v2 - single consolidated relations object
 export { relations } from './relations'
 // Telemetry installation schema exports

--- a/packages/dal/src/db/schemas/index.ts
+++ b/packages/dal/src/db/schemas/index.ts
@@ -64,6 +64,8 @@ export type {
   LinearIntegration,
   NewLinearIntegration,
 } from './linear-integration/types'
+export { linearOauthState } from './linear-oauth-state/schema'
+export type { LinearOauthState, NewLinearOauthState } from './linear-oauth-state/types'
 export { linearJobIssue } from './linear-job-issue/schema'
 export type { LinearJobIssue, NewLinearJobIssue } from './linear-job-issue/types'
 // Relations v2 - single consolidated relations object

--- a/packages/dal/src/db/schemas/linear-integration/schema.ts
+++ b/packages/dal/src/db/schemas/linear-integration/schema.ts
@@ -11,8 +11,12 @@ export const linearIntegration = pgTable('linear_integration', {
     .notNull()
     .unique()
     .references(() => organization.id, { onDelete: 'cascade' }),
-  encryptedApiKey: text('encrypted_api_key').notNull(),
-  keyPreview: text('key_preview').notNull(),
+  encryptedAccessToken: text('encrypted_access_token').notNull(),
+  encryptedRefreshToken: text('encrypted_refresh_token').notNull(),
+  tokenType: text('token_type').notNull().default('Bearer'),
+  scopes: text('scopes').notNull(),
+  accessTokenExpiresAt: timestamp('access_token_expires_at', { withTimezone: true }).notNull(),
+  linearOrganizationName: text('linear_organization_name'),
   validationStatus: text('validation_status')
     .$type<LinearIntegrationValidationStatus>()
     .notNull()

--- a/packages/dal/src/db/schemas/linear-integration/schema.ts
+++ b/packages/dal/src/db/schemas/linear-integration/schema.ts
@@ -1,0 +1,27 @@
+import { integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { baseColumns } from '../common'
+import { organization } from '../organization/schema'
+
+export const linearIntegrationValidationStatuses = ['valid', 'invalid', 'unknown'] as const
+export type LinearIntegrationValidationStatus = (typeof linearIntegrationValidationStatuses)[number]
+
+export const linearIntegration = pgTable('linear_integration', {
+  ...baseColumns,
+  organizationId: text('organization_id')
+    .notNull()
+    .unique()
+    .references(() => organization.id, { onDelete: 'cascade' }),
+  encryptedApiKey: text('encrypted_api_key').notNull(),
+  keyPreview: text('key_preview').notNull(),
+  validationStatus: text('validation_status')
+    .$type<LinearIntegrationValidationStatus>()
+    .notNull()
+    .default('unknown'),
+  defaultTeamId: text('default_team_id'),
+  defaultProjectId: text('default_project_id'),
+  defaultLabelIds: jsonb('default_label_ids').$type<string[]>().notNull().default([]),
+  defaultAssigneeId: text('default_assignee_id'),
+  defaultStateId: text('default_state_id'),
+  defaultPriority: integer('default_priority'),
+  lastValidatedAt: timestamp('last_validated_at', { withTimezone: true }),
+})

--- a/packages/dal/src/db/schemas/linear-integration/types.ts
+++ b/packages/dal/src/db/schemas/linear-integration/types.ts
@@ -1,0 +1,5 @@
+import type { linearIntegration } from './schema'
+
+export type LinearIntegration = typeof linearIntegration.$inferSelect
+export type NewLinearIntegration = typeof linearIntegration.$inferInsert
+export type { LinearIntegrationValidationStatus } from './schema'

--- a/packages/dal/src/db/schemas/linear-job-issue-event/schema.ts
+++ b/packages/dal/src/db/schemas/linear-job-issue-event/schema.ts
@@ -1,0 +1,24 @@
+import { index, pgTable, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
+import { alertEvent } from '../alert-event/schema'
+import { baseColumns } from '../common'
+import { linearJobIssue } from '../linear-job-issue/schema'
+
+export const linearJobIssueEvent = pgTable(
+  'linear_job_issue_event',
+  {
+    ...baseColumns,
+    linearJobIssueId: uuid('linear_job_issue_id')
+      .notNull()
+      .references(() => linearJobIssue.id, { onDelete: 'cascade' }),
+    alertEventId: uuid('alert_event_id')
+      .notNull()
+      .references(() => alertEvent.id, { onDelete: 'cascade' }),
+  },
+  (table) => ({
+    eventIdx: index('linear_job_issue_event_alert_event_id_idx').on(table.alertEventId),
+    issueEventUniqueIdx: uniqueIndex('linear_job_issue_event_unique_idx').on(
+      table.linearJobIssueId,
+      table.alertEventId
+    ),
+  })
+)

--- a/packages/dal/src/db/schemas/linear-job-issue-event/types.ts
+++ b/packages/dal/src/db/schemas/linear-job-issue-event/types.ts
@@ -1,0 +1,4 @@
+import type { linearJobIssueEvent } from './schema'
+
+export type LinearJobIssueEvent = typeof linearJobIssueEvent.$inferSelect
+export type NewLinearJobIssueEvent = typeof linearJobIssueEvent.$inferInsert

--- a/packages/dal/src/db/schemas/linear-job-issue/schema.ts
+++ b/packages/dal/src/db/schemas/linear-job-issue/schema.ts
@@ -1,0 +1,35 @@
+import { index, pgTable, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
+import { alertEvent } from '../alert-event/schema'
+import { baseColumns } from '../common'
+import { organization } from '../organization/schema'
+import { redisConnection } from '../redis-connection/schema'
+
+export const linearJobIssue = pgTable(
+  'linear_job_issue',
+  {
+    ...baseColumns,
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    connectionId: uuid('connection_id')
+      .notNull()
+      .references(() => redisConnection.id, { onDelete: 'cascade' }),
+    queueName: text('queue_name').notNull(),
+    jobId: text('job_id').notNull(),
+    alertEventId: uuid('alert_event_id')
+      .notNull()
+      .references(() => alertEvent.id, { onDelete: 'cascade' }),
+    linearIssueId: text('linear_issue_id').notNull(),
+    linearIssueIdentifier: text('linear_issue_identifier').notNull(),
+    linearIssueUrl: text('linear_issue_url').notNull(),
+  },
+  (table) => ({
+    eventIdx: index('linear_job_issue_alert_event_id_idx').on(table.alertEventId),
+    jobUniqueIdx: uniqueIndex('linear_job_issue_job_unique_idx').on(
+      table.organizationId,
+      table.connectionId,
+      table.queueName,
+      table.jobId
+    ),
+  })
+)

--- a/packages/dal/src/db/schemas/linear-job-issue/schema.ts
+++ b/packages/dal/src/db/schemas/linear-job-issue/schema.ts
@@ -1,5 +1,4 @@
-import { index, pgTable, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
-import { alertEvent } from '../alert-event/schema'
+import { pgTable, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
 import { baseColumns } from '../common'
 import { organization } from '../organization/schema'
 import { redisConnection } from '../redis-connection/schema'
@@ -16,15 +15,11 @@ export const linearJobIssue = pgTable(
       .references(() => redisConnection.id, { onDelete: 'cascade' }),
     queueName: text('queue_name').notNull(),
     jobId: text('job_id').notNull(),
-    alertEventId: uuid('alert_event_id')
-      .notNull()
-      .references(() => alertEvent.id, { onDelete: 'cascade' }),
     linearIssueId: text('linear_issue_id').notNull(),
     linearIssueIdentifier: text('linear_issue_identifier').notNull(),
     linearIssueUrl: text('linear_issue_url').notNull(),
   },
   (table) => ({
-    eventIdx: index('linear_job_issue_alert_event_id_idx').on(table.alertEventId),
     jobUniqueIdx: uniqueIndex('linear_job_issue_job_unique_idx').on(
       table.organizationId,
       table.connectionId,

--- a/packages/dal/src/db/schemas/linear-job-issue/types.ts
+++ b/packages/dal/src/db/schemas/linear-job-issue/types.ts
@@ -1,0 +1,4 @@
+import type { linearJobIssue } from './schema'
+
+export type LinearJobIssue = typeof linearJobIssue.$inferSelect
+export type NewLinearJobIssue = typeof linearJobIssue.$inferInsert

--- a/packages/dal/src/db/schemas/linear-oauth-state/schema.ts
+++ b/packages/dal/src/db/schemas/linear-oauth-state/schema.ts
@@ -1,0 +1,20 @@
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { baseColumns } from '../common'
+import { organization } from '../organization/schema'
+
+export const linearOauthState = pgTable(
+  'linear_oauth_state',
+  {
+    ...baseColumns,
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    userId: text('user_id').notNull(),
+    stateHash: text('state_hash').notNull().unique(),
+    redirectUri: text('redirect_uri').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  },
+  (table) => ({
+    expiresAtIdx: index('linear_oauth_state_expires_at_idx').on(table.expiresAt),
+  })
+)

--- a/packages/dal/src/db/schemas/linear-oauth-state/types.ts
+++ b/packages/dal/src/db/schemas/linear-oauth-state/types.ts
@@ -1,0 +1,4 @@
+import type { linearOauthState } from './schema'
+
+export type LinearOauthState = typeof linearOauthState.$inferSelect
+export type NewLinearOauthState = typeof linearOauthState.$inferInsert

--- a/packages/dal/src/db/schemas/relations.ts
+++ b/packages/dal/src/db/schemas/relations.ts
@@ -107,6 +107,7 @@ export const relations = defineRelations(tables, (r) => ({
     }),
     deliveries: r.many.alertDelivery(),
     linearJobIssues: r.many.linearJobIssue(),
+    linearJobIssueEvents: r.many.linearJobIssueEvent(),
   },
   alertCheckCursor: {
     connection: r.one.redisConnection({
@@ -147,6 +148,17 @@ export const relations = defineRelations(tables, (r) => ({
     }),
     event: r.one.alertEvent({
       from: r.linearJobIssue.alertEventId,
+      to: r.alertEvent.id,
+    }),
+    eventLinks: r.many.linearJobIssueEvent(),
+  },
+  linearJobIssueEvent: {
+    issue: r.one.linearJobIssue({
+      from: r.linearJobIssueEvent.linearJobIssueId,
+      to: r.linearJobIssue.id,
+    }),
+    event: r.one.alertEvent({
+      from: r.linearJobIssueEvent.alertEventId,
       to: r.alertEvent.id,
     }),
   },

--- a/packages/dal/src/db/schemas/relations.ts
+++ b/packages/dal/src/db/schemas/relations.ts
@@ -40,6 +40,8 @@ export const relations = defineRelations(tables, (r) => ({
     redisConnections: r.many.redisConnection(),
     alertRules: r.many.alertRule(),
     alertEvents: r.many.alertEvent(),
+    linearIntegration: r.one.linearIntegration(),
+    linearJobIssues: r.many.linearJobIssue(),
   },
   member: {
     user: r.one.user({
@@ -70,6 +72,7 @@ export const relations = defineRelations(tables, (r) => ({
     alertRules: r.many.alertRule(),
     alertEvents: r.many.alertEvent(),
     alertCheckCursors: r.many.alertCheckCursor(),
+    linearJobIssues: r.many.linearJobIssue(),
   },
   redisDiscoveredQueue: {
     connection: r.one.redisConnection({
@@ -101,11 +104,43 @@ export const relations = defineRelations(tables, (r) => ({
       from: r.alertEvent.connectionId,
       to: r.redisConnection.id,
     }),
+    deliveries: r.many.alertDelivery(),
+    linearJobIssues: r.many.linearJobIssue(),
   },
   alertCheckCursor: {
     connection: r.one.redisConnection({
       from: r.alertCheckCursor.connectionId,
       to: r.redisConnection.id,
+    }),
+  },
+  alertDelivery: {
+    event: r.one.alertEvent({
+      from: r.alertDelivery.alertEventId,
+      to: r.alertEvent.id,
+    }),
+    organization: r.one.organization({
+      from: r.alertDelivery.organizationId,
+      to: r.organization.id,
+    }),
+  },
+  linearIntegration: {
+    organization: r.one.organization({
+      from: r.linearIntegration.organizationId,
+      to: r.organization.id,
+    }),
+  },
+  linearJobIssue: {
+    organization: r.one.organization({
+      from: r.linearJobIssue.organizationId,
+      to: r.organization.id,
+    }),
+    connection: r.one.redisConnection({
+      from: r.linearJobIssue.connectionId,
+      to: r.redisConnection.id,
+    }),
+    event: r.one.alertEvent({
+      from: r.linearJobIssue.alertEventId,
+      to: r.alertEvent.id,
     }),
   },
 }))

--- a/packages/dal/src/db/schemas/relations.ts
+++ b/packages/dal/src/db/schemas/relations.ts
@@ -41,6 +41,7 @@ export const relations = defineRelations(tables, (r) => ({
     alertRules: r.many.alertRule(),
     alertEvents: r.many.alertEvent(),
     linearIntegration: r.one.linearIntegration(),
+    linearOauthStates: r.many.linearOauthState(),
     linearJobIssues: r.many.linearJobIssue(),
   },
   member: {
@@ -126,6 +127,12 @@ export const relations = defineRelations(tables, (r) => ({
   linearIntegration: {
     organization: r.one.organization({
       from: r.linearIntegration.organizationId,
+      to: r.organization.id,
+    }),
+  },
+  linearOauthState: {
+    organization: r.one.organization({
+      from: r.linearOauthState.organizationId,
       to: r.organization.id,
     }),
   },

--- a/packages/dal/src/db/schemas/relations.ts
+++ b/packages/dal/src/db/schemas/relations.ts
@@ -106,7 +106,6 @@ export const relations = defineRelations(tables, (r) => ({
       to: r.redisConnection.id,
     }),
     deliveries: r.many.alertDelivery(),
-    linearJobIssues: r.many.linearJobIssue(),
     linearJobIssueEvents: r.many.linearJobIssueEvent(),
   },
   alertCheckCursor: {
@@ -145,10 +144,6 @@ export const relations = defineRelations(tables, (r) => ({
     connection: r.one.redisConnection({
       from: r.linearJobIssue.connectionId,
       to: r.redisConnection.id,
-    }),
-    event: r.one.alertEvent({
-      from: r.linearJobIssue.alertEventId,
-      to: r.alertEvent.id,
     }),
     eventLinks: r.many.linearJobIssueEvent(),
   },

--- a/packages/dal/src/db/schemas/tables.ts
+++ b/packages/dal/src/db/schemas/tables.ts
@@ -19,6 +19,7 @@ export { connectionEnvironments, redisConnection } from './redis-connection/sche
 export { redisDiscoveredQueue } from './redis-discovered-queue/schema'
 export { linearIntegration } from './linear-integration/schema'
 export { linearJobIssue } from './linear-job-issue/schema'
+export { linearOauthState } from './linear-oauth-state/schema'
 // Telemetry installation schema tables
 export { telemetryInstallation } from './telemetry-installation/schema'
 // User schema tables

--- a/packages/dal/src/db/schemas/tables.ts
+++ b/packages/dal/src/db/schemas/tables.ts
@@ -10,16 +10,15 @@ export { alertEvent } from './alert-event/schema'
 export { alertRule } from './alert-rule/schema'
 // Auth schema tables
 export { authAccount, authSession, authVerification } from './auth/schema'
-
+export { linearIntegration } from './linear-integration/schema'
+export { linearJobIssue } from './linear-job-issue/schema'
+export { linearJobIssueEvent } from './linear-job-issue-event/schema'
+export { linearOauthState } from './linear-oauth-state/schema'
 // Organization schema tables
 export { invitation, member, organization } from './organization/schema'
-
 // Redis Connection schema tables
 export { connectionEnvironments, redisConnection } from './redis-connection/schema'
 export { redisDiscoveredQueue } from './redis-discovered-queue/schema'
-export { linearIntegration } from './linear-integration/schema'
-export { linearJobIssue } from './linear-job-issue/schema'
-export { linearOauthState } from './linear-oauth-state/schema'
 // Telemetry installation schema tables
 export { telemetryInstallation } from './telemetry-installation/schema'
 // User schema tables

--- a/packages/dal/src/db/schemas/tables.ts
+++ b/packages/dal/src/db/schemas/tables.ts
@@ -5,6 +5,7 @@
 
 // Alert schema tables
 export { alertCheckCursor } from './alert-check-cursor/schema'
+export { alertDelivery } from './alert-delivery/schema'
 export { alertEvent } from './alert-event/schema'
 export { alertRule } from './alert-rule/schema'
 // Auth schema tables
@@ -16,6 +17,8 @@ export { invitation, member, organization } from './organization/schema'
 // Redis Connection schema tables
 export { connectionEnvironments, redisConnection } from './redis-connection/schema'
 export { redisDiscoveredQueue } from './redis-discovered-queue/schema'
+export { linearIntegration } from './linear-integration/schema'
+export { linearJobIssue } from './linear-job-issue/schema'
 // Telemetry installation schema tables
 export { telemetryInstallation } from './telemetry-installation/schema'
 // User schema tables

--- a/packages/dal/src/db/secret-encryption.test.ts
+++ b/packages/dal/src/db/secret-encryption.test.ts
@@ -19,14 +19,14 @@ describe('secret encryption', () => {
     mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY =
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
 
-    const encrypted = encryptSecret('lin_api_super_secret_key')
+    const encrypted = encryptSecret('linear_oauth_access_token')
 
     expect(isSecretEncrypted(encrypted)).toBe(true)
-    expect(encrypted).not.toContain('lin_api_super_secret_key')
-    expect(decryptSecret(encrypted)).toBe('lin_api_super_secret_key')
+    expect(encrypted).not.toContain('linear_oauth_access_token')
+    expect(decryptSecret(encrypted)).toBe('linear_oauth_access_token')
   })
 
   it('creates a safe key preview', () => {
-    expect(maskSecretPreview('lin_api_1234567890')).toBe('lin_…7890')
+    expect(maskSecretPreview('linear_oauth_access_token_1234567890')).toBe('line…7890')
   })
 })

--- a/packages/dal/src/db/secret-encryption.test.ts
+++ b/packages/dal/src/db/secret-encryption.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { env } from '@durabull/env'
+import {
+  decryptSecret,
+  encryptSecret,
+  isSecretEncrypted,
+  maskSecretPreview,
+} from './secret-encryption'
+
+const mutableEnv = env as { DURABULL_SECRET_ENCRYPTION_KEY?: string }
+const originalKey = mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY
+
+describe('secret encryption', () => {
+  afterEach(() => {
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = originalKey
+  })
+
+  it('encrypts and decrypts secrets without storing plaintext', () => {
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+    const encrypted = encryptSecret('lin_api_super_secret_key')
+
+    expect(isSecretEncrypted(encrypted)).toBe(true)
+    expect(encrypted).not.toContain('lin_api_super_secret_key')
+    expect(decryptSecret(encrypted)).toBe('lin_api_super_secret_key')
+  })
+
+  it('creates a safe key preview', () => {
+    expect(maskSecretPreview('lin_api_1234567890')).toBe('lin_…7890')
+  })
+})

--- a/packages/dal/src/db/secret-encryption.ts
+++ b/packages/dal/src/db/secret-encryption.ts
@@ -1,0 +1,111 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+import { env } from '@durabull/env'
+
+const SECRET_ENCRYPTION_PREFIX = 'enc:v1:'
+const AES_256_KEY_BYTES = 32
+const GCM_IV_BYTES = 12
+
+function parseEncryptionKey(rawKey: string | undefined): Buffer | null {
+  const key = rawKey?.trim()
+  if (!key) return null
+
+  if (/^[0-9a-fA-F]{64}$/.test(key)) {
+    return Buffer.from(key, 'hex')
+  }
+
+  const base64Candidate = key.replace(/-/g, '+').replace(/_/g, '/')
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(base64Candidate)) {
+    return null
+  }
+
+  const padding = (4 - (base64Candidate.length % 4)) % 4
+  const decoded = Buffer.from(`${base64Candidate}${'='.repeat(padding)}`, 'base64')
+  return decoded.length === AES_256_KEY_BYTES ? decoded : null
+}
+
+function requireEncryptionKey(): Buffer {
+  const key = parseEncryptionKey(env.DURABULL_SECRET_ENCRYPTION_KEY)
+  if (!key) {
+    throw new Error(
+      'DURABULL_SECRET_ENCRYPTION_KEY must be set to a 32-byte key encoded as 64-char hex or base64.'
+    )
+  }
+
+  return key
+}
+
+function toHex(buffer: Uint8Array): string {
+  return Buffer.from(buffer).toString('hex')
+}
+
+function fromHex(hex: string): Buffer {
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+    throw new Error('Invalid encrypted secret format.')
+  }
+
+  return Buffer.from(hex, 'hex')
+}
+
+export function isSecretEncryptionKeyConfigured(): boolean {
+  return parseEncryptionKey(env.DURABULL_SECRET_ENCRYPTION_KEY) !== null
+}
+
+export function assertSecretEncryptionKeyConfigured(): void {
+  requireEncryptionKey()
+}
+
+export function isSecretEncrypted(value: string): boolean {
+  return value.startsWith(SECRET_ENCRYPTION_PREFIX)
+}
+
+export function encryptSecret(secret: string): string {
+  const key = requireEncryptionKey()
+  const iv = randomBytes(GCM_IV_BYTES)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+
+  const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  return `${SECRET_ENCRYPTION_PREFIX}${toHex(iv)}:${toHex(authTag)}:${toHex(encrypted)}`
+}
+
+export function decryptSecret(value: string): string {
+  if (!isSecretEncrypted(value)) {
+    throw new Error('Secret is not encrypted.')
+  }
+
+  const key = requireEncryptionKey()
+  const payload = value.slice(SECRET_ENCRYPTION_PREFIX.length)
+  const [ivHex, tagHex, encryptedHex] = payload.split(':')
+
+  if (!ivHex || !tagHex || !encryptedHex) {
+    throw new Error('Invalid encrypted secret format.')
+  }
+
+  try {
+    const iv = fromHex(ivHex)
+    const authTag = fromHex(tagHex)
+    const encrypted = fromHex(encryptedHex)
+
+    if (iv.length !== GCM_IV_BYTES || authTag.length !== 16) {
+      throw new Error('Invalid encrypted secret format.')
+    }
+
+    const decipher = createDecipheriv('aes-256-gcm', key, iv)
+    decipher.setAuthTag(authTag)
+
+    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8')
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Invalid encrypted secret format.') {
+      throw error
+    }
+
+    throw new Error('Failed to decrypt secret. Verify DURABULL_SECRET_ENCRYPTION_KEY.')
+  }
+}
+
+export function maskSecretPreview(secret: string): string {
+  const trimmed = secret.trim()
+  if (trimmed.length <= 8) return '••••'
+  return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`
+}

--- a/packages/dal/src/index.ts
+++ b/packages/dal/src/index.ts
@@ -19,14 +19,6 @@ export {
   isRedisUrlEncrypted,
   isRedisUrlEncryptionKeyConfigured,
 } from './db/redis-url-encryption'
-export {
-  assertSecretEncryptionKeyConfigured,
-  decryptSecret,
-  encryptSecret,
-  isSecretEncrypted,
-  isSecretEncryptionKeyConfigured,
-  maskSecretPreview,
-} from './db/secret-encryption'
 export type { RedisUrlValidationResult } from './db/redis-url-validation'
 export {
   allowsInternalConnections,
@@ -42,10 +34,10 @@ export type {
 export { alertCheckCursor } from './db/schemas/alert-check-cursor/schema'
 export type { AlertCheckCursor, NewAlertCheckCursor } from './db/schemas/alert-check-cursor/types'
 export {
-  alertDelivery,
   type AlertDeliveryChannelType,
-  alertDeliveryChannelTypes,
   type AlertDeliveryStatus,
+  alertDelivery,
+  alertDeliveryChannelTypes,
   alertDeliveryStatuses,
 } from './db/schemas/alert-delivery/schema'
 export type { AlertDelivery, NewAlertDelivery } from './db/schemas/alert-delivery/types'
@@ -75,6 +67,24 @@ export type {
   NewAuthSession,
   NewAuthVerification,
 } from './db/schemas/auth/types'
+export {
+  type LinearIntegrationValidationStatus,
+  linearIntegration,
+  linearIntegrationValidationStatuses,
+} from './db/schemas/linear-integration/schema'
+export type {
+  LinearIntegration,
+  NewLinearIntegration,
+} from './db/schemas/linear-integration/types'
+export { linearJobIssue } from './db/schemas/linear-job-issue/schema'
+export type { LinearJobIssue, NewLinearJobIssue } from './db/schemas/linear-job-issue/types'
+export { linearJobIssueEvent } from './db/schemas/linear-job-issue-event/schema'
+export type {
+  LinearJobIssueEvent,
+  NewLinearJobIssueEvent,
+} from './db/schemas/linear-job-issue-event/types'
+export { linearOauthState } from './db/schemas/linear-oauth-state/schema'
+export type { LinearOauthState, NewLinearOauthState } from './db/schemas/linear-oauth-state/types'
 // Organization schema exports for Better Auth organization plugin
 export * as organizationSchema from './db/schemas/organization/schema'
 export { invitation, member, organization } from './db/schemas/organization/schema'
@@ -101,24 +111,19 @@ export type {
   NewRedisDiscoveredQueue,
   RedisDiscoveredQueue,
 } from './db/schemas/redis-discovered-queue/types'
-export {
-  type LinearIntegrationValidationStatus,
-  linearIntegration,
-  linearIntegrationValidationStatuses,
-} from './db/schemas/linear-integration/schema'
-export type {
-  LinearIntegration,
-  NewLinearIntegration,
-} from './db/schemas/linear-integration/types'
-export { linearJobIssue } from './db/schemas/linear-job-issue/schema'
-export type { LinearJobIssue, NewLinearJobIssue } from './db/schemas/linear-job-issue/types'
-export { linearOauthState } from './db/schemas/linear-oauth-state/schema'
-export type { LinearOauthState, NewLinearOauthState } from './db/schemas/linear-oauth-state/types'
 export { telemetryInstallation } from './db/schemas/telemetry-installation/schema'
 export * as userSchema from './db/schemas/user/schema'
 // User schema exports
 export { user } from './db/schemas/user/schema'
 export type { NewUser, User } from './db/schemas/user/types'
+export {
+  assertSecretEncryptionKeyConfigured,
+  decryptSecret,
+  encryptSecret,
+  isSecretEncrypted,
+  isSecretEncryptionKeyConfigured,
+  maskSecretPreview,
+} from './db/secret-encryption'
 export { alertCheckCursorRepository } from './repositories/alert-check-cursor'
 export { alertDeliveryRepository } from './repositories/alert-delivery'
 export { alertEventRepository } from './repositories/alert-event'

--- a/packages/dal/src/index.ts
+++ b/packages/dal/src/index.ts
@@ -19,6 +19,14 @@ export {
   isRedisUrlEncrypted,
   isRedisUrlEncryptionKeyConfigured,
 } from './db/redis-url-encryption'
+export {
+  assertSecretEncryptionKeyConfigured,
+  decryptSecret,
+  encryptSecret,
+  isSecretEncrypted,
+  isSecretEncryptionKeyConfigured,
+  maskSecretPreview,
+} from './db/secret-encryption'
 export type { RedisUrlValidationResult } from './db/redis-url-validation'
 export {
   allowsInternalConnections,
@@ -33,6 +41,14 @@ export type {
 } from './db/schemas'
 export { alertCheckCursor } from './db/schemas/alert-check-cursor/schema'
 export type { AlertCheckCursor, NewAlertCheckCursor } from './db/schemas/alert-check-cursor/types'
+export {
+  alertDelivery,
+  type AlertDeliveryChannelType,
+  alertDeliveryChannelTypes,
+  type AlertDeliveryStatus,
+  alertDeliveryStatuses,
+} from './db/schemas/alert-delivery/schema'
+export type { AlertDelivery, NewAlertDelivery } from './db/schemas/alert-delivery/types'
 export {
   type AlertEventStatus,
   alertEvent,
@@ -85,14 +101,28 @@ export type {
   NewRedisDiscoveredQueue,
   RedisDiscoveredQueue,
 } from './db/schemas/redis-discovered-queue/types'
+export {
+  type LinearIntegrationValidationStatus,
+  linearIntegration,
+  linearIntegrationValidationStatuses,
+} from './db/schemas/linear-integration/schema'
+export type {
+  LinearIntegration,
+  NewLinearIntegration,
+} from './db/schemas/linear-integration/types'
+export { linearJobIssue } from './db/schemas/linear-job-issue/schema'
+export type { LinearJobIssue, NewLinearJobIssue } from './db/schemas/linear-job-issue/types'
 export { telemetryInstallation } from './db/schemas/telemetry-installation/schema'
 export * as userSchema from './db/schemas/user/schema'
 // User schema exports
 export { user } from './db/schemas/user/schema'
 export type { NewUser, User } from './db/schemas/user/types'
 export { alertCheckCursorRepository } from './repositories/alert-check-cursor'
+export { alertDeliveryRepository } from './repositories/alert-delivery'
 export { alertEventRepository } from './repositories/alert-event'
 export { alertRuleRepository } from './repositories/alert-rule'
+export { linearIntegrationRepository } from './repositories/linear-integration'
+export { linearJobIssueRepository } from './repositories/linear-job-issue'
 // Repositories
 export { redisConnectionRepository } from './repositories/redis-connection'
 export { redisDiscoveredQueueRepository } from './repositories/redis-discovered-queue'

--- a/packages/dal/src/index.ts
+++ b/packages/dal/src/index.ts
@@ -112,6 +112,8 @@ export type {
 } from './db/schemas/linear-integration/types'
 export { linearJobIssue } from './db/schemas/linear-job-issue/schema'
 export type { LinearJobIssue, NewLinearJobIssue } from './db/schemas/linear-job-issue/types'
+export { linearOauthState } from './db/schemas/linear-oauth-state/schema'
+export type { LinearOauthState, NewLinearOauthState } from './db/schemas/linear-oauth-state/types'
 export { telemetryInstallation } from './db/schemas/telemetry-installation/schema'
 export * as userSchema from './db/schemas/user/schema'
 // User schema exports
@@ -123,6 +125,7 @@ export { alertEventRepository } from './repositories/alert-event'
 export { alertRuleRepository } from './repositories/alert-rule'
 export { linearIntegrationRepository } from './repositories/linear-integration'
 export { linearJobIssueRepository } from './repositories/linear-job-issue'
+export { linearOauthStateRepository } from './repositories/linear-oauth-state'
 // Repositories
 export { redisConnectionRepository } from './repositories/redis-connection'
 export { redisDiscoveredQueueRepository } from './repositories/redis-discovered-queue'

--- a/packages/dal/src/repositories/alert-delivery.test.ts
+++ b/packages/dal/src/repositories/alert-delivery.test.ts
@@ -1,16 +1,16 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { env } from '@durabull/env'
 import { eq } from 'drizzle-orm'
 import { closeDb, getDb } from '../db/client'
 import { alertDelivery } from '../db/schemas/alert-delivery/schema'
 import { organization } from '../db/schemas/organization/schema'
+import { alertDeliveryRepository } from './alert-delivery'
 import { alertEventRepository } from './alert-event'
 import { alertRuleRepository } from './alert-rule'
 import { redisConnectionRepository } from './redis-connection'
-import { alertDeliveryRepository } from './alert-delivery'
 
 const TEST_ORG_ID = 'alert-delivery-org'
 const TEST_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
@@ -122,7 +122,7 @@ describe('alertDeliveryRepository', () => {
     expect(firstClaim[0]?.status).toBe('claimed')
     expect(firstClaim[0]?.claimedAt).toBeInstanceOf(Date)
 
-    await alertDeliveryRepository.markDelivered(firstClaim[0]!.id)
+    await alertDeliveryRepository.markDelivered(firstClaim[0]!.id, {}, firstClaim[0]!.claimedAt!)
 
     const secondClaim = await alertDeliveryRepository.claimDueForEvent(event.id)
     expect(secondClaim).toHaveLength(1)
@@ -134,7 +134,7 @@ describe('alertDeliveryRepository', () => {
 
   it('does not reclaim non-retryable failed deliveries', async () => {
     const event = await seedAlertEvent()
-    const [delivery] = await alertDeliveryRepository.enqueueMany([
+    await alertDeliveryRepository.enqueueMany([
       {
         alertEventId: event.id,
         organizationId: TEST_ORG_ID,
@@ -143,10 +143,12 @@ describe('alertDeliveryRepository', () => {
       },
     ])
 
+    const [delivery] = await alertDeliveryRepository.claimDueForEvent(event.id)
     expect(delivery).toBeDefined()
     await alertDeliveryRepository.markFailed(delivery!.id, {
       error: 'Manual reconciliation required',
       retryable: false,
+      expectedClaimedAt: delivery!.claimedAt!,
     })
 
     const claimed = await alertDeliveryRepository.claimDueForEvent(event.id)
@@ -174,14 +176,14 @@ describe('alertDeliveryRepository', () => {
       .set({ status: 'claimed', claimedAt: stolenClaimedAt })
       .where(eq(alertDelivery.id, claim!.id))
 
-    expect(await alertDeliveryRepository.markDelivered(claim!.id, {}, claim!.claimedAt)).toBe(
+    expect(await alertDeliveryRepository.markDelivered(claim!.id, {}, claim!.claimedAt!)).toBe(
       false
     )
     expect(
       await alertDeliveryRepository.markFailed(claim!.id, {
         error: 'stale worker failed',
         retryable: true,
-        expectedClaimedAt: claim!.claimedAt,
+        expectedClaimedAt: claim!.claimedAt!,
       })
     ).toBe(false)
 

--- a/packages/dal/src/repositories/alert-delivery.test.ts
+++ b/packages/dal/src/repositories/alert-delivery.test.ts
@@ -1,0 +1,193 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { env } from '@durabull/env'
+import { eq } from 'drizzle-orm'
+import { closeDb, getDb } from '../db/client'
+import { alertDelivery } from '../db/schemas/alert-delivery/schema'
+import { organization } from '../db/schemas/organization/schema'
+import { alertEventRepository } from './alert-event'
+import { alertRuleRepository } from './alert-rule'
+import { redisConnectionRepository } from './redis-connection'
+import { alertDeliveryRepository } from './alert-delivery'
+
+const TEST_ORG_ID = 'alert-delivery-org'
+const TEST_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+const mutableEnv = env as {
+  DATABASE_URL?: string
+  DURABULL_ENV_CONNECTIONS?: boolean
+  DURABULL_REDIS_URL_ENCRYPTION_KEY?: string
+}
+
+const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalEnvConnectionsFlag = mutableEnv.DURABULL_ENV_CONNECTIONS
+const originalEncryptionKey = mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY
+const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+
+let tempPgliteDir = ''
+
+async function seedAlertEvent() {
+  const db = await getDb()
+  const now = new Date()
+
+  await db.insert(organization).values({
+    id: TEST_ORG_ID,
+    name: 'Alert Delivery Org',
+    slug: 'alert-delivery-org',
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  const connection = await redisConnectionRepository.create({
+    name: 'Primary Redis',
+    url: 'redis://localhost:6379/0',
+    environment: 'development',
+    isDefault: true,
+    organizationId: TEST_ORG_ID,
+  })
+
+  const rule = await alertRuleRepository.create({
+    organizationId: TEST_ORG_ID,
+    connectionId: connection.id,
+    queueName: 'email-send',
+    name: 'Failure threshold',
+    type: 'failure_threshold',
+    config: { count: 5, windowMinutes: 5 },
+    cooldownMinutes: 30,
+  })
+
+  return alertEventRepository.create({
+    alertRuleId: rule.id,
+    organizationId: TEST_ORG_ID,
+    connectionId: connection.id,
+    queueName: 'email-send',
+    type: 'failure_threshold',
+    status: 'firing',
+    summary: 'Queue failure threshold breached',
+    context: {},
+    firedAt: now,
+  })
+}
+
+describe('alertDeliveryRepository', () => {
+  beforeEach(async () => {
+    tempPgliteDir = await mkdtemp(join(tmpdir(), 'durabull-alert-delivery-'))
+    process.env.DURABULL_PGLITE_DIR = tempPgliteDir
+    delete process.env.DATABASE_URL
+    mutableEnv.DATABASE_URL = undefined
+    mutableEnv.DURABULL_ENV_CONNECTIONS = false
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY
+    await closeDb()
+  })
+
+  afterEach(async () => {
+    await closeDb()
+    mutableEnv.DATABASE_URL = originalDatabaseUrl
+    mutableEnv.DURABULL_ENV_CONNECTIONS = originalEnvConnectionsFlag
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = originalEncryptionKey
+
+    if (originalPgliteDir) {
+      process.env.DURABULL_PGLITE_DIR = originalPgliteDir
+    } else {
+      delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (tempPgliteDir) {
+      await rm(tempPgliteDir, { recursive: true, force: true })
+      tempPgliteDir = ''
+    }
+  })
+
+  it('claims due deliveries without reclaiming fresh or delivered rows', async () => {
+    const event = await seedAlertEvent()
+    await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'email',
+        target: 'ops@example.com',
+      },
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'linear',
+        target: 'org-default:team-1::::',
+      },
+    ])
+
+    const firstClaim = await alertDeliveryRepository.claimDueForEvent(event.id, 1)
+    expect(firstClaim).toHaveLength(1)
+    expect(firstClaim[0]?.status).toBe('claimed')
+    expect(firstClaim[0]?.claimedAt).toBeInstanceOf(Date)
+
+    await alertDeliveryRepository.markDelivered(firstClaim[0]!.id)
+
+    const secondClaim = await alertDeliveryRepository.claimDueForEvent(event.id)
+    expect(secondClaim).toHaveLength(1)
+    expect(secondClaim[0]?.id).not.toBe(firstClaim[0]?.id)
+
+    const finalClaim = await alertDeliveryRepository.claimDueForEvent(event.id)
+    expect(finalClaim).toHaveLength(0)
+  })
+
+  it('does not reclaim non-retryable failed deliveries', async () => {
+    const event = await seedAlertEvent()
+    const [delivery] = await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'linear',
+        target: 'org-default:team-1::::',
+      },
+    ])
+
+    expect(delivery).toBeDefined()
+    await alertDeliveryRepository.markFailed(delivery!.id, {
+      error: 'Manual reconciliation required',
+      retryable: false,
+    })
+
+    const claimed = await alertDeliveryRepository.claimDueForEvent(event.id)
+    expect(claimed).toHaveLength(0)
+  })
+
+  it('only lets the current claim complete or fail a delivery', async () => {
+    const event = await seedAlertEvent()
+    await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'email',
+        target: 'ops@example.com',
+      },
+    ])
+
+    const [claim] = await alertDeliveryRepository.claimDueForEvent(event.id)
+    expect(claim?.claimedAt).toBeInstanceOf(Date)
+
+    const db = await getDb()
+    const stolenClaimedAt = new Date(claim!.claimedAt!.getTime() + 1000)
+    await db
+      .update(alertDelivery)
+      .set({ status: 'claimed', claimedAt: stolenClaimedAt })
+      .where(eq(alertDelivery.id, claim!.id))
+
+    expect(await alertDeliveryRepository.markDelivered(claim!.id, {}, claim!.claimedAt)).toBe(
+      false
+    )
+    expect(
+      await alertDeliveryRepository.markFailed(claim!.id, {
+        error: 'stale worker failed',
+        retryable: true,
+        expectedClaimedAt: claim!.claimedAt,
+      })
+    ).toBe(false)
+
+    expect(await alertDeliveryRepository.markDelivered(claim!.id, {}, stolenClaimedAt)).toBe(true)
+
+    const [delivery] = await alertDeliveryRepository.listByEvent(event.id)
+    expect(delivery?.status).toBe('delivered')
+  })
+})

--- a/packages/dal/src/repositories/alert-delivery.ts
+++ b/packages/dal/src/repositories/alert-delivery.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, isNull, lte, or, sql } from 'drizzle-orm'
+import { and, asc, eq, sql } from 'drizzle-orm'
 import { getDb } from '../db/client'
 import {
   alertDelivery,
@@ -12,6 +12,34 @@ const STALE_CLAIM_MS = 10 * 60 * 1000
 function toNumber(value: number | string | bigint | null | undefined): number {
   if (value === null || value === undefined) return 0
   return Number(value)
+}
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[]
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    Array.isArray((result as { rows?: unknown[] }).rows)
+  ) {
+    return (result as { rows: T[] }).rows
+  }
+  return []
+}
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) return value
+  if (typeof value === 'string') return new Date(value)
+  return null
+}
+
+function normalizeAlertDeliveryRow(row: AlertDelivery): AlertDelivery {
+  return {
+    ...row,
+    createdAt: toDate(row.createdAt) ?? row.createdAt,
+    updatedAt: toDate(row.updatedAt) ?? row.updatedAt,
+    nextRetryAt: toDate(row.nextRetryAt) ?? row.nextRetryAt,
+    claimedAt: toDate(row.claimedAt) ?? row.claimedAt,
+  }
 }
 
 export interface AlertDeliveryInput {
@@ -56,35 +84,55 @@ export const alertDeliveryRepository = {
     const now = new Date()
     const staleClaimCutoff = new Date(now.getTime() - STALE_CLAIM_MS)
 
-    const rows = await db
-      .select({ id: alertDelivery.id })
-      .from(alertDelivery)
-      .where(
-        and(
-          eq(alertDelivery.alertEventId, alertEventId),
-          or(
-            eq(alertDelivery.status, 'pending'),
-            eq(alertDelivery.status, 'failed'),
-            and(eq(alertDelivery.status, 'claimed'), lte(alertDelivery.claimedAt, staleClaimCutoff))
-          ),
-          or(isNull(alertDelivery.nextRetryAt), lte(alertDelivery.nextRetryAt, now))
-        )
+    const result = await db.execute(sql`
+      UPDATE ${alertDelivery} AS delivery
+      SET
+        status = 'claimed',
+        claimed_at = ${now},
+        updated_at = ${now}
+      WHERE delivery.id IN (
+        SELECT candidate.id
+        FROM ${alertDelivery} AS candidate
+        WHERE candidate.alert_event_id = ${alertEventId}
+          AND (
+            candidate.status = 'pending'
+            OR (
+              candidate.status = 'failed'
+              AND candidate.next_retry_at IS NOT NULL
+            )
+            OR (
+              candidate.status = 'claimed'
+              AND candidate.claimed_at <= ${staleClaimCutoff}
+            )
+          )
+          AND (
+            candidate.next_retry_at IS NULL
+            OR candidate.next_retry_at <= ${now}
+          )
+        ORDER BY candidate.created_at
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
       )
-      .orderBy(asc(alertDelivery.createdAt))
-      .limit(limit)
+      RETURNING
+        delivery.id,
+        delivery.created_at AS "createdAt",
+        delivery.updated_at AS "updatedAt",
+        delivery.alert_event_id AS "alertEventId",
+        delivery.organization_id AS "organizationId",
+        delivery.channel_type AS "channelType",
+        delivery.target,
+        delivery.status,
+        delivery.attempt_count AS "attemptCount",
+        delivery.next_retry_at AS "nextRetryAt",
+        delivery.claimed_at AS "claimedAt",
+        delivery.last_error AS "lastError",
+        delivery.provider_metadata AS "providerMetadata",
+        delivery.external_id AS "externalId",
+        delivery.external_identifier AS "externalIdentifier",
+        delivery.external_url AS "externalUrl"
+    `)
 
-    if (rows.length === 0) return []
-    const ids = rows.map((row) => row.id)
-
-    return db
-      .update(alertDelivery)
-      .set({
-        status: 'claimed',
-        claimedAt: now,
-        updatedAt: now,
-      })
-      .where(inArray(alertDelivery.id, ids))
-      .returning()
+    return rowsFromExecute<AlertDelivery>(result).map(normalizeAlertDeliveryRow)
   },
 
   async markDelivered(
@@ -94,10 +142,11 @@ export const alertDeliveryRepository = {
       externalIdentifier?: string | null
       externalUrl?: string | null
       providerMetadata?: Record<string, unknown>
-    } = {}
-  ): Promise<void> {
+    } = {},
+    expectedClaimedAt?: Date | null
+  ): Promise<boolean> {
     const db = await getDb()
-    await db
+    const rows = await db
       .update(alertDelivery)
       .set({
         status: 'delivered',
@@ -110,16 +159,32 @@ export const alertDeliveryRepository = {
         providerMetadata: metadata.providerMetadata ?? {},
         updatedAt: new Date(),
       })
-      .where(eq(alertDelivery.id, id))
+      .where(
+        expectedClaimedAt
+          ? and(
+              eq(alertDelivery.id, id),
+              eq(alertDelivery.status, 'claimed'),
+              eq(alertDelivery.claimedAt, expectedClaimedAt)
+            )
+          : eq(alertDelivery.id, id)
+      )
+      .returning({ id: alertDelivery.id })
+
+    return rows.length > 0
   },
 
   async markFailed(
     id: string,
-    options: { error: string; retryable: boolean; nextRetryAt?: Date | null }
-  ): Promise<void> {
+    options: {
+      error: string
+      retryable: boolean
+      nextRetryAt?: Date | null
+      expectedClaimedAt?: Date | null
+    }
+  ): Promise<boolean> {
     const db = await getDb()
     const now = new Date()
-    await db
+    const rows = await db
       .update(alertDelivery)
       .set({
         status: 'failed',
@@ -129,7 +194,18 @@ export const alertDeliveryRepository = {
         lastError: options.error.slice(0, 1000),
         updatedAt: now,
       })
-      .where(eq(alertDelivery.id, id))
+      .where(
+        options.expectedClaimedAt
+          ? and(
+              eq(alertDelivery.id, id),
+              eq(alertDelivery.status, 'claimed'),
+              eq(alertDelivery.claimedAt, options.expectedClaimedAt)
+            )
+          : eq(alertDelivery.id, id)
+      )
+      .returning({ id: alertDelivery.id })
+
+    return rows.length > 0
   },
 
   async countByStatuses(alertEventId: string): Promise<Record<AlertDeliveryStatus, number>> {

--- a/packages/dal/src/repositories/alert-delivery.ts
+++ b/packages/dal/src/repositories/alert-delivery.ts
@@ -1,9 +1,9 @@
 import { and, asc, eq, sql } from 'drizzle-orm'
 import { getDb } from '../db/client'
 import {
-  alertDelivery,
   type AlertDeliveryChannelType,
   type AlertDeliveryStatus,
+  alertDelivery,
 } from '../db/schemas/alert-delivery/schema'
 import type { AlertDelivery } from '../db/schemas/alert-delivery/types'
 
@@ -143,7 +143,7 @@ export const alertDeliveryRepository = {
       externalUrl?: string | null
       providerMetadata?: Record<string, unknown>
     } = {},
-    expectedClaimedAt?: Date | null
+    expectedClaimedAt: Date
   ): Promise<boolean> {
     const db = await getDb()
     const rows = await db
@@ -160,13 +160,11 @@ export const alertDeliveryRepository = {
         updatedAt: new Date(),
       })
       .where(
-        expectedClaimedAt
-          ? and(
-              eq(alertDelivery.id, id),
-              eq(alertDelivery.status, 'claimed'),
-              eq(alertDelivery.claimedAt, expectedClaimedAt)
-            )
-          : eq(alertDelivery.id, id)
+        and(
+          eq(alertDelivery.id, id),
+          eq(alertDelivery.status, 'claimed'),
+          eq(alertDelivery.claimedAt, expectedClaimedAt)
+        )
       )
       .returning({ id: alertDelivery.id })
 
@@ -179,7 +177,7 @@ export const alertDeliveryRepository = {
       error: string
       retryable: boolean
       nextRetryAt?: Date | null
-      expectedClaimedAt?: Date | null
+      expectedClaimedAt: Date
     }
   ): Promise<boolean> {
     const db = await getDb()
@@ -195,13 +193,11 @@ export const alertDeliveryRepository = {
         updatedAt: now,
       })
       .where(
-        options.expectedClaimedAt
-          ? and(
-              eq(alertDelivery.id, id),
-              eq(alertDelivery.status, 'claimed'),
-              eq(alertDelivery.claimedAt, options.expectedClaimedAt)
-            )
-          : eq(alertDelivery.id, id)
+        and(
+          eq(alertDelivery.id, id),
+          eq(alertDelivery.status, 'claimed'),
+          eq(alertDelivery.claimedAt, options.expectedClaimedAt)
+        )
       )
       .returning({ id: alertDelivery.id })
 

--- a/packages/dal/src/repositories/alert-delivery.ts
+++ b/packages/dal/src/repositories/alert-delivery.ts
@@ -1,0 +1,154 @@
+import { and, asc, eq, inArray, isNull, lte, or, sql } from 'drizzle-orm'
+import { getDb } from '../db/client'
+import {
+  alertDelivery,
+  type AlertDeliveryChannelType,
+  type AlertDeliveryStatus,
+} from '../db/schemas/alert-delivery/schema'
+import type { AlertDelivery } from '../db/schemas/alert-delivery/types'
+
+const STALE_CLAIM_MS = 10 * 60 * 1000
+
+function toNumber(value: number | string | bigint | null | undefined): number {
+  if (value === null || value === undefined) return 0
+  return Number(value)
+}
+
+export interface AlertDeliveryInput {
+  alertEventId: string
+  organizationId: string
+  channelType: AlertDeliveryChannelType
+  target: string
+  providerMetadata?: Record<string, unknown>
+}
+
+export const alertDeliveryRepository = {
+  async enqueueMany(inputs: AlertDeliveryInput[]): Promise<AlertDelivery[]> {
+    if (inputs.length === 0) return []
+    const db = await getDb()
+
+    return db
+      .insert(alertDelivery)
+      .values(
+        inputs.map((input) => ({
+          alertEventId: input.alertEventId,
+          organizationId: input.organizationId,
+          channelType: input.channelType,
+          target: input.target,
+          providerMetadata: input.providerMetadata ?? {},
+        }))
+      )
+      .onConflictDoNothing()
+      .returning()
+  },
+
+  async listByEvent(alertEventId: string): Promise<AlertDelivery[]> {
+    const db = await getDb()
+    return db
+      .select()
+      .from(alertDelivery)
+      .where(eq(alertDelivery.alertEventId, alertEventId))
+      .orderBy(asc(alertDelivery.createdAt))
+  },
+
+  async claimDueForEvent(alertEventId: string, limit = 20): Promise<AlertDelivery[]> {
+    const db = await getDb()
+    const now = new Date()
+    const staleClaimCutoff = new Date(now.getTime() - STALE_CLAIM_MS)
+
+    const rows = await db
+      .select({ id: alertDelivery.id })
+      .from(alertDelivery)
+      .where(
+        and(
+          eq(alertDelivery.alertEventId, alertEventId),
+          or(
+            eq(alertDelivery.status, 'pending'),
+            eq(alertDelivery.status, 'failed'),
+            and(eq(alertDelivery.status, 'claimed'), lte(alertDelivery.claimedAt, staleClaimCutoff))
+          ),
+          or(isNull(alertDelivery.nextRetryAt), lte(alertDelivery.nextRetryAt, now))
+        )
+      )
+      .orderBy(asc(alertDelivery.createdAt))
+      .limit(limit)
+
+    if (rows.length === 0) return []
+    const ids = rows.map((row) => row.id)
+
+    return db
+      .update(alertDelivery)
+      .set({
+        status: 'claimed',
+        claimedAt: now,
+        updatedAt: now,
+      })
+      .where(inArray(alertDelivery.id, ids))
+      .returning()
+  },
+
+  async markDelivered(
+    id: string,
+    metadata: {
+      externalId?: string | null
+      externalIdentifier?: string | null
+      externalUrl?: string | null
+      providerMetadata?: Record<string, unknown>
+    } = {}
+  ): Promise<void> {
+    const db = await getDb()
+    await db
+      .update(alertDelivery)
+      .set({
+        status: 'delivered',
+        claimedAt: null,
+        nextRetryAt: null,
+        lastError: null,
+        externalId: metadata.externalId ?? null,
+        externalIdentifier: metadata.externalIdentifier ?? null,
+        externalUrl: metadata.externalUrl ?? null,
+        providerMetadata: metadata.providerMetadata ?? {},
+        updatedAt: new Date(),
+      })
+      .where(eq(alertDelivery.id, id))
+  },
+
+  async markFailed(
+    id: string,
+    options: { error: string; retryable: boolean; nextRetryAt?: Date | null }
+  ): Promise<void> {
+    const db = await getDb()
+    const now = new Date()
+    await db
+      .update(alertDelivery)
+      .set({
+        status: 'failed',
+        attemptCount: sql`${alertDelivery.attemptCount} + 1`,
+        claimedAt: null,
+        nextRetryAt: options.retryable ? (options.nextRetryAt ?? now) : null,
+        lastError: options.error.slice(0, 1000),
+        updatedAt: now,
+      })
+      .where(eq(alertDelivery.id, id))
+  },
+
+  async countByStatuses(alertEventId: string): Promise<Record<AlertDeliveryStatus, number>> {
+    const db = await getDb()
+    const rows = await db
+      .select({
+        status: alertDelivery.status,
+        count: sql<number>`count(*)`,
+      })
+      .from(alertDelivery)
+      .where(eq(alertDelivery.alertEventId, alertEventId))
+      .groupBy(alertDelivery.status)
+
+    return {
+      pending: 0,
+      claimed: 0,
+      delivered: 0,
+      failed: 0,
+      ...Object.fromEntries(rows.map((row) => [row.status, toNumber(row.count)])),
+    }
+  },
+}

--- a/packages/dal/src/repositories/alert-event.ts
+++ b/packages/dal/src/repositories/alert-event.ts
@@ -1,7 +1,7 @@
 import { uuidv7 } from '@durabull/utils/uuid'
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { getDb } from '../db/client'
-import { alertEvent, type AlertEventStatus } from '../db/schemas/alert-event/schema'
+import { type AlertEventStatus, alertEvent } from '../db/schemas/alert-event/schema'
 import type { AlertEvent, NewAlertEvent } from '../db/schemas/alert-event/types'
 
 function toNumber(value: number | string | bigint | null | undefined): number {
@@ -94,7 +94,13 @@ export const alertEventRepository = {
   async findByConnection(
     connectionId: string,
     organizationId: string,
-    options: { offset: number; limit: number; status?: AlertEventStatus }
+    options: {
+      offset: number
+      limit: number
+      status?: AlertEventStatus
+      queueName?: string
+      jobId?: string
+    }
   ): Promise<AlertEvent[]> {
     const db = await getDb()
     return db
@@ -104,7 +110,9 @@ export const alertEventRepository = {
         and(
           eq(alertEvent.connectionId, connectionId),
           eq(alertEvent.organizationId, organizationId),
-          ...(options.status ? [eq(alertEvent.status, options.status)] : [])
+          ...(options.status ? [eq(alertEvent.status, options.status)] : []),
+          ...(options.queueName ? [eq(alertEvent.queueName, options.queueName)] : []),
+          ...(options.jobId ? [sql`${alertEvent.context}->>'jobId' = ${options.jobId}`] : [])
         )
       )
       .orderBy(desc(alertEvent.firedAt))

--- a/packages/dal/src/repositories/alert-event.ts
+++ b/packages/dal/src/repositories/alert-event.ts
@@ -25,6 +25,42 @@ export const alertEventRepository = {
     return result
   },
 
+  async createOrGetByDedupeKey(
+    data: Omit<NewAlertEvent, 'id' | 'createdAt' | 'updatedAt'> & { dedupeKey: string }
+  ): Promise<{ event: AlertEvent; created: boolean }> {
+    const db = await getDb()
+    const id = uuidv7()
+
+    const [inserted] = await db
+      .insert(alertEvent)
+      .values({
+        id,
+        ...data,
+      })
+      .onConflictDoNothing({
+        target: [alertEvent.alertRuleId, alertEvent.dedupeKey],
+      })
+      .returning()
+
+    if (inserted) {
+      return { event: inserted, created: true }
+    }
+
+    const rows = await db
+      .select()
+      .from(alertEvent)
+      .where(
+        and(eq(alertEvent.alertRuleId, data.alertRuleId), eq(alertEvent.dedupeKey, data.dedupeKey))
+      )
+      .limit(1)
+
+    if (!rows[0]) {
+      throw new Error('Alert event dedupe conflict could not be resolved.')
+    }
+
+    return { event: rows[0], created: false }
+  },
+
   async findActiveFiring(alertRuleId: string, queueName: string): Promise<AlertEvent | null> {
     const db = await getDb()
     const rows = await db

--- a/packages/dal/src/repositories/linear-integration.ts
+++ b/packages/dal/src/repositories/linear-integration.ts
@@ -111,19 +111,21 @@ export const linearIntegrationRepository = {
     }
   ): Promise<LinearIntegration | null> {
     const db = await getDb()
+    const update: Partial<LinearIntegration> = { updatedAt: new Date() }
+    if ('defaultTeamId' in defaults) update.defaultTeamId = defaults.defaultTeamId ?? null
+    if ('defaultProjectId' in defaults) update.defaultProjectId = defaults.defaultProjectId ?? null
+    if ('defaultLabelIds' in defaults) update.defaultLabelIds = defaults.defaultLabelIds ?? []
+    if ('defaultAssigneeId' in defaults)
+      update.defaultAssigneeId = defaults.defaultAssigneeId ?? null
+    if ('defaultStateId' in defaults) update.defaultStateId = defaults.defaultStateId ?? null
+    if ('defaultPriority' in defaults) update.defaultPriority = defaults.defaultPriority ?? null
+    if ('validationStatus' in defaults)
+      update.validationStatus = defaults.validationStatus ?? 'unknown'
+    if ('lastValidatedAt' in defaults) update.lastValidatedAt = defaults.lastValidatedAt ?? null
+
     const [row] = await db
       .update(linearIntegration)
-      .set({
-        defaultTeamId: defaults.defaultTeamId ?? null,
-        defaultProjectId: defaults.defaultProjectId ?? null,
-        defaultLabelIds: defaults.defaultLabelIds ?? [],
-        defaultAssigneeId: defaults.defaultAssigneeId ?? null,
-        defaultStateId: defaults.defaultStateId ?? null,
-        defaultPriority: defaults.defaultPriority ?? null,
-        validationStatus: defaults.validationStatus ?? 'unknown',
-        lastValidatedAt: defaults.lastValidatedAt ?? null,
-        updatedAt: new Date(),
-      })
+      .set(update)
       .where(eq(linearIntegration.organizationId, organizationId))
       .returning()
 

--- a/packages/dal/src/repositories/linear-integration.ts
+++ b/packages/dal/src/repositories/linear-integration.ts
@@ -1,0 +1,119 @@
+import { eq } from 'drizzle-orm'
+import { getDb } from '../db/client'
+import { linearIntegration } from '../db/schemas/linear-integration/schema'
+import type {
+  LinearIntegration,
+  LinearIntegrationValidationStatus,
+} from '../db/schemas/linear-integration/types'
+import { encryptSecret, maskSecretPreview } from '../db/secret-encryption'
+
+export interface LinearIntegrationDefaults {
+  defaultTeamId?: string | null
+  defaultProjectId?: string | null
+  defaultLabelIds?: string[]
+  defaultAssigneeId?: string | null
+  defaultStateId?: string | null
+  defaultPriority?: number | null
+}
+
+export interface UpsertLinearIntegrationInput extends LinearIntegrationDefaults {
+  organizationId: string
+  apiKey: string
+  validationStatus?: LinearIntegrationValidationStatus
+  lastValidatedAt?: Date | null
+}
+
+export const linearIntegrationRepository = {
+  async findByOrganization(organizationId: string): Promise<LinearIntegration | null> {
+    const db = await getDb()
+    const rows = await db
+      .select()
+      .from(linearIntegration)
+      .where(eq(linearIntegration.organizationId, organizationId))
+      .limit(1)
+
+    return rows[0] ?? null
+  },
+
+  async upsert(input: UpsertLinearIntegrationInput): Promise<LinearIntegration> {
+    const db = await getDb()
+    const now = new Date()
+    const values = {
+      organizationId: input.organizationId,
+      encryptedApiKey: encryptSecret(input.apiKey),
+      keyPreview: maskSecretPreview(input.apiKey),
+      validationStatus: input.validationStatus ?? 'unknown',
+      defaultTeamId: input.defaultTeamId ?? null,
+      defaultProjectId: input.defaultProjectId ?? null,
+      defaultLabelIds: input.defaultLabelIds ?? [],
+      defaultAssigneeId: input.defaultAssigneeId ?? null,
+      defaultStateId: input.defaultStateId ?? null,
+      defaultPriority: input.defaultPriority ?? null,
+      lastValidatedAt: input.lastValidatedAt ?? null,
+      updatedAt: now,
+    }
+
+    const [row] = await db
+      .insert(linearIntegration)
+      .values(values)
+      .onConflictDoUpdate({
+        target: linearIntegration.organizationId,
+        set: values,
+      })
+      .returning()
+
+    return row
+  },
+
+  async updateDefaults(
+    organizationId: string,
+    defaults: LinearIntegrationDefaults & {
+      validationStatus?: LinearIntegrationValidationStatus
+      lastValidatedAt?: Date | null
+    }
+  ): Promise<LinearIntegration | null> {
+    const db = await getDb()
+    const [row] = await db
+      .update(linearIntegration)
+      .set({
+        defaultTeamId: defaults.defaultTeamId ?? null,
+        defaultProjectId: defaults.defaultProjectId ?? null,
+        defaultLabelIds: defaults.defaultLabelIds ?? [],
+        defaultAssigneeId: defaults.defaultAssigneeId ?? null,
+        defaultStateId: defaults.defaultStateId ?? null,
+        defaultPriority: defaults.defaultPriority ?? null,
+        validationStatus: defaults.validationStatus ?? 'unknown',
+        lastValidatedAt: defaults.lastValidatedAt ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(linearIntegration.organizationId, organizationId))
+      .returning()
+
+    return row ?? null
+  },
+
+  async markValidationStatus(
+    organizationId: string,
+    validationStatus: LinearIntegrationValidationStatus
+  ): Promise<void> {
+    const db = await getDb()
+    await db
+      .update(linearIntegration)
+      .set({
+        validationStatus,
+        lastValidatedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(linearIntegration.organizationId, organizationId))
+  },
+
+  async delete(organizationId: string): Promise<boolean> {
+    const db = await getDb()
+    const rows = await db
+      .delete(linearIntegration)
+      .where(eq(linearIntegration.organizationId, organizationId))
+      .returning({ id: linearIntegration.id })
+
+    return rows.length > 0
+  },
+}

--- a/packages/dal/src/repositories/linear-integration.ts
+++ b/packages/dal/src/repositories/linear-integration.ts
@@ -5,7 +5,7 @@ import type {
   LinearIntegration,
   LinearIntegrationValidationStatus,
 } from '../db/schemas/linear-integration/types'
-import { encryptSecret, maskSecretPreview } from '../db/secret-encryption'
+import { encryptSecret } from '../db/secret-encryption'
 
 export interface LinearIntegrationDefaults {
   defaultTeamId?: string | null
@@ -16,9 +16,14 @@ export interface LinearIntegrationDefaults {
   defaultPriority?: number | null
 }
 
-export interface UpsertLinearIntegrationInput extends LinearIntegrationDefaults {
+export interface UpsertLinearOauthIntegrationInput extends LinearIntegrationDefaults {
   organizationId: string
-  apiKey: string
+  accessToken: string
+  refreshToken: string
+  tokenType?: string
+  scopes: string
+  accessTokenExpiresAt: Date
+  linearOrganizationName?: string | null
   validationStatus?: LinearIntegrationValidationStatus
   lastValidatedAt?: Date | null
 }
@@ -35,13 +40,17 @@ export const linearIntegrationRepository = {
     return rows[0] ?? null
   },
 
-  async upsert(input: UpsertLinearIntegrationInput): Promise<LinearIntegration> {
+  async upsertOauth(input: UpsertLinearOauthIntegrationInput): Promise<LinearIntegration> {
     const db = await getDb()
     const now = new Date()
     const values = {
       organizationId: input.organizationId,
-      encryptedApiKey: encryptSecret(input.apiKey),
-      keyPreview: maskSecretPreview(input.apiKey),
+      encryptedAccessToken: encryptSecret(input.accessToken),
+      encryptedRefreshToken: encryptSecret(input.refreshToken),
+      tokenType: input.tokenType ?? 'Bearer',
+      scopes: input.scopes,
+      accessTokenExpiresAt: input.accessTokenExpiresAt,
+      linearOrganizationName: input.linearOrganizationName ?? null,
       validationStatus: input.validationStatus ?? 'unknown',
       defaultTeamId: input.defaultTeamId ?? null,
       defaultProjectId: input.defaultProjectId ?? null,
@@ -63,6 +72,35 @@ export const linearIntegrationRepository = {
       .returning()
 
     return row
+  },
+
+  async updateOauthTokens(
+    organizationId: string,
+    tokens: {
+      accessToken: string
+      refreshToken: string
+      tokenType?: string
+      scopes?: string
+      accessTokenExpiresAt: Date
+    }
+  ): Promise<LinearIntegration | null> {
+    const db = await getDb()
+    const [row] = await db
+      .update(linearIntegration)
+      .set({
+        encryptedAccessToken: encryptSecret(tokens.accessToken),
+        encryptedRefreshToken: encryptSecret(tokens.refreshToken),
+        tokenType: tokens.tokenType ?? 'Bearer',
+        ...(tokens.scopes ? { scopes: tokens.scopes } : {}),
+        accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+        validationStatus: 'valid',
+        lastValidatedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(linearIntegration.organizationId, organizationId))
+      .returning()
+
+    return row ?? null
   },
 
   async updateDefaults(

--- a/packages/dal/src/repositories/linear-job-issue.test.ts
+++ b/packages/dal/src/repositories/linear-job-issue.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { env } from '@durabull/env'
+import { closeDb, getDb } from '../db/client'
+import { organization } from '../db/schemas/organization/schema'
+import { alertEventRepository } from './alert-event'
+import { alertRuleRepository } from './alert-rule'
+import { linearJobIssueRepository } from './linear-job-issue'
+import { redisConnectionRepository } from './redis-connection'
+
+const TEST_ORG_ID = 'linear-job-issue-org'
+const TEST_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+const mutableEnv = env as {
+  DATABASE_URL?: string
+  DURABULL_ENV_CONNECTIONS?: boolean
+  DURABULL_REDIS_URL_ENCRYPTION_KEY?: string
+}
+
+const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalEnvConnectionsFlag = mutableEnv.DURABULL_ENV_CONNECTIONS
+const originalEncryptionKey = mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY
+const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+
+let tempPgliteDir = ''
+
+async function seedBase() {
+  const db = await getDb()
+  const now = new Date()
+
+  await db.insert(organization).values({
+    id: TEST_ORG_ID,
+    name: 'Linear Job Issue Org',
+    slug: 'linear-job-issue-org',
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  const connection = await redisConnectionRepository.create({
+    name: 'Primary Redis',
+    url: 'redis://localhost:6379/0',
+    environment: 'development',
+    isDefault: true,
+    organizationId: TEST_ORG_ID,
+  })
+
+  const rule = await alertRuleRepository.create({
+    organizationId: TEST_ORG_ID,
+    connectionId: connection.id,
+    queueName: 'email-send',
+    name: 'Job failed',
+    type: 'job_failed',
+    config: { maxIssuesPerPoll: 100 },
+    cooldownMinutes: 30,
+  })
+
+  return { connection, rule }
+}
+
+describe('linearJobIssueRepository', () => {
+  beforeEach(async () => {
+    tempPgliteDir = await mkdtemp(join(tmpdir(), 'durabull-linear-job-issue-'))
+    process.env.DURABULL_PGLITE_DIR = tempPgliteDir
+    delete process.env.DATABASE_URL
+    mutableEnv.DATABASE_URL = undefined
+    mutableEnv.DURABULL_ENV_CONNECTIONS = false
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY
+    await closeDb()
+  })
+
+  afterEach(async () => {
+    await closeDb()
+    mutableEnv.DATABASE_URL = originalDatabaseUrl
+    mutableEnv.DURABULL_ENV_CONNECTIONS = originalEnvConnectionsFlag
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = originalEncryptionKey
+
+    if (originalPgliteDir) {
+      process.env.DURABULL_PGLITE_DIR = originalPgliteDir
+    } else {
+      delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (tempPgliteDir) {
+      await rm(tempPgliteDir, { recursive: true, force: true })
+      tempPgliteDir = ''
+    }
+  })
+
+  it('links reused job issues to every alert event that reused them', async () => {
+    const { connection, rule } = await seedBase()
+    const firstEvent = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: connection.id,
+      queueName: 'email-send',
+      type: 'job_failed',
+      status: 'firing',
+      summary: 'First alert',
+      context: { jobId: 'job-1' },
+      firedAt: new Date(),
+    })
+    const secondEvent = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: connection.id,
+      queueName: 'email-send',
+      type: 'job_failed',
+      status: 'firing',
+      summary: 'Second alert',
+      context: { jobId: 'job-1' },
+      firedAt: new Date(),
+    })
+
+    const firstIssue = await linearJobIssueRepository.createOrGet({
+      organizationId: TEST_ORG_ID,
+      connectionId: connection.id,
+      queueName: 'email-send',
+      jobId: 'job-1',
+      alertEventId: firstEvent.id,
+      linearIssueId: 'issue-1',
+      linearIssueIdentifier: 'OPS-1',
+      linearIssueUrl: 'https://linear.app/acme/issue/OPS-1',
+    })
+    const reusedIssue = await linearJobIssueRepository.createOrGet({
+      organizationId: TEST_ORG_ID,
+      connectionId: connection.id,
+      queueName: 'email-send',
+      jobId: 'job-1',
+      alertEventId: secondEvent.id,
+      linearIssueId: 'issue-1',
+      linearIssueIdentifier: 'OPS-1',
+      linearIssueUrl: 'https://linear.app/acme/issue/OPS-1',
+    })
+
+    expect(reusedIssue.id).toBe(firstIssue.id)
+    await expect(linearJobIssueRepository.findByEvent(firstEvent.id)).resolves.toEqual([
+      expect.objectContaining({ id: firstIssue.id, linearIssueIdentifier: 'OPS-1' }),
+    ])
+    await expect(linearJobIssueRepository.findByEvent(secondEvent.id)).resolves.toEqual([
+      expect.objectContaining({ id: firstIssue.id, linearIssueIdentifier: 'OPS-1' }),
+    ])
+  })
+})

--- a/packages/dal/src/repositories/linear-job-issue.ts
+++ b/packages/dal/src/repositories/linear-job-issue.ts
@@ -62,7 +62,15 @@ export const linearJobIssueRepository = {
     const db = await getDb()
     const [inserted] = await db
       .insert(linearJobIssue)
-      .values(input)
+      .values({
+        organizationId: input.organizationId,
+        connectionId: input.connectionId,
+        queueName: input.queueName,
+        jobId: input.jobId,
+        linearIssueId: input.linearIssueId,
+        linearIssueIdentifier: input.linearIssueIdentifier,
+        linearIssueUrl: input.linearIssueUrl,
+      })
       .onConflictDoNothing({
         target: [
           linearJobIssue.organizationId,

--- a/packages/dal/src/repositories/linear-job-issue.ts
+++ b/packages/dal/src/repositories/linear-job-issue.ts
@@ -1,7 +1,8 @@
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { getDb } from '../db/client'
 import { linearJobIssue } from '../db/schemas/linear-job-issue/schema'
 import type { LinearJobIssue } from '../db/schemas/linear-job-issue/types'
+import { linearJobIssueEvent } from '../db/schemas/linear-job-issue-event/schema'
 
 export interface CreateLinearJobIssueInput {
   organizationId: string
@@ -37,6 +38,16 @@ async function findLinearJobIssueByJob(input: {
   return rows[0] ?? null
 }
 
+async function linkIssueToEvent(linearJobIssueId: string, alertEventId: string): Promise<void> {
+  const db = await getDb()
+  await db
+    .insert(linearJobIssueEvent)
+    .values({ linearJobIssueId, alertEventId })
+    .onConflictDoNothing({
+      target: [linearJobIssueEvent.linearJobIssueId, linearJobIssueEvent.alertEventId],
+    })
+}
+
 export const linearJobIssueRepository = {
   async findByJob(input: {
     organizationId: string
@@ -62,7 +73,10 @@ export const linearJobIssueRepository = {
       })
       .returning()
 
-    if (inserted) return inserted
+    if (inserted) {
+      await linkIssueToEvent(inserted.id, input.alertEventId)
+      return inserted
+    }
 
     const existing = await findLinearJobIssueByJob(input)
 
@@ -70,11 +84,27 @@ export const linearJobIssueRepository = {
       throw new Error('Linear job issue dedupe conflict could not be resolved.')
     }
 
+    await linkIssueToEvent(existing.id, input.alertEventId)
     return existing
   },
 
   async findByEvent(alertEventId: string): Promise<LinearJobIssue[]> {
     const db = await getDb()
-    return db.select().from(linearJobIssue).where(eq(linearJobIssue.alertEventId, alertEventId))
+    const links = await db
+      .select({ linearJobIssueId: linearJobIssueEvent.linearJobIssueId })
+      .from(linearJobIssueEvent)
+      .where(eq(linearJobIssueEvent.alertEventId, alertEventId))
+
+    if (links.length === 0) return []
+
+    return db
+      .select()
+      .from(linearJobIssue)
+      .where(
+        inArray(
+          linearJobIssue.id,
+          links.map((link) => link.linearJobIssueId)
+        )
+      )
   },
 }

--- a/packages/dal/src/repositories/linear-job-issue.ts
+++ b/packages/dal/src/repositories/linear-job-issue.ts
@@ -14,7 +14,39 @@ export interface CreateLinearJobIssueInput {
   linearIssueUrl: string
 }
 
+async function findLinearJobIssueByJob(input: {
+  organizationId: string
+  connectionId: string
+  queueName: string
+  jobId: string
+}): Promise<LinearJobIssue | null> {
+  const db = await getDb()
+  const rows = await db
+    .select()
+    .from(linearJobIssue)
+    .where(
+      and(
+        eq(linearJobIssue.organizationId, input.organizationId),
+        eq(linearJobIssue.connectionId, input.connectionId),
+        eq(linearJobIssue.queueName, input.queueName),
+        eq(linearJobIssue.jobId, input.jobId)
+      )
+    )
+    .limit(1)
+
+  return rows[0] ?? null
+}
+
 export const linearJobIssueRepository = {
+  async findByJob(input: {
+    organizationId: string
+    connectionId: string
+    queueName: string
+    jobId: string
+  }): Promise<LinearJobIssue | null> {
+    return findLinearJobIssueByJob(input)
+  },
+
   async createOrGet(input: CreateLinearJobIssueInput): Promise<LinearJobIssue> {
     const db = await getDb()
     const [inserted] = await db
@@ -32,24 +64,13 @@ export const linearJobIssueRepository = {
 
     if (inserted) return inserted
 
-    const rows = await db
-      .select()
-      .from(linearJobIssue)
-      .where(
-        and(
-          eq(linearJobIssue.organizationId, input.organizationId),
-          eq(linearJobIssue.connectionId, input.connectionId),
-          eq(linearJobIssue.queueName, input.queueName),
-          eq(linearJobIssue.jobId, input.jobId)
-        )
-      )
-      .limit(1)
+    const existing = await findLinearJobIssueByJob(input)
 
-    if (!rows[0]) {
+    if (!existing) {
       throw new Error('Linear job issue dedupe conflict could not be resolved.')
     }
 
-    return rows[0]
+    return existing
   },
 
   async findByEvent(alertEventId: string): Promise<LinearJobIssue[]> {

--- a/packages/dal/src/repositories/linear-job-issue.ts
+++ b/packages/dal/src/repositories/linear-job-issue.ts
@@ -1,0 +1,59 @@
+import { and, eq } from 'drizzle-orm'
+import { getDb } from '../db/client'
+import { linearJobIssue } from '../db/schemas/linear-job-issue/schema'
+import type { LinearJobIssue } from '../db/schemas/linear-job-issue/types'
+
+export interface CreateLinearJobIssueInput {
+  organizationId: string
+  connectionId: string
+  queueName: string
+  jobId: string
+  alertEventId: string
+  linearIssueId: string
+  linearIssueIdentifier: string
+  linearIssueUrl: string
+}
+
+export const linearJobIssueRepository = {
+  async createOrGet(input: CreateLinearJobIssueInput): Promise<LinearJobIssue> {
+    const db = await getDb()
+    const [inserted] = await db
+      .insert(linearJobIssue)
+      .values(input)
+      .onConflictDoNothing({
+        target: [
+          linearJobIssue.organizationId,
+          linearJobIssue.connectionId,
+          linearJobIssue.queueName,
+          linearJobIssue.jobId,
+        ],
+      })
+      .returning()
+
+    if (inserted) return inserted
+
+    const rows = await db
+      .select()
+      .from(linearJobIssue)
+      .where(
+        and(
+          eq(linearJobIssue.organizationId, input.organizationId),
+          eq(linearJobIssue.connectionId, input.connectionId),
+          eq(linearJobIssue.queueName, input.queueName),
+          eq(linearJobIssue.jobId, input.jobId)
+        )
+      )
+      .limit(1)
+
+    if (!rows[0]) {
+      throw new Error('Linear job issue dedupe conflict could not be resolved.')
+    }
+
+    return rows[0]
+  },
+
+  async findByEvent(alertEventId: string): Promise<LinearJobIssue[]> {
+    const db = await getDb()
+    return db.select().from(linearJobIssue).where(eq(linearJobIssue.alertEventId, alertEventId))
+  },
+}

--- a/packages/dal/src/repositories/linear-oauth-state.ts
+++ b/packages/dal/src/repositories/linear-oauth-state.ts
@@ -53,6 +53,19 @@ export const linearOauthStateRepository = {
     return rows[0] ?? null
   },
 
+  async consumeByState(state: string): Promise<LinearOauthState | null> {
+    const db = await getDb()
+    const stateHash = hashLinearOauthState(state)
+    const rows = await db
+      .delete(linearOauthState)
+      .where(
+        and(eq(linearOauthState.stateHash, stateHash), gt(linearOauthState.expiresAt, new Date()))
+      )
+      .returning()
+
+    return rows[0] ?? null
+  },
+
   async deleteExpired(): Promise<void> {
     const db = await getDb()
     await db.delete(linearOauthState).where(lt(linearOauthState.expiresAt, new Date()))

--- a/packages/dal/src/repositories/linear-oauth-state.ts
+++ b/packages/dal/src/repositories/linear-oauth-state.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'node:crypto'
+import { and, eq, gt, lt } from 'drizzle-orm'
+import { getDb } from '../db/client'
+import { linearOauthState } from '../db/schemas/linear-oauth-state/schema'
+import type { LinearOauthState } from '../db/schemas/linear-oauth-state/types'
+
+export function hashLinearOauthState(state: string): string {
+  return createHash('sha256').update(state).digest('hex')
+}
+
+export const linearOauthStateRepository = {
+  async create(input: {
+    organizationId: string
+    userId: string
+    state: string
+    redirectUri: string
+    expiresAt: Date
+  }): Promise<LinearOauthState> {
+    const db = await getDb()
+    const [row] = await db
+      .insert(linearOauthState)
+      .values({
+        organizationId: input.organizationId,
+        userId: input.userId,
+        stateHash: hashLinearOauthState(input.state),
+        redirectUri: input.redirectUri,
+        expiresAt: input.expiresAt,
+      })
+      .returning()
+
+    return row
+  },
+
+  async consume(input: {
+    organizationId: string
+    userId: string
+    state: string
+  }): Promise<LinearOauthState | null> {
+    const db = await getDb()
+    const stateHash = hashLinearOauthState(input.state)
+    const rows = await db
+      .delete(linearOauthState)
+      .where(
+        and(
+          eq(linearOauthState.organizationId, input.organizationId),
+          eq(linearOauthState.userId, input.userId),
+          eq(linearOauthState.stateHash, stateHash),
+          gt(linearOauthState.expiresAt, new Date())
+        )
+      )
+      .returning()
+
+    return rows[0] ?? null
+  },
+
+  async deleteExpired(): Promise<void> {
+    const db = await getDb()
+    await db.delete(linearOauthState).where(lt(linearOauthState.expiresAt, new Date()))
+  },
+}

--- a/tooling/env/src/index.ts
+++ b/tooling/env/src/index.ts
@@ -82,6 +82,7 @@ const envSchema = z.object({
   DURABULL_AUTHLESS: optionalBoolean,
   DURABULL_ENV_CONNECTIONS: optionalBoolean,
   DURABULL_REDIS_URL_ENCRYPTION_KEY: optionalString,
+  DURABULL_SECRET_ENCRYPTION_KEY: optionalString,
   DURABULL_REDIS_PORT: optionalInt,
   DURABULL_REDIS_URL_DEFAULT: optionalString,
   DURABULL_DEMO_ACCOUNT_REDIS_CONNECTION_STRING: optionalString,

--- a/tooling/env/src/index.ts
+++ b/tooling/env/src/index.ts
@@ -55,6 +55,10 @@ const appBaseUrlSchema = z.preprocess(
   emptyToUndefined,
   z.string().default('http://localhost:5173')
 )
+const linearOauthActorSchema = z.preprocess(
+  emptyToUndefined,
+  z.enum(['user', 'app']).default('user')
+)
 
 const envSchema = z.object({
   NODE_ENV: nodeEnvSchema,
@@ -91,6 +95,7 @@ const envSchema = z.object({
   LINEAR_OAUTH_CLIENT_ID: optionalString,
   LINEAR_OAUTH_CLIENT_SECRET: optionalString,
   LINEAR_OAUTH_REDIRECT_URI: optionalString,
+  LINEAR_OAUTH_ACTOR: linearOauthActorSchema,
   DEMO_HEALTH_MAX_AGE_HOURS: optionalNonNegativeInt,
 })
 

--- a/tooling/env/src/index.ts
+++ b/tooling/env/src/index.ts
@@ -88,6 +88,9 @@ const envSchema = z.object({
   DURABULL_DEMO_ACCOUNT_REDIS_CONNECTION_STRING: optionalString,
   DURABULL_ALERT_ENABLED: optionalBoolean,
   DURABULL_ALERT_POLL_INTERVAL_MS: optionalInt,
+  LINEAR_OAUTH_CLIENT_ID: optionalString,
+  LINEAR_OAUTH_CLIENT_SECRET: optionalString,
+  LINEAR_OAUTH_REDIRECT_URI: optionalString,
   DEMO_HEALTH_MAX_AGE_HOURS: optionalNonNegativeInt,
 })
 


### PR DESCRIPTION
## Summary

Implements Linear as a first-class alert notification channel for Durabull, using Linear OAuth 2.0 instead of user-supplied API keys.

- Adds encrypted org-level Linear OAuth token storage backed by `DURABULL_SECRET_ENCRYPTION_KEY`
- Adds OAuth connect/callback flow with hashed, expiring state and automatic token refresh
- Adds per-channel alert delivery/outbox records with retries, stale-claim recovery, and provider metadata
- Adds Linear GraphQL validation, metadata lookup, and issue creation over bearer tokens
- Adds `job_failed` alert rules with database-backed dedupe by `(organization, connection, queue, job id)`
- Adds event `dedupe_key` support for concurrent-safe per-subject alert creation
- Extends alert rule APIs/UI for Linear routing and job-failed config
- Replaces the Linear API-key settings UI with a Linear OAuth connect flow and encrypted token defaults
- Shows Linear defaults only after OAuth is connected, keeping the disconnected state focused on the Connect Linear action
- Shows Linear issue links in alert events and job detail views
- Documents `LINEAR_OAUTH_CLIENT_ID`, `LINEAR_OAUTH_CLIENT_SECRET`, optional `LINEAR_OAUTH_REDIRECT_URI`, optional `LINEAR_OAUTH_ACTOR`, token encryption requirements, and the exact Linear callback URL for cloud/self-hosted installs

Closes #63.

## OAuth Hardening

- Authorization URL includes `response_type=code`, `scope=read,issues:create`, `prompt=consent`, and opaque state
- Uses Linear's default user actor OAuth flow by default, omitting `actor`; `LINEAR_OAUTH_ACTOR=app` opts into app actor authorization
- Default redirect is derived from `${APP_BASE_URL}/api/alerts/integrations/linear/callback`
- Split-host self-hosting can override the callback with `LINEAR_OAUTH_REDIRECT_URI`
- Callback can complete from the opaque state even when browser session cookies are unavailable, and still rejects invalid, expired, and replayed state before code exchange
- Token exchange persists encrypted access and refresh tokens only
- Expired access tokens refresh before metadata/issue calls and persist rotated refresh tokens
- Disconnect revokes both refresh and access tokens best-effort before deleting local integration state

## Validation

- `bun test packages/dal/src/db/secret-encryption.test.ts apps/api/src/lib/linear-oauth.test.ts apps/api/src/lib/alert-notifier.test.ts apps/api/src/routes/alerts-global.test.ts apps/api/src/routes/alerts.test.ts apps/api/src/lib/alert-monitor.test.ts`
- `bun run --filter @durabull/web test:unit -- src/components/alerts/alert-rule-form.test.ts src/components/alerts/alert-events-table.test.tsx 'src/routes/$orgSlug.c.$connectionId.alerts.new.test.tsx' 'src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.test.tsx' src/routes/settings.test.tsx src/hooks/use-alerts.test.tsx src/components/alerts/alert-rule-builder-page.test.tsx`
- `bun run typecheck`
- `bun run --filter @durabull/api lint`
- `bun run --filter @durabull/dal lint`
- `bun run --filter @durabull/web lint`
- `bun run --filter @durabull/docs typecheck`
- `git diff --check`

## Note

`bun test` at the repo root is not a valid full-suite command in this repository today because it tries to run Vitest and Playwright suites through Bun's test runner. It fails on pre-existing harness errors such as `vi.hoisted is not a function`, missing browser `document`, and Playwright tests being loaded outside the Playwright runner. The package-appropriate tests above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linear integration: OAuth connect, configure defaults, route alerts to Linear, persistent delivery/outbox processing, and linked Linear issues shown in Settings, Rules builder, Events, and Job details.
  * New "Job Failed" alert type with per-poll caps, deduplication, and Linear routing support.
  * UI: delivery summaries and Linear issue links in events table and job page.
  * Secret encryption for safely storing third‑party tokens.

* **Documentation**
  * Added Linear integration docs and updated environment variable guidance (including required secret‑encryption key).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->