### PR TITLE
feat(alerts): add webhook notification channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,7 @@ BETTER_AUTH_SECRET=replace-me-with-a-long-random-string
 # -----------------------------------------------------------------------------
 # DURABULL_ALERT_ENABLED=true
 # DURABULL_ALERT_POLL_INTERVAL_MS=60000
+# DURABULL_WEBHOOK_ALLOW_HTTP=false
 
 # -----------------------------------------------------------------------------
 # Public (Client) Environment Variables

--- a/apps/api/src/lib/alert-app-urls.ts
+++ b/apps/api/src/lib/alert-app-urls.ts
@@ -1,0 +1,39 @@
+export function buildAlertAppUrls({
+  appBaseUrl,
+  organizationSlug,
+  connectionId,
+  queueName,
+  alertRuleId,
+  jobId,
+}: {
+  appBaseUrl: string
+  organizationSlug: string | null
+  connectionId: string
+  queueName: string
+  alertRuleId: string
+  jobId?: string | null
+}): { dashboardUrl: string; muteUrl: string; jobUrl: string } {
+  const baseUrl = appBaseUrl.replace(/\/+$/, '')
+
+  if (!organizationSlug) {
+    console.warn('[alert-app-urls] Missing organization slug for alert links')
+    return {
+      dashboardUrl: baseUrl,
+      muteUrl: baseUrl,
+      jobUrl: baseUrl,
+    }
+  }
+
+  const orgSegment = encodeURIComponent(organizationSlug)
+  const connectionSegment = encodeURIComponent(connectionId)
+  const queueSegment = encodeURIComponent(queueName)
+  const ruleQuery = new URLSearchParams({ ruleId: alertRuleId }).toString()
+
+  return {
+    dashboardUrl: `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}`,
+    jobUrl: jobId
+      ? `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}/jobs/${encodeURIComponent(jobId)}`
+      : `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}`,
+    muteUrl: `${baseUrl}/${orgSegment}/c/${connectionSegment}/alerts?${ruleQuery}`,
+  }
+}

--- a/apps/api/src/lib/alert-monitor.test.ts
+++ b/apps/api/src/lib/alert-monitor.test.ts
@@ -340,6 +340,58 @@ describe('alert monitor', () => {
     expect(await listRuleEvents(rule.id)).toHaveLength(1)
   })
 
+  it('retries due deliveries when an aggregate rule is still firing', async () => {
+    const processAlertDeliveriesMock = mock(
+      async (_event: { id: string }, _connection: RedisConnection, _ruleName: string) => {}
+    )
+    mock.module('./alert-notifier', () => ({
+      dispatchAlertNotification: mock(async () => {}),
+      processAlertDeliveries: processAlertDeliveriesMock,
+    }))
+
+    const { __alertMonitorTestUtils } = await loadMonitorModule()
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: testConnectionId,
+      queueName: 'email-send',
+      name: 'Failure threshold',
+      type: 'failure_threshold',
+      config: { count: 5, windowMinutes: 5 },
+      cooldownMinutes: 30,
+    })
+
+    const activeEvent = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: testConnectionId,
+      queueName: 'email-send',
+      type: rule.type,
+      status: 'firing',
+      summary: 'Already firing',
+      context: {},
+      firedAt: new Date(Date.now() - 5 * 60_000),
+    })
+
+    await __alertMonitorTestUtils.evaluateAndMaybeAlert(
+      rule,
+      createSnapshot(),
+      {
+        lastCheckedAt: new Date(Date.now() - 5 * 60_000),
+        lastFailedCount: 0,
+        lastCompletedCount: 100,
+      },
+      createConnection()
+    )
+
+    expect(processAlertDeliveriesMock).toHaveBeenCalledTimes(1)
+    expect(processAlertDeliveriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: activeEvent.id }),
+      expect.anything(),
+      expect.anything()
+    )
+    expect(await listRuleEvents(rule.id)).toHaveLength(1)
+  })
+
   it('suppresses new events while the cooldown window is still active', async () => {
     const { __alertMonitorTestUtils } = await loadMonitorModule()
     const rule = await alertRuleRepository.create({

--- a/apps/api/src/lib/alert-monitor.ts
+++ b/apps/api/src/lib/alert-monitor.ts
@@ -301,7 +301,15 @@ async function evaluateAndMaybeAlert(
   }
 
   const activeEvent = await alertEventRepository.findActiveFiring(rule.id, snapshot.queueName)
-  if (activeEvent) return
+  if (activeEvent) {
+    try {
+      await processAlertDeliveries(activeEvent, connection, rule.name)
+      await markLegacyNotificationSentIfComplete(activeEvent.id)
+    } catch (error) {
+      console.error('[alert-monitor] Delivery retry failed:', error)
+    }
+    return
+  }
 
   const recentEvent = await alertEventRepository.findMostRecentForRule(rule.id, snapshot.queueName)
   if (recentEvent) {

--- a/apps/api/src/lib/alert-notifier.test.ts
+++ b/apps/api/src/lib/alert-notifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { buildAlertAppUrls } from './alert-notifier'
+import { buildAlertAppUrls } from './alert-app-urls'
 
 describe('buildAlertAppUrls', () => {
   it('builds app routes that match the current web router', () => {

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -2,6 +2,7 @@ import {
   type AlertDelivery,
   type AlertEvent,
   alertDeliveryRepository,
+  alertRuleRepository,
   eq,
   getDb,
   linearIntegrationRepository,
@@ -13,6 +14,22 @@ import { isEmailConfigured } from '@durabull/email'
 import { env } from '@durabull/env'
 import { createLinearIssue, LinearApiError } from './linear-client'
 import { getValidLinearAccessToken } from './linear-oauth'
+import { buildAlertAppUrls } from './alert-app-urls'
+import {
+  deliverWebhookOrThrow,
+  isWebhookDeliveryExpired,
+  WEBHOOK_DELIVERY_ABANDONED_MESSAGE,
+  WebhookDeliveryError,
+} from './alert-webhook-client'
+import {
+  buildAlertWebhookPayloadFromEvent,
+  serializeAlertWebhookPayload,
+} from './alert-webhook-payload'
+import {
+  findWebhookSecretFromChannels,
+  toWebhookDeliveryMetadata,
+} from './alert-webhook-channels'
+import { getWebhookDeliveryTarget } from './alert-webhook-url'
 
 class NonRetryableDeliveryError extends Error {
   constructor(message: string) {
@@ -36,6 +53,11 @@ export type NotificationChannel =
       stateId?: string
       priority?: number
     }
+  | {
+      type: 'webhook'
+      url: string
+      secret?: string
+    }
 
 export async function dispatchAlertNotification(
   event: AlertEvent,
@@ -48,7 +70,7 @@ export async function dispatchAlertNotification(
     organizationId: event.organizationId,
     channelType: channel.type,
     target: getDeliveryTarget(channel),
-    providerMetadata: channel,
+    providerMetadata: getDeliveryProviderMetadata(channel),
   }))
 
   await alertDeliveryRepository.enqueueMany(deliveries)
@@ -66,6 +88,15 @@ export async function processAlertDeliveries(
   const organizationSlug = await getOrganizationSlug(event.organizationId)
 
   for (const delivery of dueDeliveries) {
+    if (delivery.channelType === 'webhook' && isWebhookDeliveryExpired(delivery.createdAt)) {
+      await alertDeliveryRepository.markFailed(delivery.id, {
+        error: WEBHOOK_DELIVERY_ABANDONED_MESSAGE,
+        retryable: false,
+        expectedClaimedAt: requireClaimedAt(delivery),
+      })
+      continue
+    }
+
     try {
       switch (delivery.channelType) {
         case 'email':
@@ -75,6 +106,9 @@ export async function processAlertDeliveries(
         case 'linear':
           await sendLinearAlert(delivery, event, connection, ruleName, organizationSlug)
           break
+        case 'webhook':
+          await sendWebhookAlert(delivery, event, connection, ruleName, organizationSlug)
+          break
         default:
           await alertDeliveryRepository.markFailed(delivery.id, {
             error: `Unknown channel type: ${delivery.channelType}`,
@@ -83,7 +117,7 @@ export async function processAlertDeliveries(
           })
       }
     } catch (error) {
-      const retry = classifyDeliveryFailure(error, delivery.attemptCount + 1)
+      const retry = classifyDeliveryFailure(error, delivery.attemptCount + 1, delivery)
       await alertDeliveryRepository.markFailed(delivery.id, {
         ...retry,
         expectedClaimedAt: requireClaimedAt(delivery),
@@ -92,8 +126,16 @@ export async function processAlertDeliveries(
   }
 }
 
+function getDeliveryProviderMetadata(channel: NotificationChannel): Record<string, unknown> {
+  if (channel.type === 'webhook') {
+    return { ...toWebhookDeliveryMetadata(channel) }
+  }
+  return channel as Record<string, unknown>
+}
+
 function getDeliveryTarget(channel: NotificationChannel): string {
   if (channel.type === 'email') return channel.target
+  if (channel.type === 'webhook') return getWebhookDeliveryTarget(channel.url)
   return [
     'org-default',
     channel.teamId ?? '',
@@ -307,6 +349,91 @@ function requireClaimedAt(delivery: AlertDelivery): Date {
   })
 }
 
+async function sendWebhookAlert(
+  delivery: AlertDelivery,
+  event: AlertEvent,
+  connection: RedisConnection,
+  ruleName: string,
+  organizationSlug: string | null
+): Promise<void> {
+  const channel = parseWebhookChannel(delivery.providerMetadata)
+  const secret = await resolveWebhookSigningSecret(
+    event,
+    channel.url,
+    delivery.providerMetadata
+  )
+  const payload = buildAlertWebhookPayloadFromEvent(
+    event,
+    delivery.id,
+    connection,
+    ruleName,
+    organizationSlug,
+    env.APP_BASE_URL
+  )
+  const body = serializeAlertWebhookPayload(payload)
+
+  const result = await deliverWebhookOrThrow({
+    url: channel.url,
+    body,
+    secret,
+    deliveryId: delivery.id,
+    idempotencyKey: event.id,
+  })
+
+  const marked = await alertDeliveryRepository.markDelivered(
+    delivery.id,
+    {
+      providerMetadata: {
+        ...((delivery.providerMetadata ?? {}) as Record<string, unknown>),
+        httpStatus: result.httpStatus,
+        responseTimeMs: result.durationMs,
+        responseBodySnippet: result.responseBodySnippet,
+      },
+    },
+    requireClaimedAt(delivery)
+  )
+  if (!marked) {
+    throw new WebhookDeliveryError('Alert delivery claim was lost before it could be completed.', {
+      httpStatus: 409,
+      retryable: false,
+    })
+  }
+}
+
+function parseWebhookChannel(value: unknown): Extract<NotificationChannel, { type: 'webhook' }> {
+  const source =
+    typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+  const url = typeof source.url === 'string' ? source.url : ''
+  if (!url) {
+    throw new NonRetryableDeliveryError('Webhook delivery is missing a target URL.')
+  }
+  return {
+    type: 'webhook',
+    url,
+  }
+}
+
+async function resolveWebhookSigningSecret(
+  event: AlertEvent,
+  url: string,
+  metadata: unknown
+): Promise<string | undefined> {
+  const source =
+    typeof metadata === 'object' && metadata !== null ? (metadata as Record<string, unknown>) : {}
+  const legacySecret = typeof source.secret === 'string' ? source.secret.trim() : ''
+  if (legacySecret.length > 0) {
+    return legacySecret
+  }
+
+  const rule = await alertRuleRepository.findById(event.alertRuleId, event.organizationId)
+  if (!rule) return undefined
+
+  return findWebhookSecretFromChannels(
+    Array.isArray(rule.notificationChannels) ? rule.notificationChannels : [],
+    url
+  )
+}
+
 function parseLinearChannel(value: unknown): Extract<NotificationChannel, { type: 'linear' }> {
   const source =
     typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
@@ -407,13 +534,23 @@ function safeLinearMarkdown(value: string, maxLength = 1000): string {
 
 function classifyDeliveryFailure(
   error: unknown,
-  attemptCount: number
+  attemptCount: number,
+  delivery?: Pick<AlertDelivery, 'channelType' | 'createdAt'>
 ): { error: string; retryable: boolean; nextRetryAt?: Date | null } {
+  if (
+    delivery?.channelType === 'webhook' &&
+    isWebhookDeliveryExpired(delivery.createdAt)
+  ) {
+    return { error: WEBHOOK_DELIVERY_ABANDONED_MESSAGE, retryable: false }
+  }
+
   const message = error instanceof Error ? error.message : String(error)
   const retryable =
     error instanceof LinearApiError
       ? error.retryable
-      : !(error instanceof NonRetryableDeliveryError)
+      : error instanceof WebhookDeliveryError
+        ? error.retryable
+        : !(error instanceof NonRetryableDeliveryError)
   if (!retryable) return { error: message, retryable: false }
 
   const resetAt = error instanceof LinearApiError ? error.rateLimitResetAt : null
@@ -437,42 +574,4 @@ async function getOrganizationSlug(organizationId: string): Promise<string | nul
   return rows[0]?.slug ?? null
 }
 
-export function buildAlertAppUrls({
-  appBaseUrl,
-  organizationSlug,
-  connectionId,
-  queueName,
-  alertRuleId,
-  jobId,
-}: {
-  appBaseUrl: string
-  organizationSlug: string | null
-  connectionId: string
-  queueName: string
-  alertRuleId: string
-  jobId?: string | null
-}): { dashboardUrl: string; muteUrl: string; jobUrl: string } {
-  const baseUrl = appBaseUrl.replace(/\/+$/, '')
-
-  if (!organizationSlug) {
-    console.warn('[alert-notifier] Missing organization slug for alert email links')
-    return {
-      dashboardUrl: baseUrl,
-      muteUrl: baseUrl,
-      jobUrl: baseUrl,
-    }
-  }
-
-  const orgSegment = encodeURIComponent(organizationSlug)
-  const connectionSegment = encodeURIComponent(connectionId)
-  const queueSegment = encodeURIComponent(queueName)
-  const ruleQuery = new URLSearchParams({ ruleId: alertRuleId }).toString()
-
-  return {
-    dashboardUrl: `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}`,
-    jobUrl: jobId
-      ? `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}/jobs/${encodeURIComponent(jobId)}`
-      : `${baseUrl}/${orgSegment}/c/${connectionSegment}/queues/${queueSegment}`,
-    muteUrl: `${baseUrl}/${orgSegment}/c/${connectionSegment}/alerts?${ruleQuery}`,
-  }
-}
+export { buildAlertAppUrls } from './alert-app-urls'

--- a/apps/api/src/lib/alert-webhook-channels.test.ts
+++ b/apps/api/src/lib/alert-webhook-channels.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  findWebhookSecretFromChannels,
+  mergeWebhookSecretsOnUpdate,
+  resolveWebhookTestSecret,
+  sanitizeDeliveryProviderMetadata,
+  sanitizeNotificationChannels,
+  sanitizeWebhookChannel,
+  toWebhookDeliveryMetadata,
+} from './alert-webhook-channels'
+
+describe('sanitizeWebhookChannel', () => {
+  it('masks webhook secrets on read', () => {
+    expect(
+      sanitizeWebhookChannel({
+        type: 'webhook',
+        url: 'https://example.com/hook',
+        secret: 'super-secret-signing-key',
+      })
+    ).toEqual({
+      type: 'webhook',
+      url: 'https://example.com/hook',
+      secretConfigured: true,
+      secretLast4: '-key',
+    })
+  })
+})
+
+describe('mergeWebhookSecretsOnUpdate', () => {
+  it('preserves existing secrets when omitted from updates', () => {
+    const merged = mergeWebhookSecretsOnUpdate(
+      [{ type: 'webhook', url: 'https://example.com/hook' }],
+      [{ type: 'webhook', url: 'https://example.com/hook', secret: 'existing-secret-value' }]
+    )
+
+    expect((merged[0] as { secret?: string }).secret).toBe('existing-secret-value')
+  })
+
+  it('clears secrets when an empty string is submitted', () => {
+    const merged = mergeWebhookSecretsOnUpdate(
+      [{ type: 'webhook', url: 'https://example.com/hook', secret: '' }],
+      [{ type: 'webhook', url: 'https://example.com/hook', secret: 'existing-secret-value' }]
+    )
+
+    expect((merged[0] as { secret?: string }).secret).toBeUndefined()
+  })
+})
+
+describe('sanitizeNotificationChannels', () => {
+  it('sanitizes webhook channels in mixed channel lists', () => {
+    const sanitized = sanitizeNotificationChannels([
+      { type: 'email', target: 'ops@example.com' },
+      { type: 'webhook', url: 'https://example.com/hook', secret: 'abcdefghijklmnop' },
+    ])
+
+    expect(sanitized[1]).toEqual({
+      type: 'webhook',
+      url: 'https://example.com/hook',
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+  })
+})
+
+describe('toWebhookDeliveryMetadata', () => {
+  it('stores webhook delivery metadata without secrets', () => {
+    expect(
+      toWebhookDeliveryMetadata({
+        type: 'webhook',
+        url: 'https://example.com/hook',
+        secret: 'abcdefghijklmnop',
+      })
+    ).toEqual({
+      type: 'webhook',
+      url: 'https://example.com/hook',
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+  })
+})
+
+describe('findWebhookSecretFromChannels', () => {
+  it('finds a webhook secret by URL', () => {
+    expect(
+      findWebhookSecretFromChannels(
+        [{ type: 'webhook', url: 'https://example.com/hook', secret: 'stored-secret-value' }],
+        'https://example.com/hook'
+      )
+    ).toBe('stored-secret-value')
+  })
+})
+
+describe('resolveWebhookTestSecret', () => {
+  it('uses the saved rule secret when the request omits one', () => {
+    expect(
+      resolveWebhookTestSecret('https://example.com/hook', undefined, [
+        { type: 'webhook', url: 'https://example.com/hook', secret: 'stored-secret-value' },
+      ])
+    ).toBe('stored-secret-value')
+  })
+
+  it('prefers an explicit secret from the request body', () => {
+    expect(
+      resolveWebhookTestSecret('https://example.com/hook', 'override-secret-value', [
+        { type: 'webhook', url: 'https://example.com/hook', secret: 'stored-secret-value' },
+      ])
+    ).toBe('override-secret-value')
+  })
+})
+
+describe('sanitizeDeliveryProviderMetadata', () => {
+  it('removes webhook secrets from delivery metadata', () => {
+    expect(
+      sanitizeDeliveryProviderMetadata({
+        type: 'webhook',
+        url: 'https://example.com/hook',
+        secret: 'abcdefghijklmnop',
+        httpStatus: 200,
+      })
+    ).toEqual({
+      type: 'webhook',
+      url: 'https://example.com/hook',
+      httpStatus: 200,
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+  })
+})

--- a/apps/api/src/lib/alert-webhook-channels.ts
+++ b/apps/api/src/lib/alert-webhook-channels.ts
@@ -44,7 +44,8 @@ export function resolveWebhookTestSecret(
   ruleChannels: unknown[] | null | undefined
 ): string | undefined {
   if (explicitSecret !== undefined) {
-    return explicitSecret.trim() === '' ? undefined : explicitSecret
+    const trimmed = explicitSecret.trim()
+    return trimmed === '' ? undefined : trimmed
   }
   return findWebhookSecretFromChannels(ruleChannels, url)
 }

--- a/apps/api/src/lib/alert-webhook-channels.ts
+++ b/apps/api/src/lib/alert-webhook-channels.ts
@@ -1,0 +1,155 @@
+import { assertAllowedWebhookUrl } from './alert-webhook-url'
+
+export interface WebhookNotificationChannel {
+  type: 'webhook'
+  url: string
+  secret?: string
+}
+
+export interface SanitizedWebhookNotificationChannel {
+  type: 'webhook'
+  url: string
+  secretConfigured: boolean
+  secretLast4?: string
+}
+
+export function toWebhookDeliveryMetadata(
+  channel: WebhookNotificationChannel
+): SanitizedWebhookNotificationChannel {
+  return sanitizeWebhookChannel(channel)
+}
+
+export function findWebhookSecretFromChannels(
+  channels: unknown[] | null | undefined,
+  url: string
+): string | undefined {
+  for (const channel of channels ?? []) {
+    if (
+      typeof channel === 'object' &&
+      channel !== null &&
+      (channel as { type?: string }).type === 'webhook' &&
+      (channel as { url?: string }).url === url &&
+      typeof (channel as { secret?: string }).secret === 'string'
+    ) {
+      const secret = (channel as { secret: string }).secret.trim()
+      return secret.length > 0 ? secret : undefined
+    }
+  }
+  return undefined
+}
+
+export function resolveWebhookTestSecret(
+  url: string,
+  explicitSecret: string | undefined,
+  ruleChannels: unknown[] | null | undefined
+): string | undefined {
+  if (explicitSecret !== undefined) {
+    return explicitSecret.trim() === '' ? undefined : explicitSecret
+  }
+  return findWebhookSecretFromChannels(ruleChannels, url)
+}
+
+export function sanitizeDeliveryProviderMetadata(
+  metadata: Record<string, unknown> | null | undefined
+): Record<string, unknown> {
+  if (!metadata || typeof metadata !== 'object') return {}
+
+  const { secret, ...rest } = metadata
+  if (rest.type !== 'webhook' || typeof rest.url !== 'string') {
+    return rest
+  }
+
+  const secretConfigured =
+    rest.secretConfigured === true ||
+    (typeof secret === 'string' && secret.trim().length > 0)
+  const secretLast4 =
+    typeof rest.secretLast4 === 'string'
+      ? rest.secretLast4
+      : typeof secret === 'string' && secret.length >= 4
+        ? secret.slice(-4)
+        : undefined
+
+  return {
+    ...rest,
+    secretConfigured,
+    ...(secretLast4 ? { secretLast4 } : {}),
+  }
+}
+
+export function sanitizeWebhookChannel(
+  channel: WebhookNotificationChannel
+): SanitizedWebhookNotificationChannel {
+  const secret = channel.secret?.trim()
+  return {
+    type: 'webhook',
+    url: channel.url,
+    secretConfigured: Boolean(secret),
+    secretLast4: secret && secret.length >= 4 ? secret.slice(-4) : undefined,
+  }
+}
+
+export function sanitizeNotificationChannels(channels: unknown[]): unknown[] {
+  return channels.map((channel) => {
+    if (
+      typeof channel === 'object' &&
+      channel !== null &&
+      (channel as { type?: string }).type === 'webhook'
+    ) {
+      const webhook = channel as WebhookNotificationChannel
+      return sanitizeWebhookChannel(webhook)
+    }
+    return channel as Record<string, unknown>
+  })
+}
+
+export function mergeWebhookSecretsOnUpdate<T extends { type: string; url?: string; secret?: string }>(
+  incomingChannels: T[],
+  existingChannels: unknown[] | null | undefined
+): T[] {
+  const existingByUrl = new Map<string, string>()
+  for (const channel of existingChannels ?? []) {
+    if (
+      typeof channel === 'object' &&
+      channel !== null &&
+      (channel as { type?: string }).type === 'webhook' &&
+      typeof (channel as { url?: string }).url === 'string' &&
+      typeof (channel as { secret?: string }).secret === 'string'
+    ) {
+      existingByUrl.set((channel as { url: string }).url, (channel as { secret: string }).secret)
+    }
+  }
+
+  return incomingChannels.map((channel) => {
+    if (channel.type !== 'webhook' || typeof channel.url !== 'string') {
+      return channel
+    }
+
+    if (channel.secret !== undefined) {
+      if (channel.secret.trim() === '') {
+        const { secret: _secret, ...rest } = channel
+        return rest as T
+      }
+      return channel
+    }
+
+    const existingSecret = existingByUrl.get(channel.url)
+    if (existingSecret) {
+      return { ...channel, secret: existingSecret }
+    }
+
+    return channel
+  })
+}
+
+export async function validateWebhookUrls(
+  channels: WebhookNotificationChannel[]
+): Promise<string | null> {
+  for (const channel of channels) {
+    try {
+      await assertAllowedWebhookUrl(channel.url)
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error)
+    }
+  }
+  return null
+}

--- a/apps/api/src/lib/alert-webhook-client.test.ts
+++ b/apps/api/src/lib/alert-webhook-client.test.ts
@@ -37,6 +37,15 @@ describe('assertAllowedWebhookUrl', () => {
     await expect(assertAllowedWebhookUrl('https://10.0.0.1/hook')).rejects.toThrow(
       'private or local IP'
     )
+    await expect(assertAllowedWebhookUrl('https://198.18.0.1/hook')).rejects.toThrow(
+      'private or local IP'
+    )
+    await expect(assertAllowedWebhookUrl('https://240.0.0.1/hook')).rejects.toThrow(
+      'private or local IP'
+    )
+    await expect(assertAllowedWebhookUrl('https://192.0.0.1/hook')).rejects.toThrow(
+      'private or local IP'
+    )
   })
 
   it('accepts public hostnames', async () => {

--- a/apps/api/src/lib/alert-webhook-client.test.ts
+++ b/apps/api/src/lib/alert-webhook-client.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  classifyWebhookHttpStatus,
+  deliverWebhook,
+  isWebhookDeliveryExpired,
+  signWebhookPayload,
+  WEBHOOK_DELIVERY_MAX_AGE_MS,
+} from './alert-webhook-client'
+import { assertAllowedWebhookUrl, getWebhookDeliveryTarget } from './alert-webhook-url'
+
+describe('signWebhookPayload', () => {
+  it('creates a sha256 signature over timestamp and body', () => {
+    const signed = signWebhookPayload('secret-key', 1_700_000_000, '{"event":"alert.test"}')
+    expect(signed.timestamp).toBe('1700000000')
+    expect(signed.signature.startsWith('sha256=')).toBe(true)
+    expect(signed.signature.length).toBeGreaterThan('sha256='.length)
+  })
+})
+
+describe('classifyWebhookHttpStatus', () => {
+  it('treats 2xx as success and 5xx as retryable', () => {
+    expect(classifyWebhookHttpStatus(200).retryable).toBe(false)
+    expect(classifyWebhookHttpStatus(503).retryable).toBe(true)
+    expect(classifyWebhookHttpStatus(404).retryable).toBe(false)
+    expect(classifyWebhookHttpStatus(429).retryable).toBe(true)
+  })
+})
+
+describe('assertAllowedWebhookUrl', () => {
+  it('rejects localhost and private IP targets', async () => {
+    await expect(assertAllowedWebhookUrl('https://localhost/hook')).rejects.toThrow(
+      'hostname is not allowed'
+    )
+    await expect(assertAllowedWebhookUrl('https://127.0.0.1/hook')).rejects.toThrow(
+      'private or local IP'
+    )
+    await expect(assertAllowedWebhookUrl('https://10.0.0.1/hook')).rejects.toThrow(
+      'private or local IP'
+    )
+  })
+
+  it('accepts public hostnames', async () => {
+    await expect(assertAllowedWebhookUrl('https://example.com/hook')).resolves.toBeUndefined()
+  })
+})
+
+describe('getWebhookDeliveryTarget', () => {
+  it('normalizes origin, path, and query while stripping fragments', () => {
+    expect(getWebhookDeliveryTarget('https://example.com/hooks/alerts?token=abc#section')).toBe(
+      'https://example.com/hooks/alerts?token=abc'
+    )
+  })
+})
+
+describe('isWebhookDeliveryExpired', () => {
+  it('returns false before the max age window elapses', () => {
+    const createdAt = new Date('2026-05-25T12:00:00.000Z')
+    const nowMs = createdAt.getTime() + WEBHOOK_DELIVERY_MAX_AGE_MS - 1
+    expect(isWebhookDeliveryExpired(createdAt, nowMs)).toBe(false)
+  })
+
+  it('returns true after the max age window elapses', () => {
+    const createdAt = new Date('2026-05-25T12:00:00.000Z')
+    const nowMs = createdAt.getTime() + WEBHOOK_DELIVERY_MAX_AGE_MS
+    expect(isWebhookDeliveryExpired(createdAt, nowMs)).toBe(true)
+  })
+
+  it('treats invalid createdAt values as expired', () => {
+    expect(isWebhookDeliveryExpired('not-a-date')).toBe(true)
+  })
+})
+
+describe('deliverWebhook', () => {
+  it('returns a non-retryable error for blocked webhook URLs', async () => {
+    const result = await deliverWebhook({
+      url: 'https://127.0.0.1/hook',
+      body: '{"event":"alert.test"}',
+      deliveryId: 'delivery_1',
+      idempotencyKey: 'event_1',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.retryable).toBe(false)
+  })
+})

--- a/apps/api/src/lib/alert-webhook-client.ts
+++ b/apps/api/src/lib/alert-webhook-client.ts
@@ -1,0 +1,200 @@
+import { createHmac } from 'node:crypto'
+import {
+  assertAllowedWebhookUrl,
+  normalizeWebhookUrl,
+  WebhookUrlError,
+} from './alert-webhook-url'
+
+export const WEBHOOK_TIMEOUT_MS = 10_000
+export const WEBHOOK_SIGNATURE_TOLERANCE_SEC = 300
+export const WEBHOOK_DELIVERY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+export const WEBHOOK_DELIVERY_ABANDONED_MESSAGE =
+  'Webhook delivery abandoned after 7 days of failed attempts.'
+
+export function isWebhookDeliveryExpired(
+  createdAt: Date | string,
+  nowMs: number = Date.now()
+): boolean {
+  const createdMs = createdAt instanceof Date ? createdAt.getTime() : new Date(createdAt).getTime()
+  if (!Number.isFinite(createdMs)) return true
+  return nowMs - createdMs >= WEBHOOK_DELIVERY_MAX_AGE_MS
+}
+
+export interface WebhookDeliveryRequest {
+  url: string
+  body: string
+  secret?: string | null
+  deliveryId: string
+  idempotencyKey: string
+}
+
+export interface WebhookDeliveryResult {
+  success: boolean
+  httpStatus: number | null
+  durationMs: number
+  error?: string
+  retryable: boolean
+  responseBodySnippet?: string
+}
+
+export class WebhookDeliveryError extends Error {
+  readonly httpStatus: number | null
+  readonly retryable: boolean
+  readonly responseBodySnippet?: string
+
+  constructor(
+    message: string,
+    options: { httpStatus?: number | null; retryable: boolean; responseBodySnippet?: string }
+  ) {
+    super(message)
+    this.name = 'WebhookDeliveryError'
+    this.httpStatus = options.httpStatus ?? null
+    this.retryable = options.retryable
+    this.responseBodySnippet = options.responseBodySnippet
+  }
+}
+
+export function signWebhookPayload(
+  secret: string,
+  timestamp: number,
+  body: string
+): { signature: string; timestamp: string } {
+  const timestampValue = String(timestamp)
+  const digest = createHmac('sha256', secret)
+    .update(`${timestampValue}.${body}`)
+    .digest('hex')
+  return {
+    signature: `sha256=${digest}`,
+    timestamp: timestampValue,
+  }
+}
+
+export function classifyWebhookHttpStatus(status: number): { retryable: boolean; message: string } {
+  if (status >= 200 && status < 300) {
+    return { retryable: false, message: 'Delivered successfully.' }
+  }
+  if (status === 408 || status === 429 || status >= 500) {
+    return { retryable: true, message: `Webhook endpoint returned HTTP ${status}.` }
+  }
+  return { retryable: false, message: `Webhook endpoint returned HTTP ${status}.` }
+}
+
+export async function deliverWebhook(request: WebhookDeliveryRequest): Promise<WebhookDeliveryResult> {
+  const startedAt = Date.now()
+
+  try {
+    await assertAllowedWebhookUrl(request.url)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      success: false,
+      httpStatus: null,
+      durationMs: Date.now() - startedAt,
+      error: message,
+      retryable: false,
+    }
+  }
+
+  const normalizedUrl = normalizeWebhookUrl(request.url)
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'Durabull-Alerts/1.0',
+    'X-Durabull-Delivery-Id': request.deliveryId,
+    'Idempotency-Key': request.idempotencyKey,
+  }
+
+  if (request.secret) {
+    const signed = signWebhookPayload(request.secret, Math.floor(Date.now() / 1000), request.body)
+    headers['X-Durabull-Signature'] = signed.signature
+    headers['X-Durabull-Timestamp'] = signed.timestamp
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(normalizedUrl, {
+      method: 'POST',
+      headers,
+      body: request.body,
+      redirect: 'manual',
+      signal: controller.signal,
+    })
+
+    const durationMs = Date.now() - startedAt
+    const responseBodySnippet = await readResponseSnippet(response)
+    const classification = classifyWebhookHttpStatus(response.status)
+
+    if (response.status >= 200 && response.status < 300) {
+      return {
+        success: true,
+        httpStatus: response.status,
+        durationMs,
+        retryable: false,
+        responseBodySnippet,
+      }
+    }
+
+    return {
+      success: false,
+      httpStatus: response.status,
+      durationMs,
+      error: classification.message,
+      retryable: classification.retryable,
+      responseBodySnippet,
+    }
+  } catch (error) {
+    const durationMs = Date.now() - startedAt
+    if (error instanceof Error && error.name === 'AbortError') {
+      return {
+        success: false,
+        httpStatus: null,
+        durationMs,
+        error: `Webhook request timed out after ${WEBHOOK_TIMEOUT_MS}ms.`,
+        retryable: true,
+      }
+    }
+
+    return {
+      success: false,
+      httpStatus: null,
+      durationMs,
+      error: error instanceof Error ? error.message : String(error),
+      retryable: true,
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export async function deliverWebhookOrThrow(
+  request: WebhookDeliveryRequest
+): Promise<{ httpStatus: number; durationMs: number; responseBodySnippet?: string }> {
+  const result = await deliverWebhook(request)
+  if (result.success && result.httpStatus !== null) {
+    return {
+      httpStatus: result.httpStatus,
+      durationMs: result.durationMs,
+      responseBodySnippet: result.responseBodySnippet,
+    }
+  }
+
+  throw new WebhookDeliveryError(result.error ?? 'Webhook delivery failed.', {
+    httpStatus: result.httpStatus,
+    retryable: result.retryable,
+    responseBodySnippet: result.responseBodySnippet,
+  })
+}
+
+async function readResponseSnippet(response: Response): Promise<string | undefined> {
+  try {
+    const text = await response.text()
+    if (!text) return undefined
+    return text.slice(0, 500)
+  } catch {
+    return undefined
+  }
+}
+
+export { WebhookUrlError }

--- a/apps/api/src/lib/alert-webhook-client.ts
+++ b/apps/api/src/lib/alert-webhook-client.ts
@@ -1,7 +1,10 @@
 import { createHmac } from 'node:crypto'
+import type { IncomingMessage } from 'node:http'
+import http from 'node:http'
+import https from 'node:https'
 import {
-  assertAllowedWebhookUrl,
-  normalizeWebhookUrl,
+  resolveAllowedWebhookEndpoint,
+  type ResolvedWebhookEndpoint,
   WebhookUrlError,
 } from './alert-webhook-url'
 
@@ -83,8 +86,9 @@ export function classifyWebhookHttpStatus(status: number): { retryable: boolean;
 export async function deliverWebhook(request: WebhookDeliveryRequest): Promise<WebhookDeliveryResult> {
   const startedAt = Date.now()
 
+  let endpoint: ResolvedWebhookEndpoint
   try {
-    await assertAllowedWebhookUrl(request.url)
+    endpoint = await resolveAllowedWebhookEndpoint(request.url)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     return {
@@ -96,7 +100,6 @@ export async function deliverWebhook(request: WebhookDeliveryRequest): Promise<W
     }
   }
 
-  const normalizedUrl = normalizeWebhookUrl(request.url)
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'User-Agent': 'Durabull-Alerts/1.0',
@@ -110,26 +113,17 @@ export async function deliverWebhook(request: WebhookDeliveryRequest): Promise<W
     headers['X-Durabull-Timestamp'] = signed.timestamp
   }
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS)
-
   try {
-    const response = await fetch(normalizedUrl, {
-      method: 'POST',
-      headers,
-      body: request.body,
-      redirect: 'manual',
-      signal: controller.signal,
+    const { statusCode, responseBodySnippet } = await postPinnedWebhook(endpoint, headers, request.body, {
+      timeoutMs: WEBHOOK_TIMEOUT_MS,
     })
-
     const durationMs = Date.now() - startedAt
-    const responseBodySnippet = await readResponseSnippet(response)
-    const classification = classifyWebhookHttpStatus(response.status)
+    const classification = classifyWebhookHttpStatus(statusCode)
 
-    if (response.status >= 200 && response.status < 300) {
+    if (statusCode >= 200 && statusCode < 300) {
       return {
         success: true,
-        httpStatus: response.status,
+        httpStatus: statusCode,
         durationMs,
         retryable: false,
         responseBodySnippet,
@@ -138,7 +132,7 @@ export async function deliverWebhook(request: WebhookDeliveryRequest): Promise<W
 
     return {
       success: false,
-      httpStatus: response.status,
+      httpStatus: statusCode,
       durationMs,
       error: classification.message,
       retryable: classification.retryable,
@@ -163,8 +157,6 @@ export async function deliverWebhook(request: WebhookDeliveryRequest): Promise<W
       error: error instanceof Error ? error.message : String(error),
       retryable: true,
     }
-  } finally {
-    clearTimeout(timeout)
   }
 }
 
@@ -187,14 +179,87 @@ export async function deliverWebhookOrThrow(
   })
 }
 
-async function readResponseSnippet(response: Response): Promise<string | undefined> {
-  try {
-    const text = await response.text()
-    if (!text) return undefined
-    return text.slice(0, 500)
-  } catch {
-    return undefined
-  }
+function postPinnedWebhook(
+  endpoint: ResolvedWebhookEndpoint,
+  headers: Record<string, string>,
+  body: string,
+  options: { timeoutMs: number }
+): Promise<{ statusCode: number; responseBodySnippet?: string }> {
+  return new Promise((resolve, reject) => {
+    const isHttps = endpoint.protocol === 'https:'
+    const client = isHttps ? https : http
+    const bodyBytes = Buffer.byteLength(body, 'utf8')
+
+    const req = client.request(
+      {
+        host: endpoint.pinnedAddress,
+        port: endpoint.port,
+        path: endpoint.path,
+        method: 'POST',
+        headers: {
+          ...headers,
+          Host: endpoint.hostname,
+          'Content-Length': bodyBytes,
+        },
+        servername: isHttps ? endpoint.hostname : undefined,
+        rejectUnauthorized: isHttps,
+      },
+      (response) => {
+        void readBoundedResponseSnippet(response, 500)
+          .then((responseBodySnippet) => {
+            resolve({
+              statusCode: response.statusCode ?? 0,
+              responseBodySnippet,
+            })
+          })
+          .catch(reject)
+      }
+    )
+
+    const timeoutError = Object.assign(
+      new Error(`Webhook request timed out after ${options.timeoutMs}ms.`),
+      { name: 'AbortError' }
+    )
+    const timer = setTimeout(() => {
+      req.destroy(timeoutError)
+    }, options.timeoutMs)
+
+    req.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    req.on('close', () => clearTimeout(timer))
+
+    req.write(body)
+    req.end()
+  })
+}
+
+async function readBoundedResponseSnippet(
+  response: IncomingMessage,
+  maxChars: number
+): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const decoder = new TextDecoder()
+    let out = ''
+    let settled = false
+
+    const finish = () => {
+      if (settled) return
+      settled = true
+      response.resume()
+      response.destroy()
+      resolve(out ? out.slice(0, maxChars) : undefined)
+    }
+
+    response.on('data', (chunk: Buffer) => {
+      if (settled) return
+      out += decoder.decode(chunk, { stream: true })
+      if (out.length >= maxChars) finish()
+    })
+    response.on('end', finish)
+    response.on('error', finish)
+  })
 }
 
 export { WebhookUrlError }

--- a/apps/api/src/lib/alert-webhook-payload.test.ts
+++ b/apps/api/src/lib/alert-webhook-payload.test.ts
@@ -91,4 +91,33 @@ describe('serializeAlertWebhookPayload', () => {
     const body = serializeAlertWebhookPayload(payload)
     expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(32_768)
   })
+
+  it('falls back to a minimal payload when repeated truncation is still too large', () => {
+    const payload = buildAlertWebhookPayload({
+      eventType: 'alert.test',
+      eventId: 'event_test',
+      deliveryId: 'delivery_test',
+      occurredAt: new Date('2026-05-25T12:00:00.000Z'),
+      organizationId: 'org_1',
+      organizationSlug: 'acme',
+      connection: { id: 'conn_1', name: 'Redis'.repeat(500) } as never,
+      ruleId: 'rule_1',
+      ruleName: 'Test rule'.repeat(500),
+      ruleType: 'job_failed',
+      queueName: 'jobs'.repeat(500),
+      summary: 'x'.repeat(40_000),
+      context: {
+        failedReason: 'y'.repeat(40_000),
+      },
+      firedAt: new Date('2026-05-25T12:00:00.000Z'),
+      appBaseUrl: 'https://app.durabull.io',
+    })
+
+    payload.links.dashboard = `https://app.durabull.io/${'z'.repeat(40_000)}`
+    payload.links.muteRule = `https://app.durabull.io/${'w'.repeat(40_000)}`
+
+    const body = serializeAlertWebhookPayload(payload)
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(32_768)
+    expect(JSON.parse(body).alert.context).toEqual({})
+  })
 })

--- a/apps/api/src/lib/alert-webhook-payload.test.ts
+++ b/apps/api/src/lib/alert-webhook-payload.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildAlertWebhookPayload,
+  serializeAlertWebhookPayload,
+  WEBHOOK_MAX_FAILED_REASON_LENGTH,
+} from './alert-webhook-payload'
+
+describe('buildAlertWebhookPayload', () => {
+  it('builds a versioned alert payload with links and sanitized context', () => {
+    const payload = buildAlertWebhookPayload({
+      eventType: 'alert.fired',
+      eventId: 'event_123',
+      deliveryId: 'delivery_456',
+      occurredAt: new Date('2026-05-25T12:00:00.000Z'),
+      organizationId: 'org_1',
+      organizationSlug: 'acme',
+      connection: {
+        id: 'conn_1',
+        name: 'Production Redis',
+      } as never,
+      ruleId: 'rule_1',
+      ruleName: 'High failure rate',
+      ruleType: 'failure_rate',
+      queueName: 'email-send',
+      summary: 'Failure rate exceeded threshold',
+      context: {
+        jobId: 'job_789',
+        failedReason: 'SMTP timeout',
+        attemptsMade: 3,
+      },
+      firedAt: new Date('2026-05-25T12:00:00.000Z'),
+      dedupeKey: 'queue:email-send',
+      appBaseUrl: 'https://app.durabull.io',
+    })
+
+    expect(payload.schemaVersion).toBe(1)
+    expect(payload.event).toBe('alert.fired')
+    expect(payload.links.job).toContain('/jobs/job_789')
+    expect(payload.alert.context.failedReason).toBe('SMTP timeout')
+    expect(payload.alert.dedupeKey).toBe('queue:email-send')
+  })
+
+  it('truncates long failedReason values in context', () => {
+    const payload = buildAlertWebhookPayload({
+      eventType: 'alert.test',
+      eventId: 'event_test',
+      deliveryId: 'delivery_test',
+      occurredAt: new Date('2026-05-25T12:00:00.000Z'),
+      organizationId: 'org_1',
+      organizationSlug: null,
+      connection: { id: 'conn_1', name: 'Redis' } as never,
+      ruleId: 'rule_1',
+      ruleName: 'Test rule',
+      ruleType: 'job_failed',
+      queueName: 'jobs',
+      summary: 'Test summary',
+      context: {
+        failedReason: 'x'.repeat(WEBHOOK_MAX_FAILED_REASON_LENGTH + 50),
+      },
+      firedAt: new Date('2026-05-25T12:00:00.000Z'),
+      appBaseUrl: 'https://app.durabull.io',
+    })
+
+    expect(payload.alert.context.failedReason).toHaveLength(WEBHOOK_MAX_FAILED_REASON_LENGTH)
+    expect(String(payload.alert.context.failedReason).endsWith('...')).toBe(true)
+  })
+})
+
+describe('serializeAlertWebhookPayload', () => {
+  it('returns JSON within the configured max body size', () => {
+    const payload = buildAlertWebhookPayload({
+      eventType: 'alert.test',
+      eventId: 'event_test',
+      deliveryId: 'delivery_test',
+      occurredAt: new Date('2026-05-25T12:00:00.000Z'),
+      organizationId: 'org_1',
+      organizationSlug: null,
+      connection: { id: 'conn_1', name: 'Redis' } as never,
+      ruleId: 'rule_1',
+      ruleName: 'Test rule',
+      ruleType: 'job_failed',
+      queueName: 'jobs',
+      summary: 'Test summary',
+      context: {
+        failedReason: 'x'.repeat(10_000),
+      },
+      firedAt: new Date('2026-05-25T12:00:00.000Z'),
+      appBaseUrl: 'https://app.durabull.io',
+    })
+
+    const body = serializeAlertWebhookPayload(payload)
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(32_768)
+  })
+})

--- a/apps/api/src/lib/alert-webhook-payload.ts
+++ b/apps/api/src/lib/alert-webhook-payload.ts
@@ -153,7 +153,53 @@ export function serializeAlertWebhookPayload(payload: AlertWebhookPayload): stri
     }
   }
 
-  return JSON.stringify(current)
+  const minimalPayload = buildMinimalWebhookPayload(current)
+  const minimalBody = JSON.stringify(minimalPayload)
+  if (Buffer.byteLength(minimalBody, 'utf8') <= WEBHOOK_MAX_BODY_BYTES) {
+    return minimalBody
+  }
+
+  throw new Error(
+    `Webhook payload exceeds ${WEBHOOK_MAX_BODY_BYTES} bytes even after truncation.`
+  )
+}
+
+function buildMinimalWebhookPayload(payload: AlertWebhookPayload): AlertWebhookPayload {
+  return {
+    schemaVersion: 1,
+    event: payload.event,
+    id: payload.id,
+    deliveryId: payload.deliveryId,
+    occurredAt: payload.occurredAt,
+    organization: {
+      id: payload.organization.id,
+      slug: payload.organization.slug,
+    },
+    connection: {
+      id: payload.connection.id,
+      name: truncateString(payload.connection.name, 200),
+    },
+    rule: {
+      id: payload.rule.id,
+      name: truncateString(payload.rule.name, 200),
+      type: payload.rule.type,
+    },
+    queue: {
+      name: truncateString(payload.queue.name, 200),
+    },
+    alert: {
+      status: 'firing',
+      summary: truncateString(payload.alert.summary, 200),
+      context: {},
+      firedAt: payload.alert.firedAt,
+      dedupeKey: payload.alert.dedupeKey,
+    },
+    links: {
+      dashboard: truncateString(payload.links.dashboard, 500),
+      job: payload.links.job ? truncateString(payload.links.job, 500) : null,
+      muteRule: truncateString(payload.links.muteRule, 500),
+    },
+  }
 }
 
 function getJobIdFromContext(context: Record<string, unknown> | null | undefined): string | null {

--- a/apps/api/src/lib/alert-webhook-payload.ts
+++ b/apps/api/src/lib/alert-webhook-payload.ts
@@ -1,0 +1,205 @@
+import type { AlertEvent, AlertRuleType, RedisConnection } from '@durabull/dal'
+import { buildAlertAppUrls } from './alert-app-urls'
+
+export const WEBHOOK_MAX_BODY_BYTES = 32_768
+export const WEBHOOK_MAX_FAILED_REASON_LENGTH = 2_000
+export const WEBHOOK_MAX_STRING_FIELD_LENGTH = 2_000
+
+export type AlertWebhookEventType = 'alert.fired' | 'alert.test'
+
+export interface AlertWebhookPayload {
+  schemaVersion: 1
+  event: AlertWebhookEventType
+  id: string
+  deliveryId: string
+  occurredAt: string
+  organization: { id: string; slug: string | null }
+  connection: { id: string; name: string }
+  rule: { id: string; name: string; type: AlertRuleType | string }
+  queue: { name: string }
+  alert: {
+    status: 'firing'
+    summary: string
+    context: Record<string, unknown>
+    firedAt: string
+    dedupeKey: string | null
+  }
+  links: {
+    dashboard: string
+    job: string | null
+    muteRule: string
+  }
+}
+
+export interface BuildAlertWebhookPayloadInput {
+  eventType: AlertWebhookEventType
+  eventId: string
+  deliveryId: string
+  occurredAt: Date
+  organizationId: string
+  organizationSlug: string | null
+  connection: RedisConnection
+  ruleId: string
+  ruleName: string
+  ruleType: AlertRuleType | string
+  queueName: string
+  summary: string
+  context: Record<string, unknown> | null | undefined
+  firedAt: Date
+  dedupeKey?: string | null
+  appBaseUrl: string
+}
+
+export function buildAlertWebhookPayload(
+  input: BuildAlertWebhookPayloadInput
+): AlertWebhookPayload {
+  const jobId = getJobIdFromContext(input.context)
+  const links = buildAlertAppUrls({
+    appBaseUrl: input.appBaseUrl,
+    organizationSlug: input.organizationSlug,
+    connectionId: input.connection.id,
+    queueName: input.queueName,
+    alertRuleId: input.ruleId,
+    jobId,
+  })
+
+  return {
+    schemaVersion: 1,
+    event: input.eventType,
+    id: input.eventId,
+    deliveryId: input.deliveryId,
+    occurredAt: input.occurredAt.toISOString(),
+    organization: {
+      id: input.organizationId,
+      slug: input.organizationSlug,
+    },
+    connection: {
+      id: input.connection.id,
+      name: input.connection.name,
+    },
+    rule: {
+      id: input.ruleId,
+      name: input.ruleName,
+      type: input.ruleType,
+    },
+    queue: {
+      name: input.queueName,
+    },
+    alert: {
+      status: 'firing',
+      summary: truncateString(input.summary, WEBHOOK_MAX_STRING_FIELD_LENGTH),
+      context: sanitizeAlertContext(input.context),
+      firedAt: input.firedAt.toISOString(),
+      dedupeKey: input.dedupeKey ?? null,
+    },
+    links: {
+      dashboard: links.dashboardUrl,
+      job: jobId ? links.jobUrl : null,
+      muteRule: links.muteUrl,
+    },
+  }
+}
+
+export function buildAlertWebhookPayloadFromEvent(
+  event: AlertEvent,
+  deliveryId: string,
+  connection: RedisConnection,
+  ruleName: string,
+  organizationSlug: string | null,
+  appBaseUrl: string
+): AlertWebhookPayload {
+  return buildAlertWebhookPayload({
+    eventType: 'alert.fired',
+    eventId: event.id,
+    deliveryId,
+    occurredAt: event.firedAt,
+    organizationId: event.organizationId,
+    organizationSlug,
+    connection,
+    ruleId: event.alertRuleId,
+    ruleName,
+    ruleType: event.type,
+    queueName: event.queueName,
+    summary: event.summary,
+    context: (event.context ?? {}) as Record<string, unknown>,
+    firedAt: event.firedAt,
+    dedupeKey: event.dedupeKey,
+    appBaseUrl,
+  })
+}
+
+export function serializeAlertWebhookPayload(payload: AlertWebhookPayload): string {
+  let current = payload
+  const summaryLimits = [WEBHOOK_MAX_STRING_FIELD_LENGTH, 500, 200]
+
+  for (let attempt = 0; attempt < summaryLimits.length; attempt++) {
+    const body = JSON.stringify(current)
+    if (Buffer.byteLength(body, 'utf8') <= WEBHOOK_MAX_BODY_BYTES) {
+      return body
+    }
+
+    current = {
+      ...current,
+      alert: {
+        ...current.alert,
+        summary: truncateString(current.alert.summary, summaryLimits[attempt] ?? 200),
+        context:
+          attempt === 0
+            ? truncateContextForSize(current.alert.context)
+            : attempt === 1
+              ? {}
+              : current.alert.context,
+      },
+    }
+  }
+
+  return JSON.stringify(current)
+}
+
+function getJobIdFromContext(context: Record<string, unknown> | null | undefined): string | null {
+  if (!context || typeof context !== 'object') return null
+  return typeof context.jobId === 'string' ? context.jobId : null
+}
+
+function sanitizeAlertContext(
+  context: Record<string, unknown> | null | undefined
+): Record<string, unknown> {
+  if (!context || typeof context !== 'object') return {}
+
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(context)) {
+    if (typeof value === 'string') {
+      const maxLength =
+        key === 'failedReason' ? WEBHOOK_MAX_FAILED_REASON_LENGTH : WEBHOOK_MAX_STRING_FIELD_LENGTH
+      sanitized[key] = truncateString(value, maxLength)
+      continue
+    }
+    if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+      sanitized[key] = value
+      continue
+    }
+    if (Array.isArray(value)) {
+      sanitized[key] = value.slice(0, 50)
+      continue
+    }
+  }
+  return sanitized
+}
+
+function truncateContextForSize(context: Record<string, unknown>): Record<string, unknown> {
+  const next: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(context)) {
+    if (typeof value === 'string') {
+      next[key] = truncateString(value, 250)
+    } else {
+      next[key] = value
+    }
+  }
+  return next
+}
+
+function truncateString(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= maxLength) return normalized
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`
+}

--- a/apps/api/src/lib/alert-webhook-rate-limit.ts
+++ b/apps/api/src/lib/alert-webhook-rate-limit.ts
@@ -1,0 +1,31 @@
+import { sendTestWebhookDelivery, type TestWebhookDeliveryInput } from './alert-webhook-test'
+
+const TEST_WEBHOOK_LIMIT = 10
+const TEST_WEBHOOK_WINDOW_MS = 60_000
+const testWebhookAttempts = new Map<string, number[]>()
+
+export async function sendRateLimitedTestWebhook(input: TestWebhookDeliveryInput) {
+  const now = Date.now()
+  const attempts = (testWebhookAttempts.get(input.organizationId) ?? []).filter(
+    (timestamp) => now - timestamp < TEST_WEBHOOK_WINDOW_MS
+  )
+
+  if (attempts.length >= TEST_WEBHOOK_LIMIT) {
+    return {
+      success: false,
+      httpStatus: null,
+      durationMs: 0,
+      retryable: false,
+      error: 'Webhook test rate limit exceeded. Try again in a minute.',
+    } as const
+  }
+
+  attempts.push(now)
+  testWebhookAttempts.set(input.organizationId, attempts)
+
+  return sendTestWebhookDelivery(input)
+}
+
+export function resetTestWebhookRateLimitsForTests(): void {
+  testWebhookAttempts.clear()
+}

--- a/apps/api/src/lib/alert-webhook-test.ts
+++ b/apps/api/src/lib/alert-webhook-test.ts
@@ -1,0 +1,58 @@
+import type { AlertRuleType } from '@durabull/dal'
+import { env } from '@durabull/env'
+import { randomUUID } from 'node:crypto'
+import { deliverWebhook } from './alert-webhook-client'
+import { buildAlertWebhookPayload, serializeAlertWebhookPayload } from './alert-webhook-payload'
+
+export interface TestWebhookDeliveryInput {
+  url: string
+  secret?: string | null
+  organizationId: string
+  organizationSlug: string | null
+  connectionId: string
+  connectionName: string
+  ruleId?: string
+  ruleName?: string
+  ruleType?: AlertRuleType | string
+  queueName?: string
+}
+
+export async function sendTestWebhookDelivery(input: TestWebhookDeliveryInput) {
+  const eventId = randomUUID()
+  const deliveryId = randomUUID()
+  const now = new Date()
+
+  const payload = buildAlertWebhookPayload({
+    eventType: 'alert.test',
+    eventId,
+    deliveryId,
+    occurredAt: now,
+    organizationId: input.organizationId,
+    organizationSlug: input.organizationSlug,
+    connection: {
+      id: input.connectionId,
+      name: input.connectionName,
+    } as never,
+    ruleId: input.ruleId ?? 'test-rule',
+    ruleName: input.ruleName ?? 'Webhook test',
+    ruleType: input.ruleType ?? 'job_failed',
+    queueName: input.queueName ?? 'example-queue',
+    summary: 'This is a test alert from Durabull.',
+    context: {
+      test: true,
+      message: 'Webhook delivery test payload.',
+    },
+    firedAt: now,
+    dedupeKey: null,
+    appBaseUrl: env.APP_BASE_URL,
+  })
+
+  const body = serializeAlertWebhookPayload(payload)
+  return deliverWebhook({
+    url: input.url,
+    body,
+    secret: input.secret,
+    deliveryId,
+    idempotencyKey: eventId,
+  })
+}

--- a/apps/api/src/lib/alert-webhook-url.ts
+++ b/apps/api/src/lib/alert-webhook-url.ts
@@ -8,15 +8,30 @@ const BLOCKED_HOSTNAMES = new Set([
   'metadata.google.internal',
 ])
 
+export interface ResolvedWebhookEndpoint {
+  hostname: string
+  port: number
+  protocol: 'http:' | 'https:'
+  path: string
+  pinnedAddress: string
+}
+
 function isPrivateIpv4(octets: number[]): boolean {
-  const [a, b] = octets
+  const [a, b, c] = octets
+  if (a === 0) return true
   if (a === 10) return true
   if (a === 127) return true
-  if (a === 0) return true
+  if (a === 100 && b >= 64 && b <= 127) return true // CGNAT
   if (a === 169 && b === 254) return true
   if (a === 172 && b >= 16 && b <= 31) return true
   if (a === 192 && b === 168) return true
-  if (a === 100 && b >= 64 && b <= 127) return true // CGNAT
+  if (a === 192 && b === 0) return true // 192.0.0.0/24
+  if (a === 192 && b === 0 && c === 2) return true // TEST-NET-1
+  if (a === 192 && b === 88 && c === 99) return true
+  if (a === 198 && (b === 18 || b === 19)) return true // benchmarking
+  if (a === 198 && b === 51 && c === 100) return true // TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return true // TEST-NET-3
+  if (a >= 224) return true // multicast + reserved
   return false
 }
 
@@ -49,6 +64,33 @@ function isHttpAllowed(): boolean {
   return env.DURABULL_WEBHOOK_ALLOW_HTTP === true || env.NODE_ENV === 'development'
 }
 
+function assertAllowedProtocol(parsed: URL): void {
+  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isHttpAllowed())) {
+    throw new WebhookUrlError('Webhook URL must use HTTPS.')
+  }
+}
+
+function assertAllowedHostname(hostname: string): void {
+  const normalized = hostname.toLowerCase()
+  if (BLOCKED_HOSTNAMES.has(normalized) || normalized.endsWith('.localhost')) {
+    throw new WebhookUrlError('Webhook URL hostname is not allowed.')
+  }
+}
+
+function assertAllowedAddresses(addresses: string[]): string {
+  if (addresses.length === 0) {
+    throw new WebhookUrlError('Webhook URL hostname could not be resolved.')
+  }
+
+  for (const address of addresses) {
+    if (isPrivateIpAddress(address)) {
+      throw new WebhookUrlError('Webhook URL must not target private or local IP addresses.')
+    }
+  }
+
+  return addresses[0]!
+}
+
 export function normalizeWebhookUrl(rawUrl: string): string {
   const parsed = new URL(rawUrl)
   parsed.hash = ''
@@ -61,33 +103,43 @@ export function getWebhookDeliveryTarget(rawUrl: string): string {
   return `${parsed.origin}${parsed.pathname}${parsed.search}`
 }
 
-export async function assertAllowedWebhookUrl(rawUrl: string): Promise<void> {
+export async function resolveAllowedWebhookEndpoint(rawUrl: string): Promise<ResolvedWebhookEndpoint> {
   let parsed: URL
   try {
-    parsed = new URL(rawUrl)
+    parsed = new URL(normalizeWebhookUrl(rawUrl))
   } catch {
     throw new WebhookUrlError('Webhook URL must be a valid URL.')
   }
 
-  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isHttpAllowed())) {
-    throw new WebhookUrlError('Webhook URL must use HTTPS.')
-  }
+  assertAllowedProtocol(parsed)
 
   if (parsed.username || parsed.password) {
     throw new WebhookUrlError('Webhook URL must not include credentials.')
   }
 
   const hostname = parsed.hostname.toLowerCase()
-  if (BLOCKED_HOSTNAMES.has(hostname) || hostname.endsWith('.localhost')) {
-    throw new WebhookUrlError('Webhook URL hostname is not allowed.')
-  }
+  assertAllowedHostname(hostname)
+
+  const port =
+    parsed.port !== ''
+      ? Number(parsed.port)
+      : parsed.protocol === 'https:'
+        ? 443
+        : 80
+  const path = `${parsed.pathname}${parsed.search}`
 
   const directIpVersion = isIP(hostname)
   if (directIpVersion !== 0) {
     if (isPrivateIpAddress(hostname)) {
       throw new WebhookUrlError('Webhook URL must not target private or local IP addresses.')
     }
-    return
+    return {
+      hostname,
+      port,
+      protocol: parsed.protocol as 'http:' | 'https:',
+      path,
+      pinnedAddress: hostname,
+    }
   }
 
   let addresses: string[]
@@ -98,15 +150,19 @@ export async function assertAllowedWebhookUrl(rawUrl: string): Promise<void> {
     throw new WebhookUrlError('Webhook URL hostname could not be resolved.')
   }
 
-  if (addresses.length === 0) {
-    throw new WebhookUrlError('Webhook URL hostname could not be resolved.')
-  }
+  const pinnedAddress = assertAllowedAddresses(addresses)
 
-  for (const address of addresses) {
-    if (isPrivateIpAddress(address)) {
-      throw new WebhookUrlError('Webhook URL must not target private or local IP addresses.')
-    }
+  return {
+    hostname,
+    port,
+    protocol: parsed.protocol as 'http:' | 'https:',
+    path,
+    pinnedAddress,
   }
+}
+
+export async function assertAllowedWebhookUrl(rawUrl: string): Promise<void> {
+  await resolveAllowedWebhookEndpoint(rawUrl)
 }
 
 export class WebhookUrlError extends Error {

--- a/apps/api/src/lib/alert-webhook-url.ts
+++ b/apps/api/src/lib/alert-webhook-url.ts
@@ -1,0 +1,117 @@
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+import { env } from '@durabull/env'
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  'metadata.google.internal',
+])
+
+function isPrivateIpv4(octets: number[]): boolean {
+  const [a, b] = octets
+  if (a === 10) return true
+  if (a === 127) return true
+  if (a === 0) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 100 && b >= 64 && b <= 127) return true // CGNAT
+  return false
+}
+
+function isPrivateIpv6(address: string): boolean {
+  const normalized = address.toLowerCase()
+  if (normalized === '::1') return true
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true
+  if (normalized.startsWith('fe80:')) return true
+  if (normalized.startsWith('::ffff:')) {
+    const mapped = normalized.slice('::ffff:'.length)
+    if (isIP(mapped) === 4) {
+      return isPrivateIpv4(mapped.split('.').map(Number))
+    }
+  }
+  return false
+}
+
+function isPrivateIpAddress(address: string): boolean {
+  const version = isIP(address)
+  if (version === 4) {
+    return isPrivateIpv4(address.split('.').map(Number))
+  }
+  if (version === 6) {
+    return isPrivateIpv6(address)
+  }
+  return true
+}
+
+function isHttpAllowed(): boolean {
+  return env.DURABULL_WEBHOOK_ALLOW_HTTP === true || env.NODE_ENV === 'development'
+}
+
+export function normalizeWebhookUrl(rawUrl: string): string {
+  const parsed = new URL(rawUrl)
+  parsed.hash = ''
+  return parsed.toString()
+}
+
+export function getWebhookDeliveryTarget(rawUrl: string): string {
+  const parsed = new URL(rawUrl)
+  parsed.hash = ''
+  return `${parsed.origin}${parsed.pathname}${parsed.search}`
+}
+
+export async function assertAllowedWebhookUrl(rawUrl: string): Promise<void> {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new WebhookUrlError('Webhook URL must be a valid URL.')
+  }
+
+  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isHttpAllowed())) {
+    throw new WebhookUrlError('Webhook URL must use HTTPS.')
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new WebhookUrlError('Webhook URL must not include credentials.')
+  }
+
+  const hostname = parsed.hostname.toLowerCase()
+  if (BLOCKED_HOSTNAMES.has(hostname) || hostname.endsWith('.localhost')) {
+    throw new WebhookUrlError('Webhook URL hostname is not allowed.')
+  }
+
+  const directIpVersion = isIP(hostname)
+  if (directIpVersion !== 0) {
+    if (isPrivateIpAddress(hostname)) {
+      throw new WebhookUrlError('Webhook URL must not target private or local IP addresses.')
+    }
+    return
+  }
+
+  let addresses: string[]
+  try {
+    const result = await lookup(hostname, { all: true, verbatim: true })
+    addresses = result.map((entry) => entry.address)
+  } catch {
+    throw new WebhookUrlError('Webhook URL hostname could not be resolved.')
+  }
+
+  if (addresses.length === 0) {
+    throw new WebhookUrlError('Webhook URL hostname could not be resolved.')
+  }
+
+  for (const address of addresses) {
+    if (isPrivateIpAddress(address)) {
+      throw new WebhookUrlError('Webhook URL must not target private or local IP addresses.')
+    }
+  }
+}
+
+export class WebhookUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WebhookUrlError'
+  }
+}

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   alertCheckCursorRepository,
+  alertDeliveryRepository,
   alertEventRepository,
   alertRuleRepository,
   closeDb,
@@ -368,5 +369,137 @@ describe('alerts routes', () => {
     expect(await resolveResponse.json()).toMatchObject({
       event: expect.objectContaining({ id: event.id, status: 'resolved' }),
     })
+  })
+
+  it('rejects webhook URLs that target private networks', async () => {
+    const app = await createAlertsRouteApp()
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Webhook SSRF guard',
+        type: 'job_failed',
+        queueName: 'email-send',
+        config: { maxIssuesPerPoll: 10 },
+        notificationChannels: [{ type: 'webhook', url: 'https://127.0.0.1/hook' }],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      error: expect.stringContaining('private or local IP'),
+    })
+  })
+
+  it('masks webhook secrets when returning alert rules', async () => {
+    const app = await createAlertsRouteApp()
+
+    const createResponse = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Webhook secret masking',
+        type: 'job_failed',
+        queueName: 'email-send',
+        config: { maxIssuesPerPoll: 10 },
+        notificationChannels: [
+          {
+            type: 'webhook',
+            url: 'https://example.com/hook',
+            secret: 'abcdefghijklmnop',
+          },
+        ],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(createResponse.status).toBe(201)
+    const createBody = (await createResponse.json()) as {
+      rule: { notificationChannels: Array<Record<string, unknown>> }
+    }
+    expect(createBody.rule.notificationChannels[0]).toEqual({
+      type: 'webhook',
+      url: 'https://example.com/hook',
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+
+    const listResponse = await app.request('/rules')
+    const listBody = (await listResponse.json()) as {
+      rules: Array<{ notificationChannels: Array<Record<string, unknown>> }>
+    }
+    expect(listBody.rules[0]?.notificationChannels[0]).toEqual({
+      type: 'webhook',
+      url: 'https://example.com/hook',
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+  })
+
+  it('masks webhook secrets in event delivery metadata', async () => {
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      name: 'Webhook delivery masking',
+      type: 'job_failed',
+      config: { maxIssuesPerPoll: 10 },
+      notificationChannels: [
+        {
+          type: 'webhook',
+          url: 'https://example.com/hook',
+          secret: 'abcdefghijklmnop',
+        },
+      ],
+      cooldownMinutes: 30,
+    })
+
+    const event = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      type: rule.type,
+      status: 'firing',
+      summary: 'Webhook delivery test',
+      context: {},
+      firedAt: new Date(),
+    })
+
+    await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'webhook',
+        target: 'https://example.com/hook',
+        providerMetadata: {
+          type: 'webhook',
+          url: 'https://example.com/hook',
+          secret: 'abcdefghijklmnop',
+          httpStatus: 503,
+        },
+      },
+    ])
+
+    const app = await createAlertsRouteApp()
+    const response = await app.request('/events?status=firing')
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as {
+      events: Array<{
+        deliveries: Array<{ providerMetadata?: Record<string, unknown> }>
+      }>
+    }
+    const delivery = body.events.find((entry) => entry.deliveries.length > 0)?.deliveries[0]
+    expect(delivery?.providerMetadata).toEqual({
+      type: 'webhook',
+      url: 'https://example.com/hook',
+      httpStatus: 503,
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+    expect(delivery?.providerMetadata?.secret).toBeUndefined()
   })
 })

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -3,13 +3,24 @@ import {
   alertDeliveryRepository,
   alertEventRepository,
   alertRuleRepository,
+  eq,
+  getDb,
   linearIntegrationRepository,
+  organization,
   redisDiscoveredQueueRepository,
 } from '@durabull/dal'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { type CursorState, evaluateRule, type QueueSnapshot } from '../lib/alert-evaluator'
+import {
+  mergeWebhookSecretsOnUpdate,
+  resolveWebhookTestSecret,
+  sanitizeDeliveryProviderMetadata,
+  sanitizeNotificationChannels,
+  validateWebhookUrls,
+} from '../lib/alert-webhook-channels'
+import { sendRateLimitedTestWebhook } from '../lib/alert-webhook-rate-limit'
 import { getConnectionRedisOptions } from '../lib/connection-options'
 import { getQueue } from '../lib/redis'
 
@@ -30,10 +41,22 @@ const linearNotificationChannelSchema = z.object({
   stateId: z.string().min(1).optional(),
   priority: z.number().int().min(0).max(4).optional(),
 })
+const webhookNotificationChannelSchema = z.object({
+  type: z.literal('webhook'),
+  url: z.string().url().max(2048),
+  secret: z.string().min(16).max(256).optional(),
+})
 const notificationChannelSchema = z.discriminatedUnion('type', [
   emailNotificationChannelSchema,
   linearNotificationChannelSchema,
+  webhookNotificationChannelSchema,
 ])
+
+const testWebhookSchema = z.object({
+  url: z.string().url().max(2048),
+  secret: z.string().min(16).max(256).optional(),
+  ruleId: z.string().uuid().optional(),
+})
 
 const createRuleSchema = z.object({
   name: z.string().min(1).max(200),
@@ -68,7 +91,14 @@ const app = new Hono()
     }
 
     const rules = await alertRuleRepository.findByConnection(connectionId, organizationId)
-    return c.json({ rules })
+    return c.json({
+      rules: rules.map((rule) => ({
+        ...rule,
+        notificationChannels: sanitizeNotificationChannels(
+          Array.isArray(rule.notificationChannels) ? rule.notificationChannels : []
+        ),
+      })),
+    })
   })
   .post('/rules', zValidator('json', createRuleSchema), async (c) => {
     const body = c.req.valid('json')
@@ -101,7 +131,17 @@ const app = new Hono()
       organizationId,
     })
 
-    return c.json({ rule }, 201)
+    return c.json(
+      {
+        rule: {
+          ...rule,
+          notificationChannels: sanitizeNotificationChannels(
+            Array.isArray(rule.notificationChannels) ? rule.notificationChannels : []
+          ),
+        },
+      },
+      201
+    )
   })
   .patch('/rules/:ruleId', zValidator('json', updateRuleSchema), async (c) => {
     const { ruleId } = c.req.param()
@@ -132,6 +172,10 @@ const app = new Hono()
       if (channelError) {
         return c.json({ error: channelError }, 400)
       }
+      body.notificationChannels = mergeWebhookSecretsOnUpdate(
+        body.notificationChannels,
+        (existingRule.notificationChannels ?? []) as unknown[]
+      )
     }
 
     const rule = await alertRuleRepository.update(ruleId, organizationId, body)
@@ -143,7 +187,14 @@ const app = new Hono()
       await alertEventRepository.resolveAllForRule(rule.id)
     }
 
-    return c.json({ rule })
+    return c.json({
+      rule: {
+        ...rule,
+        notificationChannels: sanitizeNotificationChannels(
+          Array.isArray(rule.notificationChannels) ? rule.notificationChannels : []
+        ),
+      },
+    })
   })
   .delete('/rules/:ruleId', async (c) => {
     const { ruleId } = c.req.param()
@@ -162,8 +213,18 @@ const app = new Hono()
 
     return c.json({ success: true })
   })
-  .post('/rules/:ruleId/test', async (c) => {
+  .post(
+    '/rules/:ruleId/test',
+    zValidator(
+      'query',
+      z.object({
+        deliver: z.enum(['true', 'false']).optional(),
+      })
+    ),
+    async (c) => {
     const { ruleId } = c.req.param()
+    const { deliver: deliverQuery } = c.req.valid('query')
+    const deliver = deliverQuery === 'true'
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
@@ -230,7 +291,110 @@ const app = new Hono()
       : null
 
     const evaluation = evaluateRule(rule, snapshot, cursor)
-    return c.json({ evaluation, snapshot })
+
+    const webhookChannels = (Array.isArray(rule.notificationChannels) ? rule.notificationChannels : [])
+      .filter(
+        (channel): channel is { type: 'webhook'; url: string; secret?: string } =>
+          typeof channel === 'object' &&
+          channel !== null &&
+          (channel as { type?: string }).type === 'webhook' &&
+          typeof (channel as { url?: string }).url === 'string'
+      )
+
+    let webhookTests:
+      | Array<{
+          url: string
+          success: boolean
+          httpStatus: number | null
+          durationMs: number
+          error?: string
+        }>
+      | undefined
+
+    if (deliver && webhookChannels.length > 0) {
+      const organizationSlug = await getOrganizationSlug(organizationId)
+      webhookTests = await Promise.all(
+        webhookChannels.map(async (channel) => {
+          const result = await sendRateLimitedTestWebhook({
+            url: channel.url,
+            secret: channel.secret,
+            organizationId,
+            organizationSlug,
+            connectionId,
+            connectionName,
+            ruleId: rule.id,
+            ruleName: rule.name,
+            ruleType: rule.type,
+            queueName,
+          })
+          return {
+            url: channel.url,
+            success: result.success,
+            httpStatus: result.httpStatus,
+            durationMs: result.durationMs,
+            error: result.error,
+          }
+        })
+      )
+    }
+
+    return c.json({ evaluation, snapshot, webhookTests })
+  })
+  .post('/webhooks/test', zValidator('json', testWebhookSchema), async (c) => {
+    const body = c.req.valid('json')
+    const connectionId = c.get('connectionId')
+    const connectionName = c.get('connectionName')
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    let ruleName = 'Webhook test'
+    let ruleType = 'job_failed'
+    let queueName = 'example-queue'
+    let ruleChannels: unknown[] | null = null
+
+    if (body.ruleId) {
+      const rule = await alertRuleRepository.findById(body.ruleId, organizationId)
+      if (!rule) {
+        return c.json({ error: 'Rule not found' }, 404)
+      }
+      ruleName = rule.name
+      ruleType = rule.type
+      queueName = rule.queueName ?? queueName
+      ruleChannels = Array.isArray(rule.notificationChannels) ? rule.notificationChannels : []
+    }
+
+    const secret = resolveWebhookTestSecret(body.url, body.secret, ruleChannels)
+    const urlError = await validateWebhookUrls([{ type: 'webhook', url: body.url, secret }])
+    if (urlError) {
+      return c.json({ error: urlError }, 400)
+    }
+
+    const organizationSlug = await getOrganizationSlug(organizationId)
+    const result = await sendRateLimitedTestWebhook({
+      url: body.url,
+      secret,
+      organizationId,
+      organizationSlug,
+      connectionId,
+      connectionName,
+      ruleId: body.ruleId,
+      ruleName,
+      ruleType,
+      queueName,
+    })
+
+    if (result.error?.includes('rate limit')) {
+      return c.json({ error: result.error }, 429)
+    }
+
+    return c.json({
+      success: result.success,
+      httpStatus: result.httpStatus,
+      durationMs: result.durationMs,
+      error: result.error,
+    })
   })
   .get(
     '/events',
@@ -281,7 +445,12 @@ async function attachDeliveries<T extends { id: string }>(events: T[]) {
   return Promise.all(
     events.map(async (event) => ({
       ...event,
-      deliveries: await alertDeliveryRepository.listByEvent(event.id),
+      deliveries: (await alertDeliveryRepository.listByEvent(event.id)).map((delivery) => ({
+        ...delivery,
+        providerMetadata: sanitizeDeliveryProviderMetadata(
+          delivery.providerMetadata as Record<string, unknown> | null | undefined
+        ),
+      })),
     }))
   )
 }
@@ -328,6 +497,11 @@ async function validateNotificationChannels(
   channels: z.infer<typeof notificationChannelSchema>[],
   organizationId: string
 ): Promise<string | null> {
+  const webhookError = await validateWebhookUrls(
+    channels.filter((channel) => channel.type === 'webhook')
+  )
+  if (webhookError) return webhookError
+
   const linearChannels = channels.filter((channel) => channel.type === 'linear')
   if (linearChannels.length > 1) {
     return 'Only one Linear notification channel is supported per rule.'
@@ -343,6 +517,17 @@ async function validateNotificationChannels(
     (channel) => !channel.teamId && !integration.defaultTeamId
   )
   return missingTeam ? 'Linear alert routing requires a teamId or organization default team.' : null
+}
+
+async function getOrganizationSlug(organizationId: string): Promise<string | null> {
+  const db = await getDb()
+  const rows = await db
+    .select({ slug: organization.slug })
+    .from(organization)
+    .where(eq(organization.id, organizationId))
+    .limit(1)
+
+  return rows[0]?.slug ?? null
 }
 
 export default app

--- a/apps/docs/app/roadmap/page.tsx
+++ b/apps/docs/app/roadmap/page.tsx
@@ -28,6 +28,7 @@ export default function RoadmapPage() {
             items: [
               'Latency improvements for busy dashboards',
               'Queue health alerts',
+              'Webhook alert notifications',
               'Faster job replays',
             ],
           },
@@ -37,7 +38,7 @@ export default function RoadmapPage() {
             items: [
               'Role-based access controls',
               'Saved views and filters',
-              'Slack and webhook notifications',
+              'Slack notifications',
             ],
           },
           {

--- a/apps/docs/content/documentation/index.mdx
+++ b/apps/docs/content/documentation/index.mdx
@@ -67,6 +67,7 @@ If you are new, follow this order:
 
 - Alert routing:
   [Linear Integration](/documentation/integrations/linear)
+  [Webhook Notifications](/documentation/integrations/webhooks)
 
 ### Operations and Reference
 

--- a/apps/docs/content/documentation/index.mdx
+++ b/apps/docs/content/documentation/index.mdx
@@ -66,7 +66,7 @@ If you are new, follow this order:
 ### Integrations
 
 - Alert routing:
-  [Linear Integration](/documentation/integrations/linear)
+  [Linear Integration](/documentation/integrations/linear),
   [Webhook Notifications](/documentation/integrations/webhooks)
 
 ### Operations and Reference

--- a/apps/docs/content/documentation/integrations/webhooks.mdx
+++ b/apps/docs/content/documentation/integrations/webhooks.mdx
@@ -1,0 +1,107 @@
+---
+title: Webhook Notifications
+description: Route Durabull alert events to HTTPS webhook endpoints with signed JSON payloads.
+---
+
+Webhook notifications let alert rules POST structured JSON to any HTTPS endpoint you control.
+Use them for custom paging, automation (Zapier, n8n), internal incident systems, or middleware
+that forwards alerts into Slack or PagerDuty.
+
+## Setup
+
+1. Open a connection's alert rule builder.
+2. Add a **Webhook route** with your endpoint URL.
+3. Optionally add a signing secret (minimum 16 characters).
+4. Use **Send test webhook** to verify delivery before enabling the rule.
+
+Webhook routes are configured per alert rule, alongside email and Linear destinations.
+
+## Payload format
+
+Durabull sends versioned JSON with `schemaVersion: 1`.
+
+```json
+{
+  "schemaVersion": 1,
+  "event": "alert.fired",
+  "id": "alert-event-uuid",
+  "deliveryId": "delivery-uuid",
+  "occurredAt": "2026-05-25T12:00:00.000Z",
+  "organization": { "id": "org_123", "slug": "acme" },
+  "connection": { "id": "conn_123", "name": "Production Redis" },
+  "rule": { "id": "rule_123", "name": "High failure rate", "type": "failure_rate" },
+  "queue": { "name": "email-send" },
+  "alert": {
+    "status": "firing",
+    "summary": "Failure rate exceeded threshold",
+    "context": { "jobId": "42", "failedReason": "SMTP timeout" },
+    "firedAt": "2026-05-25T12:00:00.000Z",
+    "dedupeKey": null
+  },
+  "links": {
+    "dashboard": "https://app.durabull.io/acme/c/conn_123/queues/email-send",
+    "job": "https://app.durabull.io/acme/c/conn_123/queues/email-send/jobs/42",
+    "muteRule": "https://app.durabull.io/acme/c/conn_123/alerts?ruleId=rule_123"
+  }
+}
+```
+
+Test deliveries use `event: "alert.test"` with synthetic context.
+
+Durabull does not include full BullMQ `job.data` payloads in webhook bodies.
+
+## Request headers
+
+| Header | Description |
+| --- | --- |
+| `Content-Type` | `application/json` |
+| `User-Agent` | `Durabull-Alerts/1.0` |
+| `Idempotency-Key` | Alert event id — use to dedupe retries |
+| `X-Durabull-Delivery-Id` | Delivery attempt id |
+| `X-Durabull-Timestamp` | Unix seconds (when signing is enabled) |
+| `X-Durabull-Signature` | `sha256=<hex>` HMAC (when signing is enabled) |
+
+## Verifying signatures
+
+When a signing secret is configured, verify:
+
+```
+signature = HMAC-SHA256(secret, "{timestamp}.{rawBody}")
+```
+
+Reject requests older than five minutes to limit replay attacks.
+
+```typescript
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+function verifyDurabullWebhook(rawBody: string, headers: Headers, secret: string): boolean {
+  const timestamp = headers.get('x-durabull-timestamp')
+  const signature = headers.get('x-durabull-signature')
+  if (!timestamp || !signature) return false
+  if (Math.abs(Date.now() / 1000 - Number(timestamp)) > 300) return false
+
+  const expected = createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex')
+
+  const provided = signature.replace(/^sha256=/, '')
+  return timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
+}
+```
+
+## Delivery behavior
+
+- Durabull uses at-least-once delivery with exponential backoff retries.
+- Respond with any `2xx` status to acknowledge receipt.
+- `408`, `429`, and `5xx` responses are retried.
+- Most other `4xx` responses are treated as permanent failures.
+- Requests time out after 10 seconds.
+- Retry attempts stop after **7 days** from the first delivery enqueue. The delivery row is marked permanently failed so dead endpoints do not retry forever.
+
+## Security notes
+
+- Production webhook URLs must use HTTPS.
+- Durabull blocks private and localhost targets (SSRF protection).
+- Signing secrets are stored on the alert rule and masked in API responses after save.
+
+For local development only, set `DURABULL_WEBHOOK_ALLOW_HTTP=true` to permit HTTP webhook URLs.

--- a/apps/web/src/components/alerts/alert-events-table.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.tsx
@@ -167,6 +167,26 @@ function DeliverySummary({ event }: { event: AlertEventRecord }) {
     )
   }
 
+  const webhookDelivery = event.deliveries.find((delivery) => delivery.channelType === 'webhook')
+  if (webhookDelivery) {
+    const httpStatus = webhookDelivery.providerMetadata?.httpStatus
+    if (webhookDelivery.status === 'delivered') {
+      return (
+        <span className="text-xs text-muted-foreground">
+          Webhook {typeof httpStatus === 'number' ? `HTTP ${httpStatus}` : 'delivered'}
+        </span>
+      )
+    }
+    if (webhookDelivery.status === 'failed') {
+      return (
+        <span className="text-xs text-destructive">
+          Webhook failed{webhookDelivery.lastError ? `: ${webhookDelivery.lastError}` : ''}
+        </span>
+      )
+    }
+    return <span className="text-xs text-muted-foreground">Webhook pending</span>
+  }
+
   if (event.deliveries.length > 0) {
     const delivered = event.deliveries.filter((delivery) => delivery.status === 'delivered').length
     return (

--- a/apps/web/src/components/alerts/alert-rule-builder-page.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router'
-import { BellRing, ChevronLeft, ChevronRight, Mail, Plus, TestTube2, Trash2 } from 'lucide-react'
+import { BellRing, ChevronLeft, ChevronRight, Mail, Plus, TestTube2, Trash2, Webhook } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -12,6 +12,7 @@ import {
   createAlertRuleDraft,
   createLinearNotificationRouteDraft,
   createNotificationRouteDraft,
+  createWebhookNotificationRouteDraft,
   normalizeNotificationEmails,
   serializeAlertRuleDraftsForMode,
   validateAlertRuleDraft,
@@ -28,6 +29,7 @@ import type {
   AlertRuleType,
   AlertTestResult,
 } from '@/hooks/use-alerts'
+import { useTestWebhook } from '@/hooks/use-alerts'
 import { cn, formatNumber } from '@/lib/utils'
 
 interface AlertRuleBuilderPageProps {
@@ -42,6 +44,173 @@ interface AlertRuleBuilderPageProps {
   isSaving?: boolean
   isTesting?: boolean
   linearIntegrationConfigured?: boolean
+}
+
+function NotificationRouteFields({
+  route,
+  index,
+  ruleId,
+  connectionId,
+  onUpdate,
+}: {
+  route: AlertRuleDraft['notificationRoutes'][number]
+  index: number
+  ruleId?: string
+  connectionId: string
+  onUpdate: (nextRoute: AlertRuleDraft['notificationRoutes'][number]) => void
+}) {
+  const testWebhookMutation = useTestWebhook(connectionId)
+  const [testingRouteId, setTestingRouteId] = useState<string | null>(null)
+
+  async function handleTestWebhook() {
+    const url = route.webhookUrl?.trim() ?? route.target.trim()
+    if (!url) {
+      toast.error('Webhook URL is required before testing.')
+      return
+    }
+
+    setTestingRouteId(route.id)
+    try {
+      const result = await testWebhookMutation.mutateAsync({
+        url,
+        secret: route.webhookSecret?.trim() || undefined,
+        ruleId,
+      })
+      if (result.success) {
+        toast.success('Test webhook delivered', {
+          description: `HTTP ${result.httpStatus ?? 'unknown'} in ${result.durationMs}ms`,
+        })
+      } else {
+        toast.error('Test webhook failed', {
+          description: result.error ?? `HTTP ${result.httpStatus ?? 'unknown'}`,
+        })
+      }
+    } catch (error) {
+      toast.error('Test webhook failed', {
+        description: error instanceof Error ? error.message : 'Unable to send test webhook.',
+      })
+    } finally {
+      setTestingRouteId(null)
+    }
+  }
+
+  if (route.type === 'email') {
+    return (
+      <>
+        <div className="inline-flex items-center gap-2 text-sm font-medium">
+          <Mail className="h-4 w-4 text-muted-foreground" />
+          Email
+        </div>
+        <Input
+          value={route.target}
+          onChange={(event) => onUpdate({ ...route, target: event.target.value })}
+          placeholder="oncall@example.com"
+          data-testid={`alert-rule-email-${index}`}
+        />
+      </>
+    )
+  }
+
+  if (route.type === 'webhook') {
+    return (
+      <>
+        <div className="inline-flex items-center gap-2 text-sm font-medium">
+          <Webhook className="h-4 w-4 text-muted-foreground" />
+          Webhook
+        </div>
+        <div className="grid gap-2">
+          <Input
+            aria-label={`Webhook URL ${index + 1}`}
+            value={route.webhookUrl ?? route.target}
+            onChange={(event) =>
+              onUpdate({
+                ...route,
+                target: event.target.value,
+                webhookUrl: event.target.value,
+              })
+            }
+            placeholder="https://example.com/webhooks/durabull"
+            data-testid={`alert-rule-webhook-url-${index}`}
+          />
+          <Input
+            aria-label={`Webhook signing secret ${index + 1}`}
+            type="password"
+            value={route.webhookSecret ?? ''}
+            onChange={(event) => onUpdate({ ...route, webhookSecret: event.target.value })}
+            placeholder={
+              route.secretConfigured
+                ? `Optional — leave blank to keep existing (…${route.secretLast4 ?? ''})`
+                : 'Optional signing secret (min 16 characters)'
+            }
+            data-testid={`alert-rule-webhook-secret-${index}`}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="justify-self-start"
+            onClick={() => void handleTestWebhook()}
+            disabled={testingRouteId === route.id || testWebhookMutation.isPending}
+          >
+            {testingRouteId === route.id ? 'Sending test...' : 'Send test webhook'}
+          </Button>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <div className="inline-flex items-center gap-2 text-sm font-medium">Linear</div>
+      <div className="grid gap-2 md:grid-cols-3">
+        <Input
+          aria-label={`Linear team override ${index + 1}`}
+          value={route.teamId ?? ''}
+          onChange={(event) => onUpdate({ ...route, teamId: event.target.value })}
+          placeholder="Team ID (optional)"
+          data-testid={`alert-rule-linear-team-${index}`}
+        />
+        <Input
+          aria-label={`Linear project override ${index + 1}`}
+          value={route.projectId ?? ''}
+          onChange={(event) => onUpdate({ ...route, projectId: event.target.value })}
+          placeholder="Project ID"
+        />
+        <Input
+          aria-label={`Linear labels override ${index + 1}`}
+          value={route.labelIds?.join(', ') ?? ''}
+          onChange={(event) =>
+            onUpdate({
+              ...route,
+              labelIds: event.target.value
+                .split(',')
+                .map((label) => label.trim())
+                .filter(Boolean),
+            })
+          }
+          placeholder="Label IDs"
+        />
+        <Input
+          aria-label={`Linear assignee override ${index + 1}`}
+          value={route.assigneeId ?? ''}
+          onChange={(event) => onUpdate({ ...route, assigneeId: event.target.value })}
+          placeholder="Assignee ID"
+        />
+        <Input
+          aria-label={`Linear state override ${index + 1}`}
+          value={route.stateId ?? ''}
+          onChange={(event) => onUpdate({ ...route, stateId: event.target.value })}
+          placeholder="State ID"
+        />
+        <Input
+          aria-label={`Linear priority override ${index + 1}`}
+          value={route.priority ?? ''}
+          onChange={(event) => onUpdate({ ...route, priority: event.target.value })}
+          placeholder="Priority 0-4"
+        />
+      </div>
+    </>
+  )
 }
 
 const RULE_TYPE_EXAMPLES: Record<
@@ -144,6 +313,7 @@ export function AlertRuleBuilderPage({
     draft.notificationRoutes.filter((route) => route.type === 'email').map((route) => route.target)
   )
   const activeLinearRoutes = draft.notificationRoutes.filter((route) => route.type === 'linear')
+  const activeWebhookRoutes = draft.notificationRoutes.filter((route) => route.type === 'webhook')
   const routeLimitReached = draft.notificationRoutes.length >= 10
 
   async function handleSubmit() {
@@ -417,99 +587,19 @@ export function AlertRuleBuilderPage({
             {draft.notificationRoutes.map((route, index) => (
               <div
                 key={route.id}
-                className="grid grid-cols-[140px_minmax(0,1fr)_auto] items-center gap-3"
+                className="grid grid-cols-[140px_minmax(0,1fr)_auto] items-start gap-3"
               >
-                {route.type === 'email' ? (
-                  <>
-                    <div className="inline-flex items-center gap-2 text-sm font-medium">
-                      <Mail className="h-4 w-4 text-muted-foreground" />
-                      Email
-                    </div>
-                    <Input
-                      value={route.target}
-                      onChange={(event) => {
-                        const notificationRoutes = draft.notificationRoutes.slice()
-                        notificationRoutes[index] = { ...route, target: event.target.value }
-                        updateDraft({ notificationRoutes })
-                      }}
-                      placeholder="oncall@example.com"
-                      data-testid={`alert-rule-email-${index}`}
-                    />
-                  </>
-                ) : (
-                  <>
-                    <div className="inline-flex items-center gap-2 text-sm font-medium">Linear</div>
-                    <div className="grid gap-2 md:grid-cols-3">
-                      <Input
-                        aria-label={`Linear team override ${index + 1}`}
-                        value={route.teamId ?? ''}
-                        onChange={(event) => {
-                          const notificationRoutes = draft.notificationRoutes.slice()
-                          notificationRoutes[index] = { ...route, teamId: event.target.value }
-                          updateDraft({ notificationRoutes })
-                        }}
-                        placeholder="Team ID (optional)"
-                        data-testid={`alert-rule-linear-team-${index}`}
-                      />
-                      <Input
-                        aria-label={`Linear project override ${index + 1}`}
-                        value={route.projectId ?? ''}
-                        onChange={(event) => {
-                          const notificationRoutes = draft.notificationRoutes.slice()
-                          notificationRoutes[index] = { ...route, projectId: event.target.value }
-                          updateDraft({ notificationRoutes })
-                        }}
-                        placeholder="Project ID"
-                      />
-                      <Input
-                        aria-label={`Linear labels override ${index + 1}`}
-                        value={route.labelIds?.join(', ') ?? ''}
-                        onChange={(event) => {
-                          const notificationRoutes = draft.notificationRoutes.slice()
-                          notificationRoutes[index] = {
-                            ...route,
-                            labelIds: event.target.value
-                              .split(',')
-                              .map((label) => label.trim())
-                              .filter(Boolean),
-                          }
-                          updateDraft({ notificationRoutes })
-                        }}
-                        placeholder="Label IDs"
-                      />
-                      <Input
-                        aria-label={`Linear assignee override ${index + 1}`}
-                        value={route.assigneeId ?? ''}
-                        onChange={(event) => {
-                          const notificationRoutes = draft.notificationRoutes.slice()
-                          notificationRoutes[index] = { ...route, assigneeId: event.target.value }
-                          updateDraft({ notificationRoutes })
-                        }}
-                        placeholder="Assignee ID"
-                      />
-                      <Input
-                        aria-label={`Linear state override ${index + 1}`}
-                        value={route.stateId ?? ''}
-                        onChange={(event) => {
-                          const notificationRoutes = draft.notificationRoutes.slice()
-                          notificationRoutes[index] = { ...route, stateId: event.target.value }
-                          updateDraft({ notificationRoutes })
-                        }}
-                        placeholder="State ID"
-                      />
-                      <Input
-                        aria-label={`Linear priority override ${index + 1}`}
-                        value={route.priority ?? ''}
-                        onChange={(event) => {
-                          const notificationRoutes = draft.notificationRoutes.slice()
-                          notificationRoutes[index] = { ...route, priority: event.target.value }
-                          updateDraft({ notificationRoutes })
-                        }}
-                        placeholder="Priority 0-4"
-                      />
-                    </div>
-                  </>
-                )}
+                <NotificationRouteFields
+                  route={route}
+                  index={index}
+                  ruleId={rule?.id}
+                  connectionId={connectionId}
+                  onUpdate={(nextRoute) => {
+                    const notificationRoutes = draft.notificationRoutes.slice()
+                    notificationRoutes[index] = nextRoute
+                    updateDraft({ notificationRoutes })
+                  }}
+                />
                 <Button
                   type="button"
                   variant="ghost"
@@ -567,6 +657,23 @@ export function AlertRuleBuilderPage({
               <Plus className="mr-1.5 h-4 w-4" />
               Add Linear route
             </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (routeLimitReached) return
+                updateDraft({
+                  notificationRoutes: [
+                    ...draft.notificationRoutes,
+                    createWebhookNotificationRouteDraft(),
+                  ],
+                })
+              }}
+              disabled={routeLimitReached}
+            >
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add webhook route
+            </Button>
             <span className="text-sm text-muted-foreground">
               Up to 10 total destinations and one Linear destination per rule.
             </span>
@@ -580,14 +687,12 @@ export function AlertRuleBuilderPage({
               />
               <div className="border border-border/70 bg-background/50 px-4 py-4">
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-sm font-medium">Linear</span>
-                  <Badge variant={linearIntegrationConfigured ? 'success' : 'secondary'}>
-                    {linearIntegrationConfigured ? 'Configured' : 'Setup required'}
-                  </Badge>
+                  <span className="text-sm font-medium">Webhook</span>
+                  <Badge variant="success">Available</Badge>
                 </div>
                 <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                  Open issues directly from alert policy routing with org defaults or rule
-                  overrides.
+                  POST signed JSON payloads to HTTPS endpoints for automation, paging, or custom
+                  incident workflows.
                 </p>
               </div>
             </div>
@@ -663,7 +768,9 @@ export function AlertRuleBuilderPage({
             <SummaryRow label="Rules on save" value="1" />
             <SummaryRow
               label="Routes"
-              value={String(activeRecipients.length + activeLinearRoutes.length)}
+              value={String(
+                activeRecipients.length + activeLinearRoutes.length + activeWebhookRoutes.length
+              )}
             />
           </div>
         </FlatPanel>

--- a/apps/web/src/components/alerts/alert-rule-form.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.ts
@@ -10,7 +10,7 @@ const emailSchema = z.string().email()
 
 export interface NotificationRouteDraft {
   id: string
-  type: 'email' | 'linear'
+  type: 'email' | 'linear' | 'webhook'
   target: string
   teamId?: string
   projectId?: string
@@ -18,6 +18,10 @@ export interface NotificationRouteDraft {
   assigneeId?: string
   stateId?: string
   priority?: string
+  webhookUrl?: string
+  webhookSecret?: string
+  secretConfigured?: boolean
+  secretLast4?: string
 }
 
 export interface AlertRuleDraft {
@@ -97,6 +101,14 @@ function extractNotificationRoutes(rule?: AlertRuleRecord | null): NotificationR
         },
       ]
     }
+    if (channel.type === 'webhook' && typeof channel.url === 'string') {
+      return [
+        createWebhookNotificationRouteDraft(index + 1, channel.url, {
+          secretConfigured: channel.secretConfigured === true,
+          secretLast4: channel.secretLast4,
+        }),
+      ]
+    }
     return []
   })
 
@@ -111,6 +123,24 @@ export function createNotificationRouteDraft(sequence = 0, target = ''): Notific
         : `email-route-${Math.random().toString(36).slice(2, 10)}`,
     type: 'email',
     target,
+  }
+}
+
+export function createWebhookNotificationRouteDraft(
+  sequence = 0,
+  webhookUrl = '',
+  options?: { secretConfigured?: boolean; secretLast4?: string }
+): NotificationRouteDraft {
+  return {
+    id:
+      sequence > 0
+        ? `webhook-route-${sequence}`
+        : `webhook-route-${Math.random().toString(36).slice(2, 10)}`,
+    type: 'webhook',
+    target: webhookUrl,
+    webhookUrl,
+    secretConfigured: options?.secretConfigured,
+    secretLast4: options?.secretLast4,
   }
 }
 
@@ -178,6 +208,29 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
         return 'Linear priority must be a whole number between 0 and 4.'
       }
     }
+  }
+
+  for (const route of draft.notificationRoutes.filter((item) => item.type === 'webhook')) {
+    const url = route.webhookUrl?.trim() ?? route.target.trim()
+    if (!url) {
+      return 'Webhook URL is required.'
+    }
+    try {
+      const parsed = new URL(url)
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        return 'Webhook URL must use HTTP or HTTPS.'
+      }
+    } catch {
+      return `Invalid webhook URL: ${url}`
+    }
+    const secret = route.webhookSecret?.trim()
+    if (secret && secret.length < 16) {
+      return 'Webhook signing secret must be at least 16 characters when provided.'
+    }
+  }
+
+  if (draft.notificationRoutes.length > 10) {
+    return 'You can configure up to 10 notification destinations.'
   }
 
   switch (draft.type) {
@@ -267,6 +320,17 @@ export function serializeAlertRuleDraft(draft: AlertRuleDraft): AlertRuleMutatio
           ? { priority: parseWholeNumber(route.priority) ?? undefined }
           : {}),
       })),
+    ...draft.notificationRoutes
+      .filter((route) => route.type === 'webhook')
+      .map((route) => {
+        const url = route.webhookUrl?.trim() ?? route.target.trim()
+        const secret = route.webhookSecret?.trim()
+        return {
+          type: 'webhook' as const,
+          url,
+          ...(secret ? { secret } : {}),
+        }
+      }),
   ]
   const config = buildAlertRuleConfig(type, draft)
   const cooldownMinutes = parseWholeNumber(draft.cooldownMinutes) ?? 30

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -62,15 +62,23 @@ export type AlertNotificationChannel =
       stateId?: string
       priority?: number
     }
+  | {
+      type: 'webhook'
+      url: string
+      secret?: string
+      secretConfigured?: boolean
+      secretLast4?: string
+    }
 
 export interface AlertDeliveryRecord {
   id: string
-  channelType: 'email' | 'linear'
+  channelType: 'email' | 'linear' | 'webhook'
   status: 'pending' | 'claimed' | 'delivered' | 'failed'
   target: string
   externalIdentifier?: string | null
   externalUrl?: string | null
   lastError?: string | null
+  providerMetadata?: Record<string, unknown>
 }
 
 export interface AlertRuleRecord {
@@ -143,6 +151,20 @@ export interface AlertTestResult {
     failedMetrics: { count: number; dataPoints: number[] }
     completedMetrics: { count: number; dataPoints: number[] }
   }
+  webhookTests?: Array<{
+    url: string
+    success: boolean
+    httpStatus: number | null
+    durationMs: number
+    error?: string
+  }>
+}
+
+export interface WebhookTestResult {
+  success: boolean
+  httpStatus: number | null
+  durationMs: number
+  error?: string
 }
 
 export interface AlertRuleMutationInput {
@@ -213,6 +235,16 @@ function normalizeNotificationChannels(value: unknown): AlertNotificationChannel
           assigneeId: typeof entry.assigneeId === 'string' ? entry.assigneeId : undefined,
           stateId: typeof entry.stateId === 'string' ? entry.stateId : undefined,
           priority: typeof entry.priority === 'number' ? entry.priority : undefined,
+        },
+      ]
+    }
+    if (entry.type === 'webhook' && typeof entry.url === 'string') {
+      return [
+        {
+          type: 'webhook',
+          url: entry.url,
+          secretConfigured: entry.secretConfigured === true,
+          secretLast4: typeof entry.secretLast4 === 'string' ? entry.secretLast4 : undefined,
         },
       ]
     }
@@ -294,7 +326,9 @@ function normalizeAlertDeliveries(value: unknown): AlertDeliveryRecord[] {
   if (!Array.isArray(value)) return []
   return value.flatMap((entry) => {
     if (!isRecord(entry)) return []
-    if (entry.channelType !== 'email' && entry.channelType !== 'linear') return []
+    if (entry.channelType !== 'email' && entry.channelType !== 'linear' && entry.channelType !== 'webhook') {
+      return []
+    }
     return [
       {
         id: typeof entry.id === 'string' ? entry.id : '',
@@ -311,6 +345,7 @@ function normalizeAlertDeliveries(value: unknown): AlertDeliveryRecord[] {
           typeof entry.externalIdentifier === 'string' ? entry.externalIdentifier : null,
         externalUrl: typeof entry.externalUrl === 'string' ? entry.externalUrl : null,
         lastError: typeof entry.lastError === 'string' ? entry.lastError : null,
+        providerMetadata: isRecord(entry.providerMetadata) ? entry.providerMetadata : undefined,
       },
     ]
   })
@@ -482,12 +517,25 @@ export function useResolveAlertEvent() {
 
 export function useTestAlertRule(connectionId: string | undefined) {
   return useMutation({
-    mutationFn: async (ruleId: string) => {
+    mutationFn: async ({ ruleId, deliver = false }: { ruleId: string; deliver?: boolean }) => {
       const res = await api.c[':connectionId'].alerts.rules[':ruleId'].test.$post({
         param: { connectionId: connectionId!, ruleId },
+        query: deliver ? { deliver: 'true' } : {},
       })
       const data = await handleRes<TestAlertRuleResponse>(res)
       return data as AlertTestResult
+    },
+  })
+}
+
+export function useTestWebhook(connectionId: string | undefined) {
+  return useMutation({
+    mutationFn: async (input: { url: string; secret?: string; ruleId?: string }) => {
+      const res = await api.c[':connectionId'].alerts.webhooks.test.$post({
+        param: { connectionId: connectionId! },
+        json: input,
+      })
+      return handleRes<WebhookTestResult>(res)
     },
   })
 }

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
@@ -70,7 +70,12 @@ export function EditAlertRuleRoute() {
           search: { tab: 'rules' },
         })
       }}
-      onTest={() => testRuleMutation.mutateAsync(ruleId)}
+      onTest={() =>
+        testRuleMutation.mutateAsync({
+          ruleId,
+          deliver: (rule.notificationChannels ?? []).some((channel) => channel.type === 'webhook'),
+        })
+      }
     />
   )
 }

--- a/packages/dal/src/db/schemas/alert-delivery/schema.ts
+++ b/packages/dal/src/db/schemas/alert-delivery/schema.ts
@@ -15,7 +15,7 @@ import { organization } from '../organization/schema'
 export const alertDeliveryStatuses = ['pending', 'claimed', 'delivered', 'failed'] as const
 export type AlertDeliveryStatus = (typeof alertDeliveryStatuses)[number]
 
-export const alertDeliveryChannelTypes = ['email', 'linear'] as const
+export const alertDeliveryChannelTypes = ['email', 'linear', 'webhook'] as const
 export type AlertDeliveryChannelType = (typeof alertDeliveryChannelTypes)[number]
 
 export const alertDelivery = pgTable(

--- a/tooling/env/src/index.ts
+++ b/tooling/env/src/index.ts
@@ -92,6 +92,7 @@ const envSchema = z.object({
   DURABULL_DEMO_ACCOUNT_REDIS_CONNECTION_STRING: optionalString,
   DURABULL_ALERT_ENABLED: optionalBoolean,
   DURABULL_ALERT_POLL_INTERVAL_MS: optionalInt,
+  DURABULL_WEBHOOK_ALLOW_HTTP: optionalBoolean,
   LINEAR_OAUTH_CLIENT_ID: optionalString,
   LINEAR_OAUTH_CLIENT_SECRET: optionalString,
   LINEAR_OAUTH_REDIRECT_URI: optionalString,


### PR DESCRIPTION
## Summary

Closes #62

- Adds webhook as a per-rule notification route alongside email and Linear, with versioned JSON payloads (`schemaVersion: 1`), optional HMAC-SHA256 signing, and dashboard/job links in the body.
- Implements delivery infrastructure: SSRF-safe URL validation, 10s timeout, exponential retry with a 7-day abandon cap, and monitor-driven retries for aggregate rules while an alert is still firing.
- Adds builder UI (URL, secret, test button), webhook delivery status in the events table, `POST /webhooks/test`, and rule live-test support via `?deliver=true`.
- Keeps signing secrets on alert rules only — resolved at delivery time, never returned from the events API, and masked on rule reads.

## Test plan

- [x] `bun test apps/api/src/lib/alert-webhook*.test.ts apps/api/src/lib/alert-notifier.test.ts apps/api/src/lib/alert-monitor.test.ts apps/api/src/routes/alerts.test.ts` (45 passing)
- [ ] Create an alert rule with a webhook route in the builder; send a test webhook and confirm delivery
- [ ] Fire a real alert (e.g. job_failed) and verify the endpoint receives a signed `alert.fired` payload
- [ ] Confirm webhook secrets are masked on rule GET/POST and absent from event delivery metadata
- [ ] Verify a transient 503 on the endpoint is retried on subsequent monitor polls


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook notification channels for alert rules with optional HMAC-SHA256 payload signing.
  * Webhook test delivery endpoint to validate configurations before saving.
  * Rate limiting (10 tests per 60 seconds) to prevent webhook test abuse.
  * SSRF protection blocks webhooks to private/local IP addresses.

* **Bug Fixes**
  * Alert delivery retry logic now reprocesses existing firing events instead of creating duplicates.

* **Documentation**
  * New webhook notifications integration guide with payload schema and signature verification examples.
  * Updated roadmap reflecting webhook alert feature availability.

* **Chores**
  * New environment variable for enabling HTTP webhooks in development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->