### PR TITLE
Allow self-signed TLS certificates for Redis connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@
 # Pattern:
 #   DURABULL_REDIS_URL_{NAME}=redis://...
 #   DURABULL_REDIS_URL_{NAME}_ENVIRONMENT=production|staging|development
+#   DURABULL_REDIS_URL_{NAME}_ALLOW_SELF_SIGNED_CERTS=true|false
 #   DURABULL_REDIS_URL_DEFAULT={NAME}
 # -----------------------------------------------------------------------------
 # DURABULL_REDIS_URL_MAIN=redis://localhost:6379

--- a/apps/api/src/lib/alert-monitor.test.ts
+++ b/apps/api/src/lib/alert-monitor.test.ts
@@ -66,6 +66,7 @@ function createConnection(): RedisConnection {
     environment: 'development',
     isDefault: true,
     prefix: 'bull',
+    allowSelfSignedCerts: false,
     createdAt: now,
     updatedAt: now,
   }

--- a/apps/api/src/lib/alert-monitor.ts
+++ b/apps/api/src/lib/alert-monitor.ts
@@ -11,6 +11,7 @@ import { env } from '@durabull/env'
 import { evaluateRule, type CursorState, type QueueSnapshot } from './alert-evaluator'
 import { dispatchAlertNotification, type NotificationChannel } from './alert-notifier'
 import { getQueue } from './redis'
+import { toRedisConnectionOptions } from './connection-options'
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000
 const MAX_STARTUP_JITTER_MS = 30_000
@@ -206,7 +207,13 @@ async function processConnection(connectionId: string, rules: AlertRule[]): Prom
     const cursorMap = new Map(cursors.map((cursor) => [cursor.queueName, cursor]))
 
     await processWithConcurrency(queueNames, MAX_CONCURRENT_QUEUES, async (queueName) => {
-      const queue = await getQueue(connectionId, connection.url, queueName, connection.prefix)
+      const queue = await getQueue(
+        connectionId,
+        connection.url,
+        queueName,
+        connection.prefix,
+        toRedisConnectionOptions(connection.allowSelfSignedCerts)
+      )
 
       const [jobCountsRaw, failedMetricsRaw, completedMetricsRaw] = await Promise.all([
         queue.getJobCounts('failed', 'waiting', 'active', 'completed'),

--- a/apps/api/src/lib/connection-options.test.ts
+++ b/apps/api/src/lib/connection-options.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test'
+import { buildIoRedisConnectionOptions, toRedisConnectionOptions } from './connection-options'
+
+describe('connection-options', () => {
+  it('returns empty TLS options by default', () => {
+    expect(buildIoRedisConnectionOptions()).toEqual({})
+    expect(buildIoRedisConnectionOptions({ allowSelfSignedCerts: false })).toEqual({})
+  })
+
+  it('disables certificate verification when self-signed certs are allowed', () => {
+    expect(buildIoRedisConnectionOptions({ allowSelfSignedCerts: true })).toEqual({
+      tls: {
+        rejectUnauthorized: false,
+      },
+    })
+  })
+
+  it('normalizes nullable allowSelfSignedCerts values', () => {
+    expect(toRedisConnectionOptions(undefined)).toEqual({ allowSelfSignedCerts: false })
+    expect(toRedisConnectionOptions(null)).toEqual({ allowSelfSignedCerts: false })
+    expect(toRedisConnectionOptions(true)).toEqual({ allowSelfSignedCerts: true })
+  })
+})

--- a/apps/api/src/lib/connection-options.ts
+++ b/apps/api/src/lib/connection-options.ts
@@ -1,0 +1,32 @@
+import type { Context } from 'hono'
+import type { RedisOptions } from 'ioredis'
+
+export type RedisConnectionOptions = {
+  allowSelfSignedCerts?: boolean
+}
+
+export function getConnectionRedisOptions(c: Context): RedisConnectionOptions {
+  return toRedisConnectionOptions(c.get('connectionAllowSelfSignedCerts'))
+}
+
+export function buildIoRedisConnectionOptions(
+  options?: RedisConnectionOptions
+): Pick<RedisOptions, 'tls'> {
+  if (!options?.allowSelfSignedCerts) {
+    return {}
+  }
+
+  return {
+    tls: {
+      rejectUnauthorized: false,
+    },
+  }
+}
+
+export function toRedisConnectionOptions(
+  allowSelfSignedCerts?: boolean | null
+): RedisConnectionOptions {
+  return {
+    allowSelfSignedCerts: allowSelfSignedCerts ?? false,
+  }
+}

--- a/apps/api/src/lib/queue-discovery.ts
+++ b/apps/api/src/lib/queue-discovery.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { redisDiscoveredQueueRepository } from '@durabull/dal'
+import type { RedisConnectionOptions } from './redis'
 import { scanQueuesPage } from './redis'
 
 const DEFAULT_DISCOVERY_SCAN_COUNT = 1000
@@ -72,7 +73,8 @@ async function runQueueDiscovery(
   connectionId: string,
   connectionUrl: string,
   scanCount: number,
-  prefix = 'bull'
+  prefix = 'bull',
+  redisOptions?: RedisConnectionOptions
 ): Promise<void> {
   const runtime = discoveryStateByConnection.get(connectionId)
   if (!runtime) return
@@ -83,7 +85,14 @@ async function runQueueDiscovery(
   do {
     if (discoveryStateByConnection.get(connectionId) !== runtime) return
 
-    const page = await scanQueuesPage(connectionId, connectionUrl, cursor, scanCount, prefix)
+    const page = await scanQueuesPage(
+      connectionId,
+      connectionUrl,
+      cursor,
+      scanCount,
+      prefix,
+      redisOptions
+    )
     cursor = page.cursor
     runtime.scannedPages += 1
 
@@ -119,7 +128,11 @@ export function resetQueueDiscoveryState(connectionId: string): void {
 export async function startQueueDiscovery(
   connectionId: string,
   connectionUrl: string,
-  options?: { scanCount?: number; prefix?: string }
+  options?: {
+    scanCount?: number
+    prefix?: string
+    allowSelfSignedCerts?: boolean
+  }
 ): Promise<QueueDiscoveryStatus> {
   const existingRun = activeDiscoveryRuns.get(connectionId)
   if (existingRun) {
@@ -128,6 +141,9 @@ export async function startQueueDiscovery(
 
   const scanCount = Math.max(100, options?.scanCount ?? DEFAULT_DISCOVERY_SCAN_COUNT)
   const prefix = options?.prefix ?? 'bull'
+  const redisOptions: RedisConnectionOptions = {
+    allowSelfSignedCerts: options?.allowSelfSignedCerts ?? false,
+  }
   const runtime: QueueDiscoveryRuntime = {
     runId: randomUUID(),
     connectionId,
@@ -143,7 +159,13 @@ export async function startQueueDiscovery(
 
   discoveryStateByConnection.set(connectionId, runtime)
 
-  const runPromise = runQueueDiscovery(connectionId, connectionUrl, scanCount, prefix)
+  const runPromise = runQueueDiscovery(
+    connectionId,
+    connectionUrl,
+    scanCount,
+    prefix,
+    redisOptions
+  )
     .catch((error) => {
       if (discoveryStateByConnection.get(connectionId) === runtime) {
         runtime.lastError = error instanceof Error ? error.message : String(error)

--- a/apps/api/src/lib/redis.ts
+++ b/apps/api/src/lib/redis.ts
@@ -1,5 +1,8 @@
 import { Queue } from 'bullmq'
 import { Redis } from 'ioredis'
+import { buildIoRedisConnectionOptions, type RedisConnectionOptions } from './connection-options'
+
+export type { RedisConnectionOptions } from './connection-options'
 
 export class RedisUnavailableError extends Error {
   readonly code = 'REDIS_UNAVAILABLE'
@@ -114,7 +117,12 @@ function shouldLogRedisError(connectionId: string, message: string): boolean {
   return true
 }
 
-function buildRedisClient(connectionUrl: string, cacheKey: string, label: string): Redis {
+function buildRedisClient(
+  connectionUrl: string,
+  cacheKey: string,
+  label: string,
+  options?: RedisConnectionOptions
+): Redis {
   const redis = new Redis(connectionUrl, {
     maxRetriesPerRequest: null,
     lazyConnect: true,
@@ -122,6 +130,7 @@ function buildRedisClient(connectionUrl: string, cacheKey: string, label: string
       if (attempts > REDIS_MAX_RECONNECT_ATTEMPTS) return null
       return Math.min(attempts * REDIS_RECONNECT_BASE_DELAY_MS, REDIS_RECONNECT_MAX_DELAY_MS)
     },
+    ...buildIoRedisConnectionOptions(options),
   })
 
   redis.on('error', (error) => {
@@ -154,9 +163,14 @@ function buildRedisClient(connectionUrl: string, cacheKey: string, label: string
 export async function getRedis(
   connectionId: string,
   connectionUrl: string,
-  connectionName?: string
+  connectionName?: string,
+  options?: RedisConnectionOptions
 ): Promise<Redis> {
-  const cacheKey = JSON.stringify([connectionId, connectionUrl])
+  const cacheKey = JSON.stringify([
+    connectionId,
+    connectionUrl,
+    options?.allowSelfSignedCerts ?? false,
+  ])
   const existingConnection = redisConnections.get(cacheKey)
   if (existingConnection) {
     if (existingConnection.status !== 'end') {
@@ -180,7 +194,7 @@ export async function getRedis(
   }
 
   const connectPromise = (async () => {
-    const redis = buildRedisClient(connectionUrl, cacheKey, connectionName ?? connectionId)
+    const redis = buildRedisClient(connectionUrl, cacheKey, connectionName ?? connectionId, options)
 
     try {
       await redis.connect()
@@ -215,7 +229,8 @@ export async function getRedis(
 export async function discoverQueues(
   connectionId: string,
   connectionUrl: string,
-  prefix = 'bull'
+  prefix = 'bull',
+  options?: RedisConnectionOptions
 ): Promise<Array<string>> {
   const queueNames = new Set<string>()
   let cursor = '0'
@@ -226,7 +241,8 @@ export async function discoverQueues(
       connectionUrl,
       cursor,
       DEFAULT_QUEUE_SCAN_COUNT,
-      prefix
+      prefix,
+      options
     )
     cursor = page.cursor
     for (const queueName of page.queueNames) {
@@ -247,9 +263,10 @@ export async function scanQueuesPage(
   connectionUrl: string,
   cursor = '0',
   count = DEFAULT_QUEUE_SCAN_COUNT,
-  prefix = 'bull'
+  prefix = 'bull',
+  options?: RedisConnectionOptions
 ): Promise<QueueScanPage> {
-  const redisClient = await getRedis(connectionId, connectionUrl)
+  const redisClient = await getRedis(connectionId, connectionUrl, undefined, options)
   const scanCount = Math.max(100, count)
   const escapedPrefix = prefix.replace(/[\\*?[\]]/g, '\\$&')
   const [nextCursor, keys] = await redisClient.scan(
@@ -280,9 +297,10 @@ export async function scanQueuesPage(
 export async function debugGetBullKeys(
   connectionId: string,
   connectionUrl: string,
-  prefix = 'bull'
+  prefix = 'bull',
+  options?: RedisConnectionOptions
 ): Promise<string[]> {
-  const redisClient = await getRedis(connectionId, connectionUrl)
+  const redisClient = await getRedis(connectionId, connectionUrl, undefined, options)
   const escapedPrefix = prefix.replace(/[\\*?[\]]/g, '\\$&')
   const keys: string[] = []
   let cursor = '0'
@@ -309,9 +327,16 @@ export async function getQueue(
   connectionId: string,
   connectionUrl: string,
   name: string,
-  prefix = 'bull'
+  prefix = 'bull',
+  options?: RedisConnectionOptions
 ): Promise<Queue> {
-  const cacheKey = JSON.stringify([connectionId, connectionUrl, prefix, name])
+  const cacheKey = JSON.stringify([
+    connectionId,
+    connectionUrl,
+    prefix,
+    name,
+    options?.allowSelfSignedCerts ?? false,
+  ])
 
   if (!queues.has(cacheKey)) {
     const queue = new Queue(name, {
@@ -322,6 +347,7 @@ export async function getQueue(
           if (attempts > REDIS_MAX_RECONNECT_ATTEMPTS) return null
           return Math.min(attempts * REDIS_RECONNECT_BASE_DELAY_MS, REDIS_RECONNECT_MAX_DELAY_MS)
         },
+        ...buildIoRedisConnectionOptions(options),
       },
       prefix,
     })
@@ -334,11 +360,14 @@ export async function getQueue(
       }
 
       if (isPermanentRedisConnectionError(message)) {
-        recentRedisConnectionFailures.set(JSON.stringify([connectionId, connectionUrl]), {
-          message,
-          at: Date.now(),
-          permanent: true,
-        })
+        recentRedisConnectionFailures.set(
+          JSON.stringify([connectionId, connectionUrl, options?.allowSelfSignedCerts ?? false]),
+          {
+            message,
+            at: Date.now(),
+            permanent: true,
+          }
+        )
         queue.close().catch(() => {})
         queues.delete(cacheKey)
       }

--- a/apps/api/src/middleware/connection.ts
+++ b/apps/api/src/middleware/connection.ts
@@ -11,6 +11,7 @@ declare module 'hono' {
     connectionUrl: string
     connectionName: string
     connectionPrefix: string
+    connectionAllowSelfSignedCerts: boolean
   }
 }
 
@@ -147,6 +148,7 @@ export function createConnectionMiddleware(auth?: Auth) {
     c.set('connectionUrl', connection.url)
     c.set('connectionName', connection.name)
     c.set('connectionPrefix', connection.prefix ?? 'bull')
+    c.set('connectionAllowSelfSignedCerts', connection.allowSelfSignedCerts ?? false)
 
     await next()
   })

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -8,6 +8,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { evaluateRule, type CursorState, type QueueSnapshot } from '../lib/alert-evaluator'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 import { getQueue } from '../lib/redis'
 
 const alertTypeSchema = z.enum(['failure_threshold', 'failure_rate', 'queue_stalled'])
@@ -134,6 +135,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const connectionName = c.get('connectionName')
     const organizationId = c.get('organizationId')
     if (!organizationId) {
@@ -157,7 +159,7 @@ const app = new Hono()
       return c.json({ error: 'No queue available to test this rule yet' }, 400)
     }
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const [jobCountsRaw, failedMetricsRaw, completedMetricsRaw] = await Promise.all([
       queue.getJobCounts('failed', 'waiting', 'active', 'completed'),
       queue.getMetrics('failed', 0, 60),

--- a/apps/api/src/routes/connections.test.ts
+++ b/apps/api/src/routes/connections.test.ts
@@ -28,6 +28,7 @@ interface ConnectionResponseBody {
   connection: {
     id: string
     prefix: string
+    allowSelfSignedCerts?: boolean
   }
 }
 
@@ -131,6 +132,41 @@ describe('connections prefix API', () => {
     expect(updateNameResponse.status).toBe(200)
     const updateNameBody = (await updateNameResponse.json()) as ConnectionResponseBody
     expect(updateNameBody.connection.prefix).toBe('tenant-b')
+  })
+
+  it('stores and updates allowSelfSignedCerts', async () => {
+    const { app } = await createApiApp({ enableLogging: false })
+
+    const createResponse = await app.request('/api/connections', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Heroku Redis',
+        url: 'rediss://example.heroku.com:6379',
+        allowSelfSignedCerts: true,
+      }),
+    })
+
+    expect(createResponse.status).toBe(201)
+    const createBody = (await createResponse.json()) as ConnectionResponseBody
+    expect(createBody.connection.allowSelfSignedCerts).toBe(true)
+
+    const getResponse = await app.request(`/api/connections/${createBody.connection.id}`)
+    expect(getResponse.status).toBe(200)
+    const getBody = (await getResponse.json()) as {
+      connection: { allowSelfSignedCerts: boolean }
+    }
+    expect(getBody.connection.allowSelfSignedCerts).toBe(true)
+
+    const updateResponse = await app.request(`/api/connections/${createBody.connection.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ allowSelfSignedCerts: false }),
+    })
+
+    expect(updateResponse.status).toBe(200)
+    const updateBody = (await updateResponse.json()) as ConnectionResponseBody
+    expect(updateBody.connection.allowSelfSignedCerts).toBe(false)
   })
 
   it('rejects blank prefixes', async () => {

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -8,6 +8,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { Redis } from 'ioredis'
 import { z } from 'zod'
+import { buildIoRedisConnectionOptions } from '../lib/connection-options'
 import { resetQueueDiscoveryState } from '../lib/queue-discovery'
 import { validateRedisUrlForEnvironment } from '../lib/url-validation'
 import { requireOrganization } from '../middleware/auth'
@@ -31,6 +32,7 @@ const app = new Hono()
       isDefault: conn.isDefault,
       environment: conn.environment,
       prefix: conn.prefix,
+      allowSelfSignedCerts: conn.allowSelfSignedCerts,
     }))
 
     return c.json({ connections })
@@ -54,6 +56,7 @@ const app = new Hono()
         isDefault: conn.isDefault,
         environment: conn.environment,
         prefix: conn.prefix,
+        allowSelfSignedCerts: conn.allowSelfSignedCerts,
         createdAt: conn.createdAt.toISOString(),
         updatedAt: conn.updatedAt.toISOString(),
       },
@@ -71,6 +74,7 @@ const app = new Hono()
         environment: z.enum(['development', 'staging', 'production']).optional(),
         isDefault: z.boolean().optional(),
         prefix: connectionPrefixSchema.default('bull'),
+        allowSelfSignedCerts: z.boolean().optional(),
       })
     ),
     async (c) => {
@@ -115,6 +119,7 @@ const app = new Hono()
         environment: body.environment ?? 'development',
         isDefault: body.isDefault ?? false,
         prefix: body.prefix,
+        allowSelfSignedCerts: body.allowSelfSignedCerts ?? false,
         organizationId,
       })
 
@@ -126,6 +131,7 @@ const app = new Hono()
             isDefault: conn.isDefault,
             environment: conn.environment,
             prefix: conn.prefix,
+            allowSelfSignedCerts: conn.allowSelfSignedCerts,
           },
         },
         201
@@ -144,6 +150,7 @@ const app = new Hono()
         environment: z.enum(['development', 'staging', 'production']).optional(),
         isDefault: z.boolean().optional(),
         prefix: connectionPrefixSchema.optional(),
+        allowSelfSignedCerts: z.boolean().optional(),
       })
     ),
     async (c) => {
@@ -198,6 +205,9 @@ const app = new Hono()
       if (body.environment !== undefined) updateData.environment = body.environment
       if (body.isDefault === false) updateData.isDefault = false
       if (body.prefix !== undefined) updateData.prefix = body.prefix
+      if (body.allowSelfSignedCerts !== undefined) {
+        updateData.allowSelfSignedCerts = body.allowSelfSignedCerts
+      }
 
       const conn = await redisConnectionRepository.update(id, organizationId, updateData)
       if (!conn) {
@@ -216,6 +226,7 @@ const app = new Hono()
           isDefault: conn.isDefault,
           environment: conn.environment,
           prefix: conn.prefix,
+          allowSelfSignedCerts: conn.allowSelfSignedCerts,
         },
       })
     }
@@ -267,10 +278,11 @@ const app = new Hono()
       'json',
       z.object({
         url: z.string().min(1),
+        allowSelfSignedCerts: z.boolean().optional(),
       })
     ),
     async (c) => {
-      const { url } = c.req.valid('json')
+      const { url, allowSelfSignedCerts } = c.req.valid('json')
 
       // Validate URL to prevent SSRF attacks
       const validation = validateRedisUrlForEnvironment(url)
@@ -292,6 +304,7 @@ const app = new Hono()
           connectTimeout: 5000,
           maxRetriesPerRequest: 1,
           lazyConnect: true,
+          ...buildIoRedisConnectionOptions({ allowSelfSignedCerts }),
         })
 
         await redis.connect()

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -2,6 +2,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { getQueue } from '../lib/redis'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 
 // Default page size for stacktraces and logs
 const DEFAULT_PAGE_SIZE = 50
@@ -80,6 +81,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const status = c.req.query('status')
     const name = c.req.query('name')
@@ -95,7 +97,7 @@ const app = new Hono()
       Number.isInteger(cursor) && cursor !== null ? Math.max(0, cursor) : (page - 1) * pageSize
     const end = start + pageSize - 1
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
 
     if (jobId) {
       const job = await queue.getJob(jobId)
@@ -218,10 +220,11 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const job = await queue.getJob(jobId)
 
     if (!job) {
@@ -263,6 +266,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
     const pageStr = c.req.query('page')
@@ -274,7 +278,7 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const job = await queue.getJob(jobId)
 
     if (!job) {
@@ -312,6 +316,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
     const pageStr = c.req.query('page')
@@ -325,7 +330,7 @@ const app = new Hono()
     const start = (page - 1) * pageSize
     const end = start + pageSize - 1
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     // BullMQ getJobLogs accepts start and end parameters for pagination
     const logs = await queue.getJobLogs(jobId, start, end)
 
@@ -343,11 +348,12 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const jobId = c.req.param('jobId')
     const keepMostRecent = 0
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const job = await queue.getJob(jobId)
 
     if (!job) {
@@ -417,11 +423,12 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const jobId = c.req.param('jobId')
       const { keepMostRecent } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       const job = await queue.getJob(jobId)
 
       if (!job) {
@@ -488,11 +495,12 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const jobId = c.req.param('jobId')
       const { keepMostRecent } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       const job = await queue.getJob(jobId)
 
       if (!job) {
@@ -561,10 +569,11 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const { jobIds, statuses } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       let success = 0
       let failed = 0
       const errors: Array<{ jobId: string; error: string }> = []
@@ -690,10 +699,11 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const { jobIds, removeScheduler } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       let success = 0
       let schedulersRemoved = 0
       const errors: Array<{ jobId: string; error: string }> = []
@@ -794,10 +804,11 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const { jobIds, jobData } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       let success = 0
       const errors: Array<{ jobId: string; error: string }> = []
 
@@ -837,10 +848,11 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const { name, data, delay, priority, attempts } = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       const job = await queue.add(name, data, { delay, priority, attempts })
 
       return c.json({

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -8,6 +8,7 @@ import {
   MAX_METRICS_WINDOW_MINUTES,
 } from '../lib/bullmq-metrics'
 import { discoverQueues, getQueue } from '../lib/redis'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 
 // Default and max page sizes for pagination
 const DEFAULT_PAGE_SIZE = 50
@@ -50,6 +51,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const query = c.req.valid('query')
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
@@ -60,7 +62,7 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix)
+    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix, redisOptions)
     const total = allQueueNames.length
 
     // Paginate the queue names BEFORE fetching metrics
@@ -78,7 +80,7 @@ const app = new Hono()
 
     const metrics = await Promise.all(
       paginatedQueueNames.map(async (queueName) => {
-        const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+        const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
         const nativeMetrics = await collectQueueNativeMetrics(queue, {
           queueName,
           start: 0,

--- a/apps/api/src/routes/queues.ts
+++ b/apps/api/src/routes/queues.ts
@@ -15,6 +15,7 @@ import {
   waitForQueueDiscovery,
 } from '../lib/queue-discovery'
 import { deleteQueueWithDiscoveryCleanup } from '../lib/delete-queue'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 import { debugGetBullKeys, getQueue, safeGetWorkers } from '../lib/redis'
 
 // Default and max page sizes for pagination
@@ -190,7 +191,8 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
-    const keys = await debugGetBullKeys(connectionId, connectionUrl, connectionPrefix)
+    const redisOptions = getConnectionRedisOptions(c)
+    const keys = await debugGetBullKeys(connectionId, connectionUrl, connectionPrefix, redisOptions)
 
     // Group keys by pattern to make it easier to understand
     const metaKeys = keys.filter((k) => k.endsWith(':meta'))
@@ -221,6 +223,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
 
     const scanCountParam = c.req.query('scanCount')
     const waitParam = c.req.query('wait')
@@ -229,6 +232,7 @@ const app = new Hono()
 
     const status = await startQueueDiscovery(connectionId, connectionUrl, {
       prefix: connectionPrefix,
+      allowSelfSignedCerts: redisOptions.allowSelfSignedCerts,
       scanCount:
         requestedScanCount && Number.isFinite(requestedScanCount) ? requestedScanCount : undefined,
     })
@@ -245,6 +249,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
 
@@ -267,7 +272,10 @@ const app = new Hono()
       discovery.lastError !== null
 
     if (total === 0 && !hasDiscoveryAttempt) {
-      await startQueueDiscovery(connectionId, connectionUrl, { prefix: connectionPrefix })
+      await startQueueDiscovery(connectionId, connectionUrl, {
+        prefix: connectionPrefix,
+        allowSelfSignedCerts: redisOptions.allowSelfSignedCerts,
+      })
       discovery = await getQueueDiscoveryStatus(connectionId)
       total = discovery.indexed.total
     }
@@ -279,7 +287,7 @@ const app = new Hono()
 
     const queuesData = await Promise.all(
       indexedQueues.map(async (indexedQueue) => {
-        const queue = await getQueue(connectionId, connectionUrl, indexedQueue.name, connectionPrefix)
+        const queue = await getQueue(connectionId, connectionUrl, indexedQueue.name, connectionPrefix, redisOptions)
         const [counts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()])
 
         const status: 'paused' | 'active' = isPaused ? 'paused' : 'active'
@@ -316,8 +324,9 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const [counts, isPaused, workers, schedulers] = await Promise.all([
       queue.getJobCounts(),
       queue.isPaused(),
@@ -355,6 +364,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const query = c.req.valid('query')
 
@@ -390,7 +400,7 @@ const app = new Hono()
     const includePrometheus = parseBoolean(query.includePrometheus)
     const priorities = parsePriorities(query.priorities)
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const metrics = await collectQueueNativeMetrics(queue, {
       queueName,
       start,
@@ -407,8 +417,9 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     await queue.pause()
     return c.json({ success: true })
   })
@@ -417,8 +428,9 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     await queue.resume()
     return c.json({ success: true })
   })
@@ -437,9 +449,10 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const { status, gracePeriod = 0, limit = 1000 } = c.req.valid('json')
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
 
       const cleanStatus = cleanStatusMap[status as PurgeableQueueStatus]
       if (!cleanStatus) {
@@ -469,6 +482,7 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const { confirmName, statuses, keepMostRecent } = c.req.valid('json')
 
@@ -491,7 +505,7 @@ const app = new Hono()
         return c.json({ error: 'At least one status must be selected for purge' }, 400)
       }
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       const removedByStatus = Object.fromEntries(
         statusesToPurge.map((status) => [status, 0])
       ) as Record<PurgeableQueueStatus, number>
@@ -699,8 +713,9 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     await deleteQueueWithDiscoveryCleanup(connectionId, queueName, queue)
     return c.json({ success: true })
   })
@@ -717,6 +732,7 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const { confirmName } = c.req.valid('json')
 
@@ -725,7 +741,7 @@ const app = new Hono()
         return c.json({ error: 'Queue name confirmation does not match', canDelete: false }, 400)
       }
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       const counts = await queue.getJobCounts()
 
       // Calculate total jobs (excluding completed as they can be cleaned)
@@ -764,8 +780,9 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const counts = await queue.getJobCounts()
 
     const totalActiveJobs =

--- a/apps/api/src/routes/redis-keys.ts
+++ b/apps/api/src/routes/redis-keys.ts
@@ -2,6 +2,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { getRedis } from '../lib/redis'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 
 const DEFAULT_PAGE_SIZE = 50
 const MAX_PAGE_SIZE = 100
@@ -33,9 +34,10 @@ const app = new Hono()
     async (c) => {
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
+      const redisOptions = getConnectionRedisOptions(c)
       const { pattern, cursor, pageSize, excludeBull } = c.req.valid('query')
 
-      const redis = await getRedis(connectionId, connectionUrl)
+      const redis = await getRedis(connectionId, connectionUrl, undefined, redisOptions)
 
       // Use SCAN for efficient key discovery
       // When excluding bull keys, we need to scan more to get enough non-bull keys
@@ -105,13 +107,14 @@ const app = new Hono()
     async (c) => {
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
+      const redisOptions = getConnectionRedisOptions(c)
       const { key } = c.req.valid('param')
       const { limit, offset } = c.req.valid('query')
 
       // URL decode the key since it might contain special characters
       const decodedKey = decodeURIComponent(key)
 
-      const redis = await getRedis(connectionId, connectionUrl)
+      const redis = await getRedis(connectionId, connectionUrl, undefined, redisOptions)
 
       // Get key type and TTL
       const [type, ttl] = await Promise.all([redis.type(decodedKey), redis.ttl(decodedKey)])
@@ -261,6 +264,7 @@ const app = new Hono()
     async (c) => {
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
+      const redisOptions = getConnectionRedisOptions(c)
       const { key } = c.req.valid('param')
       const decodedKey = decodeURIComponent(key)
 
@@ -276,7 +280,7 @@ const app = new Hono()
         )
       }
 
-      const redis = await getRedis(connectionId, connectionUrl)
+      const redis = await getRedis(connectionId, connectionUrl, undefined, redisOptions)
       const deleted = await redis.del(decodedKey)
 
       return c.json({ success: deleted > 0, deleted })

--- a/apps/api/src/routes/scheduled-jobs.ts
+++ b/apps/api/src/routes/scheduled-jobs.ts
@@ -1,6 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { discoverQueues, getQueue } from '../lib/redis'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 import {
   buildScheduledJobCreateInput,
   buildScheduledJobUpdateInput,
@@ -70,6 +71,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
 
@@ -79,7 +81,7 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix)
+    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix, redisOptions)
     const totalQueues = allQueueNames.length
 
     // Paginate at the queue level to prevent loading scheduled jobs from thousands of queues
@@ -90,7 +92,7 @@ const app = new Hono()
     const allScheduledJobs: ScheduledJobSummary[] = []
 
     for (const queueName of paginatedQueueNames) {
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       const schedulers = await queue.getJobSchedulers()
 
       // Get unique job names from schedulers
@@ -121,8 +123,9 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const schedulers = await queue.getJobSchedulers()
 
     // Get unique job names from schedulers
@@ -144,10 +147,11 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const schedulerId = c.req.param('schedulerId')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const scheduler = (await queue.getJobSchedulers()).find((item) => item.key === schedulerId)
 
     if (!scheduler) {
@@ -165,10 +169,11 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const payload = c.req.valid('json')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     const existingSchedulers = await queue.getJobSchedulers()
     const existingScheduler = existingSchedulers.find(
       (scheduler) => scheduler.key === payload.schedulerId
@@ -220,11 +225,12 @@ const app = new Hono()
       const connectionId = c.get('connectionId')
       const connectionUrl = c.get('connectionUrl')
       const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
       const schedulerId = c.req.param('schedulerId')
       const payload = c.req.valid('json')
 
-      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+      const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
       const existingScheduler = (await queue.getJobSchedulers()).find(
         (scheduler) => scheduler.key === schedulerId
       )
@@ -267,10 +273,11 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const queueName = c.req.param('queueName')
     const schedulerId = c.req.param('schedulerId')
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     await queue.removeJobScheduler(schedulerId)
     return c.json({ success: true })
   })

--- a/apps/api/src/routes/workers.ts
+++ b/apps/api/src/routes/workers.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { discoverQueues, getQueue, safeGetWorkers } from '../lib/redis'
+import { getConnectionRedisOptions } from '../lib/connection-options'
 
 // Default and max page sizes for pagination
 const DEFAULT_PAGE_SIZE = 50
@@ -12,6 +13,7 @@ const app = new Hono()
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
+    const redisOptions = getConnectionRedisOptions(c)
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
 
@@ -21,7 +23,7 @@ const app = new Hono()
       MAX_PAGE_SIZE
     )
 
-    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix)
+    const allQueueNames = await discoverQueues(connectionId, connectionUrl, connectionPrefix, redisOptions)
     const totalQueues = allQueueNames.length
 
     // Paginate the queue names BEFORE fetching worker details
@@ -46,7 +48,7 @@ const app = new Hono()
 
     await Promise.all(
       paginatedQueueNames.map(async (queueName) => {
-        const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix)
+        const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
         const [workers, isPaused, counts] = await Promise.all([
           safeGetWorkers(queue),
           queue.isPaused(),

--- a/apps/docs/content/documentation/getting-started/connection-management.mdx
+++ b/apps/docs/content/documentation/getting-started/connection-management.mdx
@@ -14,6 +14,7 @@ Connections are defined through environment variables:
 ```bash
 DURABULL_REDIS_URL_MAIN=redis://localhost:6379
 DURABULL_REDIS_URL_MAIN_ENVIRONMENT=development
+DURABULL_REDIS_URL_MAIN_ALLOW_SELF_SIGNED_CERTS=false
 DURABULL_REDIS_URL_WORKERS=redis://localhost:6380
 DURABULL_REDIS_URL_WORKERS_ENVIRONMENT=staging
 DURABULL_REDIS_URL_DEFAULT=MAIN
@@ -31,7 +32,7 @@ Connections are managed in UI/API:
 
 - Create connection
 - Test connection
-- Edit name/url/environment/default
+- Edit name/url/environment/default/TLS options
 - Delete with guardrails
 
 ## Connection Validation and Safety

--- a/apps/docs/content/documentation/getting-started/connection-troubleshooting.mdx
+++ b/apps/docs/content/documentation/getting-started/connection-troubleshooting.mdx
@@ -13,6 +13,7 @@ Use this guide if you are adding a new Redis connection and the test or create f
    - **Connection Name**
    - **Connection URL**
    - **Environment**
+   - **Allow self-signed TLS certificates** (only when your provider requires it)
 4. Click **Test** to verify connectivity before saving.
 5. Click **Create Connection**.
 
@@ -21,6 +22,25 @@ Use this guide if you are adding a new Redis connection and the test or create f
 ### TLS Encryption
 
 Ensure your protocol is set to `rediss://` instead of `redis://` (note the extra `s`).
+
+### Self-Signed TLS Certificates
+
+Some managed Redis providers, including [Heroku Key-Value Store](https://devcenter.heroku.com/articles/connecting-heroku-redis), terminate TLS with self-signed certificates. Durabull validates TLS certificates by default, so these connections fail unless you opt in.
+
+When adding or editing a connection:
+
+1. Use a `rediss://` URL.
+2. Enable **Allow self-signed TLS certificates**.
+3. Re-run **Test** before saving.
+
+For env-driven connections, set:
+
+```bash
+DURABULL_REDIS_URL_MAIN=rediss://...
+DURABULL_REDIS_URL_MAIN_ALLOW_SELF_SIGNED_CERTS=true
+```
+
+Only enable this when your provider requires it. It disables certificate authority validation for that connection.
 
 ### IP Allowlisting
 

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -41,6 +41,7 @@ description: Complete runtime environment variable reference for local and produ
 | `DURABULL_REDIS_URL_DEFAULT` | Recommended | Default env connection key |
 | `DURABULL_REDIS_URL_<NAME>` | When env mode enabled | Redis URL for named connection |
 | `DURABULL_REDIS_URL_<NAME>_ENVIRONMENT` | Optional | `development`, `staging`, or `production` |
+| `DURABULL_REDIS_URL_<NAME>_ALLOW_SELF_SIGNED_CERTS` | Optional | Set to `true` for providers with self-signed TLS certs (for example Heroku Key-Value Store) |
 
 ## Optional Integrations
 

--- a/apps/web/src/hooks/use-connections.ts
+++ b/apps/web/src/hooks/use-connections.ts
@@ -54,6 +54,7 @@ export function useCreateConnection() {
       environment?: 'development' | 'staging' | 'production'
       isDefault?: boolean
       prefix?: string
+      allowSelfSignedCerts?: boolean
     }) => {
       const res = await api.connections.$post({
         json: data,
@@ -99,6 +100,7 @@ export function useUpdateConnection() {
         environment?: 'development' | 'staging' | 'production'
         isDefault?: boolean
         prefix?: string
+        allowSelfSignedCerts?: boolean
       }
     }) => {
       const res = await api.connections[':id'].$patch({
@@ -163,9 +165,15 @@ export function useDeleteConnection() {
 // Test connection mutation
 export function useTestConnection() {
   return useMutation({
-    mutationFn: async (url: string) => {
+    mutationFn: async ({
+      url,
+      allowSelfSignedCerts,
+    }: {
+      url: string
+      allowSelfSignedCerts?: boolean
+    }) => {
       const res = await api.connections.test.$post({
-        json: { url },
+        json: { url, allowSelfSignedCerts },
       })
       return handleRes<TestConnectionResponse>(res)
     },

--- a/apps/web/src/routes/$orgSlug.connections.tsx
+++ b/apps/web/src/routes/$orgSlug.connections.tsx
@@ -27,6 +27,7 @@ import {
   Pencil,
   Plus,
   Server,
+  ShieldAlert,
   Star,
   Trash2,
   Wifi,
@@ -546,6 +547,7 @@ function ConnectionFormDialog({
   const [showUrl, setShowUrl] = useState(false)
   const [environment, setEnvironment] = useState<ConnectionEnvironment>('development')
   const [isDefault, setIsDefault] = useState(false)
+  const [allowSelfSignedCerts, setAllowSelfSignedCerts] = useState(false)
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null)
   const [discoveryConnectionId, setDiscoveryConnectionId] = useState<string | null>(null)
 
@@ -579,12 +581,14 @@ function ConnectionFormDialog({
       setPrefix(existingConnection.prefix ?? 'bull')
       setEnvironment(existingConnection.environment ?? 'development')
       setIsDefault(existingConnection.isDefault)
+      setAllowSelfSignedCerts(existingConnection.allowSelfSignedCerts ?? false)
     } else if (mode === 'create' && open) {
       setName('')
       setUrl('')
       setPrefix('bull')
       setEnvironment('development')
       setIsDefault(false)
+      setAllowSelfSignedCerts(false)
       setDiscoveryConnectionId(null)
     }
     setTestResult(null)
@@ -601,6 +605,7 @@ function ConnectionFormDialog({
           environment,
           isDefault,
           prefix,
+          allowSelfSignedCerts,
         })
         setDiscoveryConnectionId(created.connection.id)
         await runQueueDiscoveryMutation.mutateAsync(created.connection.id)
@@ -613,6 +618,7 @@ function ConnectionFormDialog({
             environment,
             isDefault,
             prefix,
+            allowSelfSignedCerts,
           },
         })
         onOpenChange(false)
@@ -625,7 +631,7 @@ function ConnectionFormDialog({
   const handleTestConnection = async () => {
     setTestResult(null)
     try {
-      const result = await testMutation.mutateAsync(url)
+      const result = await testMutation.mutateAsync({ url, allowSelfSignedCerts })
       setTestResult(result)
     } catch (error) {
       setTestResult({
@@ -874,6 +880,30 @@ function ConnectionFormDialog({
             </div>
 
             {/* Default toggle */}
+            <div className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-0.5">
+                <Label className="text-sm font-medium">Allow self-signed TLS certificates</Label>
+                <p className="text-xs text-muted-foreground">
+                  Enable for providers like Heroku Key-Value Store that use self-signed TLS certs
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant={allowSelfSignedCerts ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => {
+                  setAllowSelfSignedCerts(!allowSelfSignedCerts)
+                  setTestResult(null)
+                }}
+                className="gap-1.5"
+              >
+                <ShieldAlert
+                  className={cn('h-3.5 w-3.5', allowSelfSignedCerts && 'fill-current')}
+                />
+                {allowSelfSignedCerts ? 'Enabled' : 'Disabled'}
+              </Button>
+            </div>
+
             <div className="flex items-center justify-between rounded-lg border p-3">
               <div className="space-y-0.5">
                 <Label className="text-sm font-medium">Set as default</Label>

--- a/packages/dal/src/db/env-redis-connections.test.ts
+++ b/packages/dal/src/db/env-redis-connections.test.ts
@@ -104,6 +104,21 @@ describe('env-redis-connections', () => {
     expect(connections[0]?.envName).toBe('MAIN')
   })
 
+  it('parses allow self-signed cert flags from env suffixes', () => {
+    process.env.DURABULL_REDIS_URL_MAIN = 'rediss://localhost:6379'
+    process.env.DURABULL_REDIS_URL_MAIN_ALLOW_SELF_SIGNED_CERTS = 'true'
+    process.env.DURABULL_REDIS_URL_WORKERS = 'redis://localhost:6380'
+
+    const connections = getEnvRedisConnections()
+
+    expect(connections.find((connection) => connection.envName === 'MAIN')?.allowSelfSignedCerts).toBe(
+      true
+    )
+    expect(
+      connections.find((connection) => connection.envName === 'WORKERS')?.allowSelfSignedCerts
+    ).toBe(false)
+  })
+
   it('generates deterministic IDs per organization and env name', () => {
     const first = getEnvRedisConnectionId('org-1', 'MAIN')
     const second = getEnvRedisConnectionId('org-1', 'MAIN')

--- a/packages/dal/src/db/env-redis-connections.ts
+++ b/packages/dal/src/db/env-redis-connections.ts
@@ -12,6 +12,7 @@ const ENV_DEFAULT_KEY = 'DURABULL_REDIS_URL_DEFAULT'
 const ENV_ENCRYPTION_KEY = 'DURABULL_REDIS_URL_ENCRYPTION_KEY'
 const ENVIRONMENT_SUFFIX = '_ENVIRONMENT'
 const PREFIX_SUFFIX = '_PREFIX'
+const ALLOW_SELF_SIGNED_CERTS_SUFFIX = '_ALLOW_SELF_SIGNED_CERTS'
 const ENV_NAMESPACE_UUID = '2a48b9e7-32fa-4d5a-8f61-7e7a2f6c3f0b'
 
 export interface EnvRedisConnection {
@@ -20,6 +21,7 @@ export interface EnvRedisConnection {
   url: string
   environment: ConnectionEnvironment
   prefix: string
+  allowSelfSignedCerts: boolean
   isDefault: boolean
 }
 
@@ -43,6 +45,11 @@ function toDisplayName(envName: string): string {
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ')
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes'
 }
 
 function parseEnvironment(value: string | undefined): ConnectionEnvironment {
@@ -73,7 +80,8 @@ export function getEnvRedisConnections(): EnvRedisConnection[] {
       key === ENV_DEFAULT_KEY ||
       key === ENV_ENCRYPTION_KEY ||
       key.endsWith(ENVIRONMENT_SUFFIX) ||
-      key.endsWith(PREFIX_SUFFIX)
+      key.endsWith(PREFIX_SUFFIX) ||
+      key.endsWith(ALLOW_SELF_SIGNED_CERTS_SUFFIX)
     ) {
       continue
     }
@@ -95,6 +103,9 @@ export function getEnvRedisConnections(): EnvRedisConnection[] {
     const envName = match[1]
     const environment = parseEnvironment(process.env[`${key}${ENVIRONMENT_SUFFIX}`])
     const prefix = process.env[`${key}${PREFIX_SUFFIX}`]?.trim() || 'bull'
+    const allowSelfSignedCerts = parseBoolean(
+      process.env[`${key}${ALLOW_SELF_SIGNED_CERTS_SUFFIX}`]
+    )
 
     connections.push({
       envName,
@@ -102,6 +113,7 @@ export function getEnvRedisConnections(): EnvRedisConnection[] {
       url,
       environment,
       prefix,
+      allowSelfSignedCerts,
       isDefault: false,
     })
   }
@@ -202,6 +214,7 @@ export async function syncEnvConnectionsForOrganization(
       url: string
       environment: ConnectionEnvironment
       prefix: string
+      allowSelfSignedCerts: boolean
       isDefault: boolean
       updatedAt: Date
     }> = {
@@ -209,6 +222,7 @@ export async function syncEnvConnectionsForOrganization(
       url: encryptRedisUrl(connection.url),
       environment: connection.environment,
       prefix: connection.prefix,
+      allowSelfSignedCerts: connection.allowSelfSignedCerts,
       isDefault,
       updatedAt: now,
     }
@@ -221,6 +235,7 @@ export async function syncEnvConnectionsForOrganization(
         url: encryptRedisUrl(connection.url),
         environment: connection.environment,
         prefix: connection.prefix,
+        allowSelfSignedCerts: connection.allowSelfSignedCerts,
         isDefault,
         organizationId,
         createdAt: now,

--- a/packages/dal/src/db/migrations/20260525151104_allow_self_signed_certs/migration.sql
+++ b/packages/dal/src/db/migrations/20260525151104_allow_self_signed_certs/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "redis_connection" ADD COLUMN "allow_self_signed_certs" boolean DEFAULT false NOT NULL;

--- a/packages/dal/src/db/migrations/20260525151104_allow_self_signed_certs/snapshot.json
+++ b/packages/dal/src/db/migrations/20260525151104_allow_self_signed_certs/snapshot.json
@@ -1,0 +1,2282 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "741d76cc-744a-4cd9-b37c-7e271fc7078f",
+  "prevIds": [
+    "3f1db067-d14d-446a-9114-6610f535563a"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "alert_check_cursor",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "alert_event",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "alert_rule",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "auth_account",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "auth_session",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "auth_verification",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "invitation",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "member",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organization",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "redis_connection",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "redis_discovered_queue",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "telemetry_installation",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_settings",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "connection_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_checked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "last_failed_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "last_completed_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_metrics_snapshot",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "alert_rule_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "connection_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'firing'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "summary",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "context",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fired_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_sent_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "connection_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'[]'",
+      "generated": null,
+      "identity": null,
+      "name": "notification_channels",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "30",
+      "generated": null,
+      "identity": null,
+      "name": "cooldown_minutes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_filter_mode",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "'[]'",
+      "generated": null,
+      "identity": null,
+      "name": "filter_queue_names",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_verification"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_verification"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_verification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_verification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_verification"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "auth_verification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "'development'",
+      "generated": null,
+      "identity": null,
+      "name": "environment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'bull'",
+      "generated": null,
+      "identity": null,
+      "name": "prefix",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "allow_self_signed_certs",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "connection_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_discovered_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "telemetry_installation"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "anonymous_instance_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "telemetry_installation"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "telemetry_installation"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "telemetry_installation"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "telemetry_installation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_sign_in_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_settings"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_settings"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_settings"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'system'",
+      "generated": null,
+      "identity": null,
+      "name": "theme",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_settings"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "connection_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "queue_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "alert_check_cursor_connection_queue_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "alert_rule_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "alert_event_rule_id_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "fired_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "alert_event_org_id_fired_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "connection_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "queue_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "alert_event_conn_queue_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "connection_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "redis_discovered_queue_connection_id_name_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "connection_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "state",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "redis_discovered_queue_connection_id_state_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "connection_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "redis_connection",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "alert_check_cursor_connection_id_redis_connection_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "alert_check_cursor"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "alert_rule_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "alert_rule",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "alert_event_alert_rule_id_alert_rule_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "alert_event_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "connection_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "redis_connection",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "alert_event_connection_id_redis_connection_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "alert_event"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "alert_rule_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "connection_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "redis_connection",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "alert_rule_connection_id_redis_connection_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "alert_rule"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "auth_account_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "auth_account"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "auth_session_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "active_organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "auth_session_active_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "auth_session"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitation_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitation_inviter_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "member_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "member_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "member"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "redis_connection_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "redis_connection"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "connection_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "redis_connection",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "redis_discovered_queue_connection_id_redis_connection_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "redis_discovered_queue"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "alert_check_cursor_pkey",
+      "schema": "public",
+      "table": "alert_check_cursor",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "alert_event_pkey",
+      "schema": "public",
+      "table": "alert_event",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "alert_rule_pkey",
+      "schema": "public",
+      "table": "alert_rule",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "auth_account_pkey",
+      "schema": "public",
+      "table": "auth_account",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "auth_session_pkey",
+      "schema": "public",
+      "table": "auth_session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "auth_verification_pkey",
+      "schema": "public",
+      "table": "auth_verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitation_pkey",
+      "schema": "public",
+      "table": "invitation",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "member_pkey",
+      "schema": "public",
+      "table": "member",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_pkey",
+      "schema": "public",
+      "table": "organization",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "redis_connection_pkey",
+      "schema": "public",
+      "table": "redis_connection",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "redis_discovered_queue_pkey",
+      "schema": "public",
+      "table": "redis_discovered_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "telemetry_installation_pkey",
+      "schema": "public",
+      "table": "telemetry_installation",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_pkey",
+      "schema": "public",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_settings_pkey",
+      "schema": "public",
+      "table": "user_settings",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "auth_session_token_key",
+      "schema": "public",
+      "table": "auth_session",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_slug_key",
+      "schema": "public",
+      "table": "organization",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "anonymous_instance_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "telemetry_installation_anonymous_instance_id_key",
+      "schema": "public",
+      "table": "telemetry_installation",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_email_key",
+      "schema": "public",
+      "table": "user",
+      "entityType": "uniques"
+    }
+  ],
+  "renames": []
+}

--- a/packages/dal/src/db/schemas/redis-connection/schema.ts
+++ b/packages/dal/src/db/schemas/redis-connection/schema.ts
@@ -20,6 +20,7 @@ export const redisConnection = pgTable('redis_connection', {
   isDefault: boolean('is_default').notNull().default(false),
   environment: text('environment').$type<ConnectionEnvironment>().default('development'),
   prefix: text('prefix').notNull().default('bull'),
+  allowSelfSignedCerts: boolean('allow_self_signed_certs').notNull().default(false),
   // Organization that owns this connection
   organizationId: text('organization_id')
     .notNull()

--- a/packages/dal/src/repositories/redis-connection.ts
+++ b/packages/dal/src/repositories/redis-connection.ts
@@ -167,13 +167,21 @@ export const redisConnectionRepository = {
   async update(
     id: string,
     organizationId: string,
-    data: Partial<Pick<RedisConnection, 'name' | 'url' | 'isDefault' | 'environment' | 'prefix'>>
+    data: Partial<
+      Pick<
+        RedisConnection,
+        'name' | 'url' | 'isDefault' | 'environment' | 'prefix' | 'allowSelfSignedCerts'
+      >
+    >
   ): Promise<RedisConnection | null> {
     assertConnectionWritesEnabled()
     const db = await getDbForOrganization(organizationId)
 
     const updateData: Partial<
-      Pick<RedisConnection, 'name' | 'url' | 'isDefault' | 'environment' | 'prefix'>
+      Pick<
+        RedisConnection,
+        'name' | 'url' | 'isDefault' | 'environment' | 'prefix' | 'allowSelfSignedCerts'
+      >
     > = { ...data }
     if (updateData.url !== undefined) {
       updateData.url = encryptRedisUrl(updateData.url)


### PR DESCRIPTION
## Summary

- Adds an opt-in `allowSelfSignedCerts` flag on Redis connections (DB, API, UI, and env-driven config) so providers like Heroku Key-Value Store can connect over `rediss://` with self-signed TLS certificates
- Threads the setting through all Redis client paths (`ioredis`, BullMQ queues, queue discovery, alert monitor, and the connection test endpoint)
- Documents the option in connection troubleshooting, connection management, and environment variable guides

Closes #77

## Test plan

- [x] `bun test apps/api/src/lib/connection-options.test.ts apps/api/src/routes/connections.test.ts packages/dal/src/db/env-redis-connections.test.ts apps/api/src/lib/redis.test.ts`
- [x] `bun run typecheck`
- [ ] Add a Heroku KVS (or other self-signed TLS) connection in the UI with **Allow self-signed TLS certificates** enabled and confirm Test succeeds
- [ ] Confirm queue discovery and queue browsing work after saving the connection
- [ ] Verify existing connections continue to work unchanged (flag defaults to `false`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for accepting self-signed TLS certificates in Redis connections.
  * New "Allow self-signed TLS certificates" toggle available in connection settings.
  * Environment variables now support per-connection self-signed certificate configuration.

* **Documentation**
  * Connection management guide updated with TLS certificate options.
  * New troubleshooting section for self-signed certificate issues.
  * Environment variable documentation expanded with TLS configuration details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->