### PR TITLE
Use setActiveOrganization hook after accepting invite

### DIFF
--- a/apps/web/src/routes/setup-organization.tsx
+++ b/apps/web/src/routes/setup-organization.tsx
@@ -1,5 +1,4 @@
 import { organization } from '@durabull/auth/client'
-import { useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { AlertCircle, Building2, Check, Loader2, LogOut, Mail, Plus, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -83,7 +82,6 @@ export const Route = createFileRoute('/setup-organization')({
 
 function SetupOrganizationPage() {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const { isAuthenticated, isLoading: sessionLoading, user, signOut } = useAuth()
 
   const { isLoading: orgsLoading } = useOrganizations()
@@ -222,14 +220,7 @@ function SetupOrganizationPage() {
         return
       }
 
-      const setActiveResult = await organization.setActive({
-        organizationId: acceptedOrg.id,
-      })
-      if (setActiveResult.error) {
-        throw new Error(setActiveResult.error.message ?? 'Failed to activate organization')
-      }
-      queryClient.invalidateQueries({ queryKey: organizationKeys.active })
-      queryClient.invalidateQueries({ queryKey: organizationKeys.list() })
+      await setActiveOrganization.mutateAsync(acceptedOrg.id)
 
       navigate({ to: '/$orgSlug', params: { orgSlug: acceptedOrg.slug } })
     } catch (err) {


### PR DESCRIPTION
## Summary

Stacked on #76 — use the existing `useSetActiveOrganization` hook instead of calling `organization.setActive` directly in `handleAcceptInvitation`.

- Reuses `setActiveOrganization.mutateAsync` for consistent cache invalidation (including connections), error handling, and org-switch analytics
- Removes redundant `useQueryClient` and manual `invalidateQueries` calls (accept + set-active mutations already invalidate the relevant keys)

## Test plan

- [ ] Accept a pending invitation on `/setup-organization` and confirm navigation lands on the invited org dashboard
- [ ] Confirm org switch analytics still fire (if you track PostHog events for `ORGANIZATION_SWITCHED`)


Made with [Cursor](https://cursor.com)