### PR TITLE
fix: PR #48 follow-ups (scale cap, count label, test mocks)

### DIFF
--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -6,6 +6,8 @@ import { getQueue } from '../lib/redis'
 // Default page size for stacktraces and logs
 const DEFAULT_PAGE_SIZE = 50
 const MAX_PAGE_SIZE = 100
+// BullMQ has no supported substring filter on job names; filtered requests scan in-memory.
+const MAX_FILTERED_JOB_RESULTS = 1000
 const RETRY_BATCH_SIZE = 1000
 const MAX_RETRY_BATCHES_PER_STATUS = 500
 const MAX_RETRY_ERRORS_IN_RESPONSE = 100
@@ -165,8 +167,9 @@ const app = new Hono()
     const needsClientFilter = !!(name || jobId)
 
     if (needsClientFilter) {
-      // Fetch each state separately so we know the status without per-job getState() calls,
-      // then return all filtered results in one response for client-side pagination.
+      // BullMQ has no public API for case-insensitive name substring search, so we scan jobs
+      // in-process. Fetch each state separately to avoid per-job getState() calls, then return
+      // matches in one response for client-side pagination.
       const jobsWithState: Array<{ job: NonNullable<Awaited<ReturnType<typeof queue.getJobs>>[number]>; state: JobState }> = []
       for (const state of states) {
         const stateJobs = await queue.getJobs([state])
@@ -191,30 +194,35 @@ const app = new Hono()
             : true
         )
 
-      const mappedJobs = filtered.map(({ job, state }) => ({
-        id: job.id ?? '',
-        name: job.name,
-        status: state,
-        data: job.data as Record<string, unknown>,
-        progress: job.progress,
-        attemptsMade: job.attemptsMade,
-        maxAttempts: job.opts.attempts ?? 1,
-        failedReason: job.failedReason,
-        processedOn: job.processedOn,
-        finishedOn: job.finishedOn,
-        timestamp: job.timestamp,
-        delay: job.delay ?? 0,
-        priority: job.opts.priority ?? 0,
-      }))
+      const totalMatched = filtered.length
+      const truncated = totalMatched > MAX_FILTERED_JOB_RESULTS
+      const mappedJobs = filtered
+        .slice(0, MAX_FILTERED_JOB_RESULTS)
+        .map(({ job, state }) => ({
+          id: job.id ?? '',
+          name: job.name,
+          status: state,
+          data: job.data as Record<string, unknown>,
+          progress: job.progress,
+          attemptsMade: job.attemptsMade,
+          maxAttempts: job.opts.attempts ?? 1,
+          failedReason: job.failedReason,
+          processedOn: job.processedOn,
+          finishedOn: job.finishedOn,
+          timestamp: job.timestamp,
+          delay: job.delay ?? 0,
+          priority: job.opts.priority ?? 0,
+        }))
 
       return c.json({
         jobs: mappedJobs,
-        total: filtered.length,
+        total: totalMatched,
+        truncated,
         page: 1,
         cursor: '0',
         nextCursor: null,
         hasMore: false,
-        pageSize: filtered.length,
+        pageSize: mappedJobs.length,
         totalPages: 1,
       })
     }

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -373,6 +373,7 @@ export function useJobs(
           priority: number
         }>
         total: number
+        truncated?: boolean
         page: number
         cursor: string
         nextCursor: string | null

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
@@ -228,6 +228,25 @@ function QueueDetailPage() {
   const hasMoreVisibleJobs = hasClientSideJobFilter
     ? visibleJobs.length < filteredVisibleJobs.length
     : hasMoreJobs
+  const jobsListTruncated = jobsData?.pages[0]?.truncated ?? false
+  const displayedJobsLabel = useMemo(() => {
+    const visibleCount = filteredVisibleJobs.length
+    const apiTotal = jobsData?.pages[0]?.total ?? 0
+    const moreToLoad = hasMoreVisibleJobs || (hasMoreJobs && !hasClientSideJobFilter)
+
+    if (hideScheduledJobs || hasClientSideJobFilter) {
+      return moreToLoad ? `${visibleCount} shown` : `${visibleCount} total`
+    }
+
+    return `${apiTotal} total`
+  }, [
+    filteredVisibleJobs.length,
+    hasClientSideJobFilter,
+    hasMoreJobs,
+    hasMoreVisibleJobs,
+    hideScheduledJobs,
+    jobsData?.pages,
+  ])
 
   useEffect(() => {
     setVisibleJobCount(20)
@@ -1566,8 +1585,14 @@ function QueueDetailPage() {
                 </table>
               </div>
             </Card>
+            {jobsListTruncated ? (
+              <div className="rounded-md border border-amber-300/60 bg-amber-50/30 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/20 dark:text-amber-300">
+                Showing the first 1,000 of {jobsData?.pages[0]?.total ?? 0} matches. Narrow your
+                search to see more specific results.
+              </div>
+            ) : null}
             <div className="flex items-center justify-between text-sm text-muted-foreground">
-              <span>{jobsData?.pages[0]?.total ?? 0} total</span>
+              <span>{displayedJobsLabel}</span>
               <span>{hasMoreVisibleJobs ? 'Scroll to load more' : 'All jobs loaded'}</span>
             </div>
           </TabsContent>

--- a/apps/web/src/routes/queue-detail-remove.test.tsx
+++ b/apps/web/src/routes/queue-detail-remove.test.tsx
@@ -23,6 +23,7 @@ const {
       tab: 'jobs' as const,
       status: '',
       jobId: '',
+      name: '',
       hideScheduled: 0 as const,
       page: 1,
     },
@@ -218,6 +219,7 @@ describe('queue detail scheduled removal', () => {
       tab: 'jobs',
       status: '',
       jobId: '',
+      name: '',
       hideScheduled: 0,
       page: 1,
     }


### PR DESCRIPTION
## Summary
Stacked follow-up to #48 addressing maintainer review nits:

- **Scale guard:** Cap filtered name/jobId search results at 1,000 jobs. The API returns `truncated: true` when more matches exist, and the queue detail page shows a warning banner.
- **Jobs footer count:** Use the client-side visible count (`X shown` / `X total`) when hide-scheduled or name/jobId filters are active, instead of the raw API total that includes hidden scheduled jobs.
- **Test mocks:** Add `name: ''` to queue detail route test search state (initial + `beforeEach`).

## Notes
- Filtered search still scans jobs in-process because BullMQ has no supported substring name filter; the cap bounds response size and memory for large queues.
- This PR targets the `feat/job-name-search` tracking branch (mirrors #48 head). After merge, cherry-pick or merge these commits into `MayeulHP:feat/job-name-search`, then rebase #48 onto `main` before the final merge.

## Test plan
- [x] `bun run test:unit -- src/routes/queue-detail-remove.test.tsx`
- [x] `bun run typecheck` (web)
- [ ] Search a queue with >1,000 name matches and confirm truncation banner appears
- [ ] Toggle hide scheduled jobs and confirm footer shows `X shown` while scrolling

Depends on #48.

Made with [Cursor](https://cursor.com)