### PR TITLE
feat: env-driven EMAIL_FROM and OAuth provider visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,10 @@ BETTER_AUTH_SECRET=replace-me-with-a-long-random-string
 # Email (optional)
 # -----------------------------------------------------------------------------
 # RESEND_API_KEY=
+# Override the From address used for invitation and alert emails. Required when
+# self-hosting against a Resend account that does not own durabull.io.
+# Format: "Display Name <user@your-verified-domain.example>"
+# EMAIL_FROM=Acme Ops <ops@acme.example>
 
 # -----------------------------------------------------------------------------
 # Alerting (optional)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -137,6 +137,10 @@ function getAppConfig() {
     persistence,
     stateless: persistence === 'pglite',
     environment: env.NODE_ENV ?? 'development',
+    oauthProviders: {
+      google: !!(env.GOOGLE_OAUTH_CLIENT_ID && env.GOOGLE_OAUTH_CLIENT_SECRET),
+      github: !!(env.GITHUB_OAUTH_CLIENT_ID && env.GITHUB_OAUTH_CLIENT_SECRET),
+    },
     posthog: {
       enabled: !!posthogKey,
       key: posthogKey,

--- a/apps/web/src/hooks/use-app-config.ts
+++ b/apps/web/src/hooks/use-app-config.ts
@@ -16,6 +16,10 @@ const FALLBACK_APP_CONFIG: AppConfigResponse = {
   persistence: 'unknown',
   stateless: false,
   environment: 'development',
+  oauthProviders: {
+    google: false,
+    github: false,
+  },
   posthog: {
     enabled: false,
     key: null,

--- a/apps/web/src/routes/invite.$invitationId.tsx
+++ b/apps/web/src/routes/invite.$invitationId.tsx
@@ -20,6 +20,7 @@ import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
+import { useAppConfig } from '@/hooks/use-app-config'
 import { getAuthErrorMessage, useAuth } from '@/hooks/use-auth'
 import {
   type InvitationDetails,
@@ -271,6 +272,9 @@ function InviteAcceptPage() {
   const { invitationId } = useParams({ from: '/invite/$invitationId' })
   const navigate = useNavigate()
   const { isAuthenticated, isLoading: sessionLoading, user, signIn, signOut } = useAuth()
+  const { config: appConfig } = useAppConfig()
+  const oauthProviders = appConfig.oauthProviders
+  const showSocialBlock = oauthProviders.google || oauthProviders.github
 
   const {
     data: inviteData,
@@ -550,61 +554,69 @@ function InviteAcceptPage() {
           ) : (
             // Not logged in - allow social auth and email/password fallback
             <div className="space-y-4">
-              <div className="space-y-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="w-full"
-                  onClick={() => handleSocialAuth('google')}
-                  disabled={socialProviderLoading !== null}
-                >
-                  {socialProviderLoading === 'google' ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
-                      <path
-                        fill="currentColor"
-                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                      />
-                      <path
-                        fill="currentColor"
-                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                      />
-                      <path
-                        fill="currentColor"
-                        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                      />
-                      <path
-                        fill="currentColor"
-                        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                      />
-                    </svg>
-                  )}
-                  Continue with Google
-                </Button>
+              {showSocialBlock && (
+                <>
+                  <div className="space-y-3">
+                    {oauthProviders.google && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full"
+                        onClick={() => handleSocialAuth('google')}
+                        disabled={socialProviderLoading !== null}
+                      >
+                        {socialProviderLoading === 'google' ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+                            <path
+                              fill="currentColor"
+                              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                            />
+                            <path
+                              fill="currentColor"
+                              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                            />
+                            <path
+                              fill="currentColor"
+                              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                            />
+                            <path
+                              fill="currentColor"
+                              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                            />
+                          </svg>
+                        )}
+                        Continue with Google
+                      </Button>
+                    )}
 
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="w-full"
-                  onClick={() => handleSocialAuth('github')}
-                  disabled={socialProviderLoading !== null}
-                >
-                  {socialProviderLoading === 'github' ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <Github className="mr-2 h-4 w-4" />
-                  )}
-                  Continue with GitHub
-                </Button>
-              </div>
+                    {oauthProviders.github && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full"
+                        onClick={() => handleSocialAuth('github')}
+                        disabled={socialProviderLoading !== null}
+                      >
+                        {socialProviderLoading === 'github' ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <Github className="mr-2 h-4 w-4" />
+                        )}
+                        Continue with GitHub
+                      </Button>
+                    )}
+                  </div>
 
-              <div className="relative my-4">
-                <Separator />
-                <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
-                  OR
-                </span>
-              </div>
+                  <div className="relative my-4">
+                    <Separator />
+                    <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
+                      OR
+                    </span>
+                  </div>
+                </>
+              )}
 
               {authMode === 'signin' ? (
                 <InviteSignInForm

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -9,6 +9,7 @@ import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
+import { useAppConfig } from '@/hooks/use-app-config'
 import { getAuthErrorMessage, useAuth } from '@/hooks/use-auth'
 
 interface LoginSearch {
@@ -29,6 +30,9 @@ function LoginPage() {
   const { invitationId } = Route.useSearch()
   const navigate = useNavigate()
   const { signIn, isAuthenticated, isLoading: sessionLoading, refetch } = useAuth()
+  const { config: appConfig } = useAppConfig()
+  const oauthProviders = appConfig.oauthProviders
+  const showSocialBlock = oauthProviders.google || oauthProviders.github
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -207,52 +211,60 @@ function LoginPage() {
             </p>
           </div>
 
-          {/* Social Login Buttons */}
-          <div className="space-y-3">
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={handleGoogleSignIn}
-              disabled={isLoading}
-            >
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  fill="currentColor"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                />
-              </svg>
-              Continue with Google
-            </Button>
+          {showSocialBlock && (
+            <>
+              {/* Social Login Buttons */}
+              <div className="space-y-3">
+                {oauthProviders.google && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={handleGoogleSignIn}
+                    disabled={isLoading}
+                  >
+                    <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+                      <path
+                        fill="currentColor"
+                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                      />
+                      <path
+                        fill="currentColor"
+                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                      />
+                      <path
+                        fill="currentColor"
+                        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                      />
+                      <path
+                        fill="currentColor"
+                        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                      />
+                    </svg>
+                    Continue with Google
+                  </Button>
+                )}
 
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={handleGitHubSignIn}
-              disabled={isLoading}
-            >
-              <Github className="mr-2 h-4 w-4" />
-              Continue with GitHub
-            </Button>
-          </div>
+                {oauthProviders.github && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={handleGitHubSignIn}
+                    disabled={isLoading}
+                  >
+                    <Github className="mr-2 h-4 w-4" />
+                    Continue with GitHub
+                  </Button>
+                )}
+              </div>
 
-          <div className="relative my-6">
-            <Separator />
-            <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
-              OR
-            </span>
-          </div>
+              <div className="relative my-6">
+                <Separator />
+                <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
+                  OR
+                </span>
+              </div>
+            </>
+          )}
 
           {/* Email/Password Form */}
           <form onSubmit={handleSubmit} className="space-y-4" data-testid="login-form">

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -9,6 +9,7 @@ import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
+import { useAppConfig } from '@/hooks/use-app-config'
 import { getAuthErrorMessage, useAuth } from '@/hooks/use-auth'
 
 interface SignupSearch {
@@ -29,6 +30,9 @@ function SignupPage() {
   const { invitationId } = Route.useSearch()
   const navigate = useNavigate()
   const { signIn, signUp, isLoading: sessionLoading, refetch } = useAuth()
+  const { config: appConfig } = useAppConfig()
+  const oauthProviders = appConfig.oauthProviders
+  const showSocialBlock = oauthProviders.google || oauthProviders.github
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -202,52 +206,60 @@ function SignupPage() {
             <p className="mt-4 text-center text-sm text-muted-foreground">Create your account</p>
           </div>
 
-          {/* Social Login Buttons */}
-          <div className="space-y-3">
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={handleGoogleSignIn}
-              disabled={isLoading}
-            >
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  fill="currentColor"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                />
-              </svg>
-              Continue with Google
-            </Button>
+          {showSocialBlock && (
+            <>
+              {/* Social Login Buttons */}
+              <div className="space-y-3">
+                {oauthProviders.google && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={handleGoogleSignIn}
+                    disabled={isLoading}
+                  >
+                    <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+                      <path
+                        fill="currentColor"
+                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                      />
+                      <path
+                        fill="currentColor"
+                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                      />
+                      <path
+                        fill="currentColor"
+                        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                      />
+                      <path
+                        fill="currentColor"
+                        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                      />
+                    </svg>
+                    Continue with Google
+                  </Button>
+                )}
 
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={handleGitHubSignIn}
-              disabled={isLoading}
-            >
-              <Github className="mr-2 h-4 w-4" />
-              Continue with GitHub
-            </Button>
-          </div>
+                {oauthProviders.github && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={handleGitHubSignIn}
+                    disabled={isLoading}
+                  >
+                    <Github className="mr-2 h-4 w-4" />
+                    Continue with GitHub
+                  </Button>
+                )}
+              </div>
 
-          <div className="relative my-6">
-            <Separator />
-            <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
-              OR
-            </span>
-          </div>
+              <div className="relative my-6">
+                <Separator />
+                <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
+                  OR
+                </span>
+              </div>
+            </>
+          )}
 
           {/* Email/Password Form */}
           <form onSubmit={handleSubmit} className="space-y-4" data-testid="signup-form">

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -5,8 +5,12 @@ import { InviteEmail, type InviteEmailProps } from './templates/invite'
 
 /**
  * The from address for all Durabull emails.
+ *
+ * Override with the EMAIL_FROM env var (e.g. "Acme Ops <ops@acme.example>")
+ * when self-hosting against a Resend account that does not control the
+ * default durabull.io domain. Falls back to the upstream default.
  */
-const FROM_EMAIL = 'Durabull <no-reply@durabull.io>'
+const FROM_EMAIL = process.env.EMAIL_FROM ?? 'Durabull <no-reply@durabull.io>'
 
 /**
  * Data passed from better-auth's organization plugin when an invitation is created.

--- a/tooling/env/src/index.ts
+++ b/tooling/env/src/index.ts
@@ -64,6 +64,7 @@ const envSchema = z.object({
   DATABASE_URL: optionalString,
   REDIS_URL: optionalString,
   RESEND_API_KEY: optionalString,
+  EMAIL_FROM: optionalString,
   GOOGLE_OAUTH_CLIENT_ID: optionalString,
   GOOGLE_OAUTH_CLIENT_SECRET: optionalString,
   GITHUB_OAUTH_CLIENT_ID: optionalString,


### PR DESCRIPTION
Two minimal additions for self-hosted deployments:

1. EMAIL_FROM env var (packages/email/src/index.ts, tooling/env/src/index.ts) Overrides the hardcoded "Durabull <no-reply@durabull.io>" From address. Required when self-hosting against a Resend account that does not own durabull.io. Falls back to the upstream default.

2. oauthProviders in /api/app/config + UI gating Server now exposes { google, github } booleans (true when both id+secret are set). login.tsx, signup.tsx, and invite.$invitationId.tsx conditionally render each social button. The OR separator hides if no provider is enabled. Existing default is preserved when both providers are set.

No behavior change for the upstream defaults: with no env overrides and both OAuth client pairs set, the rendered UI and email From address are identical to v1.6.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social login with Google and GitHub is now optional and configurable; login buttons display only when explicitly enabled across login, signup, and invite pages
  * Outgoing email sender address is now customizable through environment configuration, with a default fallback when not specified

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->