### PR TITLE
Remove macOS download version callout

### DIFF
--- a/apps/docs/content/documentation/getting-started/desktop-apps.mdx
+++ b/apps/docs/content/documentation/getting-started/desktop-apps.mdx
@@ -13,7 +13,7 @@ If you want to self-host Durabull instead, start with
 
 | Platform | Recommended path | Notes |
 | --- | --- | --- |
-| Apple Silicon macOS | [Download the v1.3.0 macOS app](https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull-1.3.0-arm64.dmg) | Direct GitHub release asset for the current arm64 macOS build. |
+| Apple Silicon macOS | [Download the macOS app](https://github.com/durabullhq/durabull/releases/latest) | Latest GitHub release for the current arm64 macOS build. |
 | Windows | [Download the Windows installer](https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull.Setup.1.3.0.exe) | Best choice for standard workstation installs. |
 | Windows (portable) | [Download the Windows zip](https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull-1.3.0-win.zip) | Useful when you prefer a portable archive. |
 | Homebrew (Apple Silicon macOS) | `brew install --cask durabullhq/tap/durabull` | Good for repeatable rollout on managed Apple Silicon Mac fleets. |
@@ -37,7 +37,7 @@ path across a team.
 ## Need the Full Release Notes?
 
 For checksums, additional assets, and future release notes, see the
-[Durabull v1.3.0 release](https://github.com/durabullhq/durabull/releases/tag/v1.3.0).
+[latest Durabull release](https://github.com/durabullhq/durabull/releases/latest).
 
 ## Next Steps
 

--- a/apps/docs/src/lib/config.ts
+++ b/apps/docs/src/lib/config.ts
@@ -9,9 +9,8 @@ export const WEB_APP_URL = process.env.NEXT_PUBLIC_WEB_APP_URL || 'https://app.d
 export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://durabull.io'
 
 // Desktop distribution and release links
-export const GITHUB_RELEASE_URL = 'https://github.com/durabullhq/durabull/releases/tag/v1.3.0'
-export const MAC_DOWNLOAD_URL =
-  'https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull-1.3.0-arm64.dmg'
+export const GITHUB_RELEASE_URL = 'https://github.com/durabullhq/durabull/releases/latest'
+export const MAC_DOWNLOAD_URL = GITHUB_RELEASE_URL
 export const WINDOWS_DOWNLOAD_URL =
   'https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull.Setup.1.3.0.exe'
 export const WINDOWS_ZIP_DOWNLOAD_URL =


### PR DESCRIPTION
## Summary
- Remove the visible macOS app version from the desktop install documentation.
- Point macOS download/release links used by the landing page metadata to the latest GitHub release.

Closes #71

## Test plan
- Not run; content/config-only change.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS (Apple Silicon) installation guidance to dynamically reference the latest GitHub release instead of a hardcoded version.
  * Release notes references now automatically point to the latest release, ensuring users always access the most current installation assets and release information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->