### PR TITLE
Fix missing job configuration options in add and duplicate flows

### DIFF
--- a/apps/api/src/lib/job-options.test.ts
+++ b/apps/api/src/lib/job-options.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test'
+import { buildQueueAddOptions, jobOptionsSchema } from './job-options'
+
+describe('job options helpers', () => {
+  it('parses full job options payload', () => {
+    const parsed = jobOptionsSchema.parse({
+      delay: 5_000,
+      priority: 7,
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 1_000,
+      },
+      removeOnComplete: 100,
+      removeOnFail: true,
+    })
+
+    expect(parsed).toEqual({
+      delay: 5_000,
+      priority: 7,
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 1_000,
+      },
+      removeOnComplete: 100,
+      removeOnFail: true,
+    })
+  })
+
+  it('builds queue.add options and omits default values', () => {
+    expect(buildQueueAddOptions({})).toEqual({})
+    expect(buildQueueAddOptions({ delay: 0, priority: 0, attempts: 1 })).toEqual({})
+  })
+
+  it('builds queue.add options with non-default values', () => {
+    expect(
+      buildQueueAddOptions({
+        delay: 2_000,
+        priority: 5,
+        attempts: 4,
+        backoff: {
+          type: 'fixed',
+          delay: 500,
+        },
+        removeOnComplete: 25,
+        removeOnFail: false,
+      })
+    ).toEqual({
+      delay: 2_000,
+      priority: 5,
+      attempts: 4,
+      backoff: {
+        type: 'fixed',
+        delay: 500,
+      },
+      removeOnComplete: 25,
+      removeOnFail: false,
+    })
+  })
+
+  it('rejects invalid backoff delay', () => {
+    const result = jobOptionsSchema.safeParse({
+      backoff: {
+        type: 'fixed',
+        delay: -1,
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/api/src/lib/job-options.ts
+++ b/apps/api/src/lib/job-options.ts
@@ -1,0 +1,74 @@
+import type { JobsOptions } from 'bullmq'
+import { z } from 'zod'
+
+export const MAX_JOB_ATTEMPTS = 100
+export const MAX_JOB_PRIORITY = 2_097_152
+export const MAX_BACKOFF_DELAY_MS = 7 * 24 * 60 * 60 * 1000
+export const MAX_RETENTION_COUNT = 1_000_000
+export const MAX_JOB_DELAY_MS = 365 * 24 * 60 * 60 * 1000
+
+export const retentionSchema = z.union([
+  z.boolean(),
+  z.number().int().min(0).max(MAX_RETENTION_COUNT),
+])
+
+export const backoffSchema = z.object({
+  type: z.enum(['fixed', 'exponential']),
+  delay: z.number().int().min(0).max(MAX_BACKOFF_DELAY_MS),
+})
+
+export const jobTemplateOptionsSchema = z.object({
+  attempts: z.number().int().min(1).max(MAX_JOB_ATTEMPTS).optional(),
+  priority: z.number().int().min(0).max(MAX_JOB_PRIORITY).optional(),
+  backoff: backoffSchema.optional(),
+  removeOnComplete: retentionSchema.optional(),
+  removeOnFail: retentionSchema.optional(),
+})
+
+export const jobOptionsSchema = jobTemplateOptionsSchema.extend({
+  delay: z.number().int().min(0).max(MAX_JOB_DELAY_MS).optional(),
+})
+
+export const optionalJobTemplateOptionsSchema = jobTemplateOptionsSchema.optional()
+
+export type JobTemplateOptionsInput = z.infer<typeof jobTemplateOptionsSchema>
+export type JobOptionsInput = z.infer<typeof jobOptionsSchema>
+
+export function buildQueueAddOptions(input: JobOptionsInput): JobsOptions {
+  const options: JobsOptions = {}
+
+  if (input.delay !== undefined && input.delay > 0) {
+    options.delay = input.delay
+  }
+
+  if (input.priority !== undefined && input.priority > 0) {
+    options.priority = input.priority
+  }
+
+  if (input.attempts !== undefined && input.attempts > 1) {
+    options.attempts = input.attempts
+  }
+
+  if (input.backoff !== undefined) {
+    options.backoff = input.backoff
+  }
+
+  if (input.removeOnComplete !== undefined) {
+    options.removeOnComplete = input.removeOnComplete
+  }
+
+  if (input.removeOnFail !== undefined) {
+    options.removeOnFail = input.removeOnFail
+  }
+
+  return options
+}
+
+export function buildTemplateOptions(input: JobTemplateOptionsInput | undefined): JobTemplateOptionsInput | undefined {
+  if (input === undefined) {
+    return undefined
+  }
+
+  const options = buildQueueAddOptions(input)
+  return Object.keys(options).length > 0 ? (options as JobTemplateOptionsInput) : undefined
+}

--- a/apps/api/src/lib/scheduled-jobs.ts
+++ b/apps/api/src/lib/scheduled-jobs.ts
@@ -1,35 +1,18 @@
 import type { JobSchedulerJson, RepeatOptions } from 'bullmq'
 import { z } from 'zod'
+import {
+  optionalJobTemplateOptionsSchema,
+  type JobTemplateOptionsInput,
+} from './job-options'
 
 const MAX_SCHEDULER_ID_LENGTH = 128
 const MAX_JOB_NAME_LENGTH = 120
-const MAX_JOB_ATTEMPTS = 100
-const MAX_JOB_PRIORITY = 2_097_152
-const MAX_BACKOFF_DELAY_MS = 7 * 24 * 60 * 60 * 1000
-const MAX_RETENTION_COUNT = 1_000_000
 const MAX_SCHEDULE_LIMIT = 1_000_000
 const MIN_EVERY_MS = 1_000
 const MAX_EVERY_MS = 365 * 24 * 60 * 60 * 1000
 const SCHEDULER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:_.-]*$/
 
 const timestampInputSchema = z.union([z.string(), z.number().int().safe()])
-
-const retentionSchema = z.union([z.boolean(), z.number().int().min(0).max(MAX_RETENTION_COUNT)])
-
-const backoffSchema = z.object({
-  type: z.enum(['fixed', 'exponential']),
-  delay: z.number().int().min(0).max(MAX_BACKOFF_DELAY_MS),
-})
-
-const templateOptionsSchema = z
-  .object({
-    attempts: z.number().int().min(1).max(MAX_JOB_ATTEMPTS).optional(),
-    priority: z.number().int().min(0).max(MAX_JOB_PRIORITY).optional(),
-    backoff: backoffSchema.optional(),
-    removeOnComplete: retentionSchema.optional(),
-    removeOnFail: retentionSchema.optional(),
-  })
-  .optional()
 
 const scheduleSchema = z.discriminatedUnion('type', [
   z.object({
@@ -54,7 +37,7 @@ const scheduledJobPayloadSchema = z.object({
   name: z.string().trim().min(1, 'Job name is required.').max(MAX_JOB_NAME_LENGTH),
   data: z.unknown().default({}),
   schedule: scheduleSchema,
-  options: templateOptionsSchema,
+  options: optionalJobTemplateOptionsSchema,
 })
 
 function validateScheduledJobPayload(
@@ -122,16 +105,7 @@ export const updateScheduledJobSchema = scheduledJobPayloadSchema.superRefine(
 export type CreateScheduledJobInput = z.infer<typeof createScheduledJobSchema>
 export type UpdateScheduledJobInput = z.infer<typeof updateScheduledJobSchema>
 
-export interface ScheduledJobTemplateOptions {
-  attempts?: number
-  priority?: number
-  backoff?: {
-    type: 'fixed' | 'exponential'
-    delay: number
-  }
-  removeOnComplete?: boolean | number
-  removeOnFail?: boolean | number
-}
+export type ScheduledJobTemplateOptions = JobTemplateOptionsInput
 
 export interface ScheduledJobSummary {
   schedulerId: string

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,6 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { buildQueueAddOptions, jobOptionsSchema } from '../lib/job-options'
 import { getQueue } from '../lib/redis'
 import { getConnectionRedisOptions } from '../lib/connection-options'
 
@@ -884,13 +885,12 @@ const app = new Hono()
     '/:queueName/jobs',
     zValidator(
       'json',
-      z.object({
-        name: z.string(),
-        data: z.unknown(),
-        delay: z.number().optional(),
-        priority: z.number().optional(),
-        attempts: z.number().optional(),
-      })
+      z
+        .object({
+          name: z.string(),
+          data: z.unknown(),
+        })
+        .merge(jobOptionsSchema)
     ),
     async (c) => {
       const connectionId = c.get('connectionId')
@@ -898,10 +898,10 @@ const app = new Hono()
       const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
       const queueName = c.req.param('queueName')
-      const { name, data, delay, priority, attempts } = c.req.valid('json')
+      const { name, data, ...options } = c.req.valid('json')
 
       const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
-      const job = await queue.add(name, data, { delay, priority, attempts })
+      const job = await queue.add(name, data, buildQueueAddOptions(options))
 
       return c.json({
         jobId: job.id,

--- a/apps/docs/content/documentation/reference/http-api.mdx
+++ b/apps/docs/content/documentation/reference/http-api.mdx
@@ -138,6 +138,26 @@ All routes below are under:
 - `POST /queues/:queueName/jobs/remove`
 - `POST /queues/:queueName/jobs/invoke`
 
+`POST /queues/:queueName/jobs` accepts optional BullMQ job options alongside `name` and `data`:
+
+```json
+{
+  "name": "send-welcome-email",
+  "data": { "userId": "123" },
+  "delay": 5000,
+  "priority": 5,
+  "attempts": 3,
+  "backoff": {
+    "type": "exponential",
+    "delay": 1000
+  },
+  "removeOnComplete": 100,
+  "removeOnFail": true
+}
+```
+
+Supported option fields match scheduled job template options plus `delay`: `attempts`, `priority`, `backoff`, `removeOnComplete`, and `removeOnFail`.
+
 ### Scheduled Jobs
 
 - `GET /scheduled-jobs`

--- a/apps/web/src/components/add-job-dialog.tsx
+++ b/apps/web/src/components/add-job-dialog.tsx
@@ -1,8 +1,9 @@
 import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
 import { Loader2, Plus } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { JsonEditor } from '@/components/json-editor'
+import { JobOptionsFields } from '@/components/job-options-fields'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -16,6 +17,13 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useAddJob } from '@/hooks/use-queues'
 import { ApiError } from '@/lib/api'
+import {
+  createDefaultJobOptionsFormValue,
+  formValueToJobOptions,
+  hasJobOptionsValidationErrors,
+  validateJobOptionsFormValue,
+  type JobOptionsFormValue,
+} from '@/lib/job-options'
 
 interface AddJobDialogProps {
   open: boolean
@@ -28,20 +36,20 @@ export function AddJobDialog({ open, onOpenChange, queueName, onSuccess }: AddJo
   const [jobName, setJobName] = useState('')
   const [jobData, setJobData] = useState<unknown>({})
   const [isJsonValid, setIsJsonValid] = useState(true)
-  const [delay, setDelay] = useState('0')
-  const [priority, setPriority] = useState('0')
-  const [attempts, setAttempts] = useState('1')
+  const [jobOptions, setJobOptions] = useState<JobOptionsFormValue>(createDefaultJobOptionsFormValue())
 
   const addJobMutation = useAddJob()
+  const jobOptionsErrors = useMemo(
+    () => validateJobOptionsFormValue(jobOptions, { includeDelay: true }),
+    [jobOptions]
+  )
 
   useEffect(() => {
     if (open) {
       setJobName('')
       setJobData({})
       setIsJsonValid(true)
-      setDelay('0')
-      setPriority('0')
-      setAttempts('1')
+      setJobOptions(createDefaultJobOptionsFormValue())
     }
   }, [open])
 
@@ -51,22 +59,16 @@ export function AddJobDialog({ open, onOpenChange, queueName, onSuccess }: AddJo
   }
 
   const handleSubmit = async () => {
-    if (!isJsonValid || !jobName.trim()) return
-
-    const delayMs = Number.parseInt(delay, 10) || 0
-    const priorityNum = Number.parseInt(priority, 10) || 0
-    const attemptsNum = Number.parseInt(attempts, 10) || 1
+    if (!isJsonValid || !jobName.trim() || hasJobOptionsValidationErrors(jobOptionsErrors)) {
+      return
+    }
 
     try {
       const result = await addJobMutation.mutateAsync({
         queueName,
         name: jobName.trim(),
         jobData,
-        options: {
-          delay: delayMs > 0 ? delayMs : undefined,
-          priority: priorityNum > 0 ? priorityNum : undefined,
-          attempts: attemptsNum > 1 ? attemptsNum : undefined,
-        },
+        options: formValueToJobOptions(jobOptions),
       })
 
       toast.success('Job created successfully', {
@@ -93,7 +95,11 @@ export function AddJobDialog({ open, onOpenChange, queueName, onSuccess }: AddJo
   }
 
   const isSubmitting = addJobMutation.isPending
-  const canSubmit = isJsonValid && jobName.trim() && !isSubmitting
+  const canSubmit =
+    isJsonValid &&
+    jobName.trim() &&
+    !isSubmitting &&
+    !hasJobOptionsValidationErrors(jobOptionsErrors)
 
   return (
     <Dialog
@@ -115,7 +121,6 @@ export function AddJobDialog({ open, onOpenChange, queueName, onSuccess }: AddJo
         </DialogHeader>
 
         <div className="space-y-6 py-4">
-          {/* Job Name */}
           <div className="space-y-2">
             <Label htmlFor="job-name">Job Name</Label>
             <Input
@@ -126,56 +131,21 @@ export function AddJobDialog({ open, onOpenChange, queueName, onSuccess }: AddJo
             />
           </div>
 
-          {/* Job Data */}
           <div className="space-y-2">
             <Label>Job Data (JSON)</Label>
             <JsonEditor value={jobData} onChange={handleJsonChange} minHeight="180px" />
           </div>
 
-          {/* Options */}
           <div className="space-y-4">
             <Label className="text-sm font-medium">Options</Label>
-            <div className="grid grid-cols-3 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="delay" className="text-xs text-muted-foreground">
-                  Delay (ms)
-                </Label>
-                <Input
-                  id="delay"
-                  type="number"
-                  min="0"
-                  value={delay}
-                  onChange={(e) => setDelay(e.target.value)}
-                  placeholder="0"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="priority" className="text-xs text-muted-foreground">
-                  Priority
-                </Label>
-                <Input
-                  id="priority"
-                  type="number"
-                  min="0"
-                  value={priority}
-                  onChange={(e) => setPriority(e.target.value)}
-                  placeholder="0"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="attempts" className="text-xs text-muted-foreground">
-                  Max Attempts
-                </Label>
-                <Input
-                  id="attempts"
-                  type="number"
-                  min="1"
-                  value={attempts}
-                  onChange={(e) => setAttempts(e.target.value)}
-                  placeholder="1"
-                />
-              </div>
-            </div>
+            <JobOptionsFields
+              value={jobOptions}
+              onChange={setJobOptions}
+              errors={jobOptionsErrors}
+              showDelay
+              compact
+              idPrefix="add-job"
+            />
           </div>
         </div>
 

--- a/apps/web/src/components/duplicate-job-dialog.tsx
+++ b/apps/web/src/components/duplicate-job-dialog.tsx
@@ -1,8 +1,9 @@
 import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
 import { Copy, Loader2, Play } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { JsonEditor } from '@/components/json-editor'
+import { JobOptionsFields } from '@/components/job-options-fields'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -15,6 +16,13 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useAddJob } from '@/hooks/use-queues'
+import {
+  formValueToJobOptions,
+  hasJobOptionsValidationErrors,
+  jobOptsToFormValue,
+  validateJobOptionsFormValue,
+  type JobOptionsFormValue,
+} from '@/lib/job-options'
 
 interface DuplicateJobDialogProps {
   open: boolean
@@ -23,11 +31,8 @@ interface DuplicateJobDialogProps {
   originalJobId: string
   originalJobName: string
   originalJobData: Record<string, unknown>
-  originalOptions?: {
-    delay?: number
-    priority?: number
-    attempts?: number
-  }
+  originalJobOpts?: Record<string, unknown>
+  originalDelay?: number
   onSuccess?: (newJobId: string) => void
 }
 
@@ -38,29 +43,31 @@ export function DuplicateJobDialog({
   originalJobId,
   originalJobName,
   originalJobData,
-  originalOptions,
+  originalJobOpts,
+  originalDelay = 0,
   onSuccess,
 }: DuplicateJobDialogProps) {
   const [jobName, setJobName] = useState(originalJobName)
   const [jobData, setJobData] = useState<unknown>(originalJobData)
   const [isJsonValid, setIsJsonValid] = useState(true)
-  const [delay, setDelay] = useState<string>(String(originalOptions?.delay ?? 0))
-  const [priority, setPriority] = useState<string>(String(originalOptions?.priority ?? 0))
-  const [attempts, setAttempts] = useState<string>(String(originalOptions?.attempts ?? 1))
+  const [jobOptions, setJobOptions] = useState<JobOptionsFormValue>(() =>
+    jobOptsToFormValue(originalJobOpts, originalDelay)
+  )
 
   const addJobMutation = useAddJob()
+  const jobOptionsErrors = useMemo(
+    () => validateJobOptionsFormValue(jobOptions, { includeDelay: true }),
+    [jobOptions]
+  )
 
-  // Reset form when dialog opens with new job
   useEffect(() => {
     if (open) {
       setJobName(originalJobName)
       setJobData(originalJobData)
       setIsJsonValid(true)
-      setDelay(String(originalOptions?.delay ?? 0))
-      setPriority(String(originalOptions?.priority ?? 0))
-      setAttempts(String(originalOptions?.attempts ?? 1))
+      setJobOptions(jobOptsToFormValue(originalJobOpts, originalDelay))
     }
-  }, [open, originalJobName, originalJobData, originalOptions])
+  }, [open, originalJobName, originalJobData, originalJobOpts, originalDelay])
 
   const handleJsonChange = (value: unknown, isValid: boolean) => {
     setJobData(value)
@@ -68,22 +75,16 @@ export function DuplicateJobDialog({
   }
 
   const handleSubmit = async () => {
-    if (!isJsonValid || !jobName.trim()) return
-
-    const delayMs = Number.parseInt(delay, 10) || 0
-    const priorityNum = Number.parseInt(priority, 10) || 0
-    const attemptsNum = Number.parseInt(attempts, 10) || 1
+    if (!isJsonValid || !jobName.trim() || hasJobOptionsValidationErrors(jobOptionsErrors)) {
+      return
+    }
 
     try {
       const result = await addJobMutation.mutateAsync({
         queueName,
         name: jobName.trim(),
         jobData,
-        options: {
-          delay: delayMs > 0 ? delayMs : undefined,
-          priority: priorityNum > 0 ? priorityNum : undefined,
-          attempts: attemptsNum > 1 ? attemptsNum : undefined,
-        },
+        options: formValueToJobOptions(jobOptions),
       })
 
       toast.success('Job created successfully', {
@@ -100,7 +101,11 @@ export function DuplicateJobDialog({
   }
 
   const isSubmitting = addJobMutation.isPending
-  const canSubmit = isJsonValid && jobName.trim() && !isSubmitting
+  const canSubmit =
+    isJsonValid &&
+    jobName.trim() &&
+    !isSubmitting &&
+    !hasJobOptionsValidationErrors(jobOptionsErrors)
 
   return (
     <Dialog
@@ -125,13 +130,11 @@ export function DuplicateJobDialog({
         </DialogHeader>
 
         <div className="space-y-6 py-4">
-          {/* Original Job ID (read-only reference) */}
           <div className="rounded-lg border bg-muted/50 p-3">
             <p className="text-xs text-muted-foreground mb-1">Duplicating from job:</p>
             <p className="font-mono text-sm break-all">{originalJobId}</p>
           </div>
 
-          {/* Job Name */}
           <div className="space-y-2">
             <Label htmlFor="job-name">Job Name</Label>
             <Input
@@ -142,56 +145,21 @@ export function DuplicateJobDialog({
             />
           </div>
 
-          {/* Job Data */}
           <div className="space-y-2">
             <Label>Job Data (JSON)</Label>
             <JsonEditor value={jobData} onChange={handleJsonChange} minHeight="180px" />
           </div>
 
-          {/* Options */}
           <div className="space-y-4">
             <Label className="text-sm font-medium">Options</Label>
-            <div className="grid grid-cols-3 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="delay" className="text-xs text-muted-foreground">
-                  Delay (ms)
-                </Label>
-                <Input
-                  id="delay"
-                  type="number"
-                  min="0"
-                  value={delay}
-                  onChange={(e) => setDelay(e.target.value)}
-                  placeholder="0"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="priority" className="text-xs text-muted-foreground">
-                  Priority
-                </Label>
-                <Input
-                  id="priority"
-                  type="number"
-                  min="0"
-                  value={priority}
-                  onChange={(e) => setPriority(e.target.value)}
-                  placeholder="0"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="attempts" className="text-xs text-muted-foreground">
-                  Max Attempts
-                </Label>
-                <Input
-                  id="attempts"
-                  type="number"
-                  min="1"
-                  value={attempts}
-                  onChange={(e) => setAttempts(e.target.value)}
-                  placeholder="1"
-                />
-              </div>
-            </div>
+            <JobOptionsFields
+              value={jobOptions}
+              onChange={setJobOptions}
+              errors={jobOptionsErrors}
+              showDelay
+              compact
+              idPrefix="duplicate-job"
+            />
           </div>
         </div>
 

--- a/apps/web/src/components/job-options-fields.tsx
+++ b/apps/web/src/components/job-options-fields.tsx
@@ -1,0 +1,231 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select } from '@/components/ui/select'
+import {
+  type BackoffMode,
+  type JobOptionsFormValue,
+  type JobOptionsValidationErrors,
+  type RetentionMode,
+} from '@/lib/job-options'
+
+const RETENTION_PRESETS = [25, 100, 500] as const
+
+function FieldMessage({ message }: { message?: string }) {
+  if (!message) {
+    return null
+  }
+
+  return <p className="text-xs text-destructive">{message}</p>
+}
+
+function RetentionControl({
+  label,
+  description,
+  mode,
+  countValue,
+  onModeChange,
+  onCountChange,
+  error,
+}: {
+  label: string
+  description: string
+  mode: RetentionMode
+  countValue: string
+  onModeChange: (mode: RetentionMode) => void
+  onCountChange: (value: string) => void
+  error?: string
+}) {
+  return (
+    <div className="space-y-3 rounded-lg border border-border/70 bg-muted/15 p-4">
+      <div className="space-y-1">
+        <Label className="text-sm font-medium">{label}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+
+      <Select value={mode} onChange={(event) => onModeChange(event.target.value as RetentionMode)}>
+        <option value="keep">Keep all</option>
+        <option value="remove">Remove immediately</option>
+        <option value="count">Keep latest N</option>
+      </Select>
+
+      {mode === 'count' ? (
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {RETENTION_PRESETS.map((preset) => (
+              <Button
+                key={preset}
+                type="button"
+                variant={countValue === String(preset) ? 'secondary' : 'outline'}
+                size="xs"
+                onClick={() => onCountChange(String(preset))}
+              >
+                {preset}
+              </Button>
+            ))}
+          </div>
+          <Input
+            value={countValue}
+            onChange={(event) => onCountChange(event.target.value)}
+            inputMode="numeric"
+            placeholder="100"
+            className={error ? 'border-destructive focus-visible:ring-destructive' : undefined}
+          />
+          <FieldMessage message={error} />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+interface JobOptionsFieldsProps {
+  value: JobOptionsFormValue
+  onChange: (value: JobOptionsFormValue) => void
+  errors?: JobOptionsValidationErrors
+  showDelay?: boolean
+  idPrefix?: string
+  compact?: boolean
+}
+
+function updateField<K extends keyof JobOptionsFormValue>(
+  value: JobOptionsFormValue,
+  onChange: (value: JobOptionsFormValue) => void,
+  field: K,
+  nextValue: JobOptionsFormValue[K]
+) {
+  onChange({ ...value, [field]: nextValue })
+}
+
+export function JobOptionsFields({
+  value,
+  onChange,
+  errors = {},
+  showDelay = false,
+  idPrefix = 'job-options',
+  compact = false,
+}: JobOptionsFieldsProps) {
+  const gridClassName = compact ? 'grid grid-cols-3 gap-4' : 'grid gap-4 md:grid-cols-3'
+
+  return (
+    <div className="space-y-4">
+      <div className={gridClassName}>
+        {showDelay ? (
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-delay`} className="text-xs text-muted-foreground">
+              Delay (ms)
+            </Label>
+            <Input
+              id={`${idPrefix}-delay`}
+              type="number"
+              min="0"
+              value={value.delay}
+              onChange={(event) => updateField(value, onChange, 'delay', event.target.value)}
+              placeholder="0"
+              className={
+                errors.delay ? 'border-destructive focus-visible:ring-destructive' : undefined
+              }
+            />
+            <FieldMessage message={errors.delay} />
+          </div>
+        ) : null}
+
+        <div className="space-y-2">
+          <Label
+            htmlFor={`${idPrefix}-attempts`}
+            className={compact ? 'text-xs text-muted-foreground' : undefined}
+          >
+            {compact ? 'Max Attempts' : 'Attempts'}
+          </Label>
+          <Input
+            id={`${idPrefix}-attempts`}
+            value={value.attempts}
+            onChange={(event) => updateField(value, onChange, 'attempts', event.target.value)}
+            inputMode="numeric"
+            min={compact ? '1' : undefined}
+            className={
+              errors.attempts ? 'border-destructive focus-visible:ring-destructive' : undefined
+            }
+          />
+          <FieldMessage message={errors.attempts} />
+        </div>
+
+        <div className="space-y-2">
+          <Label
+            htmlFor={`${idPrefix}-priority`}
+            className={compact ? 'text-xs text-muted-foreground' : undefined}
+          >
+            Priority
+          </Label>
+          <Input
+            id={`${idPrefix}-priority`}
+            value={value.priority}
+            onChange={(event) => updateField(value, onChange, 'priority', event.target.value)}
+            inputMode="numeric"
+            min={compact ? '0' : undefined}
+            className={
+              errors.priority ? 'border-destructive focus-visible:ring-destructive' : undefined
+            }
+          />
+          <FieldMessage message={errors.priority} />
+        </div>
+
+        <div className="space-y-2">
+          <Label
+            htmlFor={`${idPrefix}-backoff-type`}
+            className={compact ? 'text-xs text-muted-foreground' : undefined}
+          >
+            Backoff
+          </Label>
+          <Select
+            id={`${idPrefix}-backoff-type`}
+            value={value.backoffMode}
+            onChange={(event) =>
+              updateField(value, onChange, 'backoffMode', event.target.value as BackoffMode)
+            }
+          >
+            <option value="none">No backoff</option>
+            <option value="fixed">Fixed</option>
+            <option value="exponential">Exponential</option>
+          </Select>
+        </div>
+      </div>
+
+      {value.backoffMode !== 'none' ? (
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-backoff-delay`}>Backoff Delay (ms)</Label>
+          <Input
+            id={`${idPrefix}-backoff-delay`}
+            value={value.backoffDelay}
+            onChange={(event) => updateField(value, onChange, 'backoffDelay', event.target.value)}
+            inputMode="numeric"
+            className={
+              errors.backoff ? 'border-destructive focus-visible:ring-destructive' : undefined
+            }
+          />
+          <FieldMessage message={errors.backoff} />
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <RetentionControl
+          label="Completed Job Retention"
+          description="Keep history for successful runs or trim it automatically."
+          mode={value.removeOnCompleteMode}
+          countValue={value.removeOnCompleteCount}
+          onModeChange={(mode) => updateField(value, onChange, 'removeOnCompleteMode', mode)}
+          onCountChange={(count) => updateField(value, onChange, 'removeOnCompleteCount', count)}
+          error={errors.removeOnComplete}
+        />
+        <RetentionControl
+          label="Failed Job Retention"
+          description="Control how much failed-run history stays available for debugging."
+          mode={value.removeOnFailMode}
+          countValue={value.removeOnFailCount}
+          onModeChange={(mode) => updateField(value, onChange, 'removeOnFailMode', mode)}
+          onCountChange={(count) => updateField(value, onChange, 'removeOnFailCount', count)}
+          error={errors.removeOnFail}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/job-options-fields.tsx
+++ b/apps/web/src/components/job-options-fields.tsx
@@ -2,12 +2,12 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
-import {
-  type BackoffMode,
-  type JobOptionsFormValue,
-  type JobOptionsValidationErrors,
-  type RetentionMode,
-} from '@/lib/job-options'
+import type {
+  BackoffMode,
+  JobOptionsFormValue,
+  JobOptionsValidationErrors,
+  RetentionMode,
+} from '`@/lib/job-options`'
 
 const RETENTION_PRESETS = [25, 100, 500] as const
 

--- a/apps/web/src/components/job-options-fields.tsx
+++ b/apps/web/src/components/job-options-fields.tsx
@@ -7,7 +7,7 @@ import type {
   JobOptionsFormValue,
   JobOptionsValidationErrors,
   RetentionMode,
-} from '`@/lib/job-options`'
+} from '@/lib/job-options'
 
 const RETENTION_PRESETS = [25, 100, 500] as const
 

--- a/apps/web/src/components/scheduled-job-form.tsx
+++ b/apps/web/src/components/scheduled-job-form.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { JsonEditor } from '@/components/json-editor'
+import { JobOptionsFields } from '@/components/job-options-fields'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -19,6 +20,15 @@ import type {
   ScheduledJobMutationInput,
   ScheduledJobTemplateOptionsInput,
 } from '@/hooks/use-queues'
+import {
+  createDefaultJobOptionsFormValue,
+  formValueToTemplateOptions,
+  hasJobOptionsValidationErrors,
+  parseOptionalWholeNumber,
+  templateOptionsToFormValue,
+  validateJobOptionsFormValue,
+  type JobOptionsFormValue,
+} from '@/lib/job-options'
 import {
   fromDateTimeLocalValue,
   getCronDescription,
@@ -33,8 +43,6 @@ import {
 import { cn, formatDate } from '@/lib/utils'
 
 type ScheduleMode = 'cron' | 'every'
-type BackoffMode = 'none' | 'fixed' | 'exponential'
-type RetentionMode = 'keep' | 'remove' | 'count'
 
 export interface ScheduledJobFormInitialValue {
   schedulerId: string
@@ -77,103 +85,12 @@ const EVERY_PRESETS = [
   { label: '1 hour', value: '3600000' },
 ] as const
 
-const RETENTION_PRESETS = [25, 100, 500] as const
-
-function parseOptionalWholeNumber(value: string): number | undefined {
-  const normalized = value.trim()
-  if (!normalized) {
-    return undefined
-  }
-
-  if (!/^\d+$/.test(normalized)) {
-    return undefined
-  }
-
-  const parsed = Number.parseInt(normalized, 10)
-  return Number.isSafeInteger(parsed) ? parsed : undefined
-}
-
-function getRetentionMode(value: boolean | number | undefined): RetentionMode {
-  if (value === true) {
-    return 'remove'
-  }
-
-  if (typeof value === 'number') {
-    return 'count'
-  }
-
-  return 'keep'
-}
-
-function getRetentionCount(value: boolean | number | undefined): string {
-  return typeof value === 'number' ? String(value) : '100'
-}
-
 function FieldMessage({ message }: { message?: string }) {
   if (!message) {
     return null
   }
 
   return <p className="text-xs text-destructive">{message}</p>
-}
-
-function RetentionControl({
-  label,
-  description,
-  mode,
-  countValue,
-  onModeChange,
-  onCountChange,
-  error,
-}: {
-  label: string
-  description: string
-  mode: RetentionMode
-  countValue: string
-  onModeChange: (mode: RetentionMode) => void
-  onCountChange: (value: string) => void
-  error?: string
-}) {
-  return (
-    <div className="space-y-3 rounded-lg border border-border/70 bg-muted/15 p-4">
-      <div className="space-y-1">
-        <Label className="text-sm font-medium">{label}</Label>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-
-      <Select value={mode} onChange={(event) => onModeChange(event.target.value as RetentionMode)}>
-        <option value="keep">Keep all</option>
-        <option value="remove">Remove immediately</option>
-        <option value="count">Keep latest N</option>
-      </Select>
-
-      {mode === 'count' ? (
-        <div className="space-y-3">
-          <div className="flex flex-wrap gap-2">
-            {RETENTION_PRESETS.map((value) => (
-              <Button
-                key={value}
-                type="button"
-                variant={countValue === String(value) ? 'secondary' : 'outline'}
-                size="xs"
-                onClick={() => onCountChange(String(value))}
-              >
-                {value}
-              </Button>
-            ))}
-          </div>
-          <Input
-            value={countValue}
-            onChange={(event) => onCountChange(event.target.value)}
-            inputMode="numeric"
-            placeholder="100"
-            className={error ? 'border-destructive focus-visible:ring-destructive' : undefined}
-          />
-          <FieldMessage message={error} />
-        </div>
-      ) : null}
-    </div>
-  )
 }
 
 export function ScheduledJobForm({
@@ -204,14 +121,7 @@ export function ScheduledJobForm({
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [limit, setLimit] = useState('')
-  const [attempts, setAttempts] = useState('1')
-  const [priority, setPriority] = useState('0')
-  const [backoffMode, setBackoffMode] = useState<BackoffMode>('none')
-  const [backoffDelay, setBackoffDelay] = useState('5000')
-  const [removeOnCompleteMode, setRemoveOnCompleteMode] = useState<RetentionMode>('keep')
-  const [removeOnCompleteCount, setRemoveOnCompleteCount] = useState('100')
-  const [removeOnFailMode, setRemoveOnFailMode] = useState<RetentionMode>('keep')
-  const [removeOnFailCount, setRemoveOnFailCount] = useState('100')
+  const [jobOptions, setJobOptions] = useState<JobOptionsFormValue>(createDefaultJobOptionsFormValue())
 
   useEffect(() => {
     if (mode === 'edit' && !initialValue) {
@@ -235,16 +145,10 @@ export function ScheduledJobForm({
     setStartDate(toDateTimeLocalValue(initialValue?.startDate))
     setEndDate(toDateTimeLocalValue(initialValue?.endDate))
     setLimit(initialValue?.limit ? String(initialValue.limit) : '')
-    setAttempts(templateOptions?.attempts ? String(templateOptions.attempts) : '1')
-    setPriority(templateOptions?.priority ? String(templateOptions.priority) : '0')
-    setBackoffMode(templateOptions?.backoff?.type ?? 'none')
-    setBackoffDelay(
-      templateOptions?.backoff?.delay ? String(templateOptions.backoff.delay) : '5000'
-    )
-    setRemoveOnCompleteMode(getRetentionMode(templateOptions?.removeOnComplete))
-    setRemoveOnCompleteCount(getRetentionCount(templateOptions?.removeOnComplete))
-    setRemoveOnFailMode(getRetentionMode(templateOptions?.removeOnFail))
-    setRemoveOnFailCount(getRetentionCount(templateOptions?.removeOnFail))
+    setJobOptions({
+      ...createDefaultJobOptionsFormValue(),
+      ...templateOptionsToFormValue(templateOptions),
+    })
   }, [browserTimeZone, initialValue, mode])
 
   useEffect(() => {
@@ -358,38 +262,10 @@ export function ScheduledJobForm({
     return undefined
   }, [limit, limitValue])
 
-  const attemptsValue = useMemo(() => parseOptionalWholeNumber(attempts), [attempts])
-  const attemptsError =
-    attemptsValue === undefined || attemptsValue < 1 ? 'Attempts must be at least 1.' : undefined
-
-  const priorityValue = useMemo(() => parseOptionalWholeNumber(priority), [priority])
-  const priorityError = priorityValue === undefined ? 'Priority must be a whole number.' : undefined
-
-  const backoffDelayValue = useMemo(() => parseOptionalWholeNumber(backoffDelay), [backoffDelay])
-  const backoffError =
-    backoffMode !== 'none' && (backoffDelayValue === undefined || backoffDelayValue < 1)
-      ? 'Backoff delay must be greater than 0.'
-      : undefined
-
-  const removeOnCompleteCountValue = useMemo(
-    () => parseOptionalWholeNumber(removeOnCompleteCount),
-    [removeOnCompleteCount]
+  const jobOptionsErrors = useMemo(
+    () => validateJobOptionsFormValue(jobOptions),
+    [jobOptions]
   )
-  const removeOnFailCountValue = useMemo(
-    () => parseOptionalWholeNumber(removeOnFailCount),
-    [removeOnFailCount]
-  )
-
-  const removeOnCompleteError =
-    removeOnCompleteMode === 'count' &&
-    (removeOnCompleteCountValue === undefined || removeOnCompleteCountValue < 1)
-      ? 'Enter how many completed jobs to retain.'
-      : undefined
-  const removeOnFailError =
-    removeOnFailMode === 'count' &&
-    (removeOnFailCountValue === undefined || removeOnFailCountValue < 1)
-      ? 'Enter how many failed jobs to retain.'
-      : undefined
 
   const canSubmit =
     isJsonValid &&
@@ -399,11 +275,7 @@ export function ScheduledJobForm({
     !timeZoneError &&
     !dateWindowError &&
     !limitError &&
-    !attemptsError &&
-    !priorityError &&
-    !backoffError &&
-    !removeOnCompleteError &&
-    !removeOnFailError &&
+    !hasJobOptionsValidationErrors(jobOptionsErrors) &&
     jobName.trim().length > 0 &&
     !isSubmitting
 
@@ -412,34 +284,7 @@ export function ScheduledJobForm({
       return
     }
 
-    const options: ScheduledJobTemplateOptionsInput = {}
-
-    if ((attemptsValue ?? 1) > 1) {
-      options.attempts = attemptsValue
-    }
-
-    if ((priorityValue ?? 0) > 0) {
-      options.priority = priorityValue
-    }
-
-    if (backoffMode !== 'none' && backoffDelayValue) {
-      options.backoff = {
-        type: backoffMode,
-        delay: backoffDelayValue,
-      }
-    }
-
-    if (removeOnCompleteMode === 'remove') {
-      options.removeOnComplete = true
-    } else if (removeOnCompleteMode === 'count' && removeOnCompleteCountValue) {
-      options.removeOnComplete = removeOnCompleteCountValue
-    }
-
-    if (removeOnFailMode === 'remove') {
-      options.removeOnFail = true
-    } else if (removeOnFailMode === 'count' && removeOnFailCountValue) {
-      options.removeOnFail = removeOnFailCountValue
-    }
+    const options = formValueToTemplateOptions(jobOptions)
 
     await onSubmit({
       schedulerId: schedulerId.trim(),
@@ -463,7 +308,7 @@ export function ScheduledJobForm({
               endDate: endDateIso,
               limit: limitValue,
             },
-      options: Object.keys(options).length > 0 ? options : undefined,
+      options,
     })
   }
 
@@ -770,89 +615,12 @@ export function ScheduledJobForm({
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-5">
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="space-y-2">
-                  <Label htmlFor="scheduled-job-attempts">Attempts</Label>
-                  <Input
-                    id="scheduled-job-attempts"
-                    value={attempts}
-                    onChange={(event) => setAttempts(event.target.value)}
-                    inputMode="numeric"
-                    className={
-                      attemptsError
-                        ? 'border-destructive focus-visible:ring-destructive'
-                        : undefined
-                    }
-                  />
-                  <FieldMessage message={attemptsError} />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="scheduled-job-priority">Priority</Label>
-                  <Input
-                    id="scheduled-job-priority"
-                    value={priority}
-                    onChange={(event) => setPriority(event.target.value)}
-                    inputMode="numeric"
-                    className={
-                      priorityError
-                        ? 'border-destructive focus-visible:ring-destructive'
-                        : undefined
-                    }
-                  />
-                  <FieldMessage message={priorityError} />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="scheduled-job-backoff-type">Backoff</Label>
-                  <Select
-                    id="scheduled-job-backoff-type"
-                    value={backoffMode}
-                    onChange={(event) => setBackoffMode(event.target.value as BackoffMode)}
-                  >
-                    <option value="none">No backoff</option>
-                    <option value="fixed">Fixed</option>
-                    <option value="exponential">Exponential</option>
-                  </Select>
-                </div>
-              </div>
-
-              {backoffMode !== 'none' ? (
-                <div className="space-y-2">
-                  <Label htmlFor="scheduled-job-backoff-delay">Backoff Delay (ms)</Label>
-                  <Input
-                    id="scheduled-job-backoff-delay"
-                    value={backoffDelay}
-                    onChange={(event) => setBackoffDelay(event.target.value)}
-                    inputMode="numeric"
-                    className={
-                      backoffError ? 'border-destructive focus-visible:ring-destructive' : undefined
-                    }
-                  />
-                  <FieldMessage message={backoffError} />
-                </div>
-              ) : null}
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <RetentionControl
-                  label="Completed Job Retention"
-                  description="Keep history for successful runs or trim it automatically."
-                  mode={removeOnCompleteMode}
-                  countValue={removeOnCompleteCount}
-                  onModeChange={setRemoveOnCompleteMode}
-                  onCountChange={setRemoveOnCompleteCount}
-                  error={removeOnCompleteError}
-                />
-                <RetentionControl
-                  label="Failed Job Retention"
-                  description="Control how much failed-run history stays available for debugging."
-                  mode={removeOnFailMode}
-                  countValue={removeOnFailCount}
-                  onModeChange={setRemoveOnFailMode}
-                  onCountChange={setRemoveOnFailCount}
-                  error={removeOnFailError}
-                />
-              </div>
+              <JobOptionsFields
+                value={jobOptions}
+                onChange={setJobOptions}
+                errors={jobOptionsErrors}
+                idPrefix="scheduled-job"
+              />
             </CardContent>
           </Card>
         </div>

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -9,6 +9,7 @@ import { useParams } from '@tanstack/react-router'
 import { useConnection } from '@/components/connection-provider'
 import { ApiError, api, fetchApi, handleRes, type InferResponseType } from '@/lib/api'
 import { PAGINATION } from '@/lib/constants'
+import type { JobOptionsInput } from '@/lib/job-options'
 
 // Re-export ApiError for backward compatibility
 export { ApiError }
@@ -961,7 +962,7 @@ export function useAddJob() {
       queueName: string
       name: string
       jobData: unknown
-      options?: { delay?: number; priority?: number; attempts?: number }
+      options?: JobOptionsInput
     }) => {
       const res = await api.c[':connectionId'].queues[':queueName'].jobs.$post({
         param: { connectionId: connectionId!, queueName },
@@ -1045,13 +1046,7 @@ export type ScheduledJobScheduleInput =
       limit?: number
     }
 
-export interface ScheduledJobTemplateOptionsInput {
-  attempts?: number
-  priority?: number
-  backoff?: { type: 'fixed' | 'exponential'; delay: number }
-  removeOnComplete?: boolean | number
-  removeOnFail?: boolean | number
-}
+export type ScheduledJobTemplateOptionsInput = Omit<JobOptionsInput, 'delay'>
 
 export interface ScheduledJobMutationInput {
   queueName: string

--- a/apps/web/src/lib/job-options.test.ts
+++ b/apps/web/src/lib/job-options.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createDefaultJobOptionsFormValue,
+  formValueToJobOptions,
+  jobOptsToFormValue,
+} from './job-options'
+
+describe('job options form helpers', () => {
+  it('maps BullMQ opts into form values for duplicate prefill', () => {
+    expect(
+      jobOptsToFormValue(
+        {
+          attempts: 3,
+          priority: 5,
+          backoff: { type: 'exponential', delay: 1000 },
+          removeOnComplete: 100,
+          removeOnFail: true,
+        },
+        2500
+      )
+    ).toEqual({
+      delay: '2500',
+      attempts: '3',
+      priority: '5',
+      backoffMode: 'exponential',
+      backoffDelay: '1000',
+      removeOnCompleteMode: 'count',
+      removeOnCompleteCount: '100',
+      removeOnFailMode: 'remove',
+      removeOnFailCount: '100',
+    })
+  })
+
+  it('maps numeric backoff shorthand to fixed backoff', () => {
+    expect(jobOptsToFormValue({ backoff: 5000 }).backoffMode).toBe('fixed')
+    expect(jobOptsToFormValue({ backoff: 5000 }).backoffDelay).toBe('5000')
+  })
+
+  it('builds API payload and omits defaults', () => {
+    expect(formValueToJobOptions(createDefaultJobOptionsFormValue())).toBeUndefined()
+    expect(
+      formValueToJobOptions({
+        ...createDefaultJobOptionsFormValue(),
+        delay: '1000',
+        attempts: '3',
+        backoffMode: 'fixed',
+        backoffDelay: '500',
+      })
+    ).toEqual({
+      delay: 1000,
+      attempts: 3,
+      backoff: { type: 'fixed', delay: 500 },
+    })
+  })
+})

--- a/apps/web/src/lib/job-options.ts
+++ b/apps/web/src/lib/job-options.ts
@@ -1,0 +1,253 @@
+export type BackoffMode = 'none' | 'fixed' | 'exponential'
+export type RetentionMode = 'keep' | 'remove' | 'count'
+
+export interface JobOptionsFormValue {
+  delay: string
+  attempts: string
+  priority: string
+  backoffMode: BackoffMode
+  backoffDelay: string
+  removeOnCompleteMode: RetentionMode
+  removeOnCompleteCount: string
+  removeOnFailMode: RetentionMode
+  removeOnFailCount: string
+}
+
+export interface JobTemplateOptionsInput {
+  attempts?: number
+  priority?: number
+  backoff?: { type: 'fixed' | 'exponential'; delay: number }
+  removeOnComplete?: boolean | number
+  removeOnFail?: boolean | number
+}
+
+export interface JobOptionsInput extends JobTemplateOptionsInput {
+  delay?: number
+}
+
+export interface JobOptionsValidationErrors {
+  delay?: string
+  attempts?: string
+  priority?: string
+  backoff?: string
+  removeOnComplete?: string
+  removeOnFail?: string
+}
+
+export function createDefaultJobOptionsFormValue(): JobOptionsFormValue {
+  return {
+    delay: '0',
+    attempts: '1',
+    priority: '0',
+    backoffMode: 'none',
+    backoffDelay: '5000',
+    removeOnCompleteMode: 'keep',
+    removeOnCompleteCount: '100',
+    removeOnFailMode: 'keep',
+    removeOnFailCount: '100',
+  }
+}
+
+export function parseOptionalWholeNumber(value: string): number | undefined {
+  const normalized = value.trim()
+  if (!normalized) {
+    return undefined
+  }
+
+  if (!/^\d+$/.test(normalized)) {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(normalized, 10)
+  return Number.isSafeInteger(parsed) ? parsed : undefined
+}
+
+export function getRetentionMode(value: boolean | number | undefined): RetentionMode {
+  if (value === true) {
+    return 'remove'
+  }
+
+  if (typeof value === 'number') {
+    return 'count'
+  }
+
+  return 'keep'
+}
+
+export function getRetentionCount(value: boolean | number | undefined): string {
+  return typeof value === 'number' ? String(value) : '100'
+}
+
+function parseBackoff(
+  backoff: unknown
+): Pick<JobOptionsFormValue, 'backoffMode' | 'backoffDelay'> {
+  if (typeof backoff === 'number') {
+    return {
+      backoffMode: 'fixed',
+      backoffDelay: String(backoff),
+    }
+  }
+
+  if (
+    backoff &&
+    typeof backoff === 'object' &&
+    'type' in backoff &&
+  (backoff.type === 'fixed' || backoff.type === 'exponential') &&
+    'delay' in backoff &&
+    typeof backoff.delay === 'number'
+  ) {
+    return {
+      backoffMode: backoff.type,
+      backoffDelay: String(backoff.delay),
+    }
+  }
+
+  return {
+    backoffMode: 'none',
+    backoffDelay: '5000',
+  }
+}
+
+export function jobOptsToFormValue(
+  opts: Record<string, unknown> | undefined,
+  delay = 0
+): JobOptionsFormValue {
+  const defaults = createDefaultJobOptionsFormValue()
+  if (!opts) {
+    return {
+      ...defaults,
+      delay: String(delay),
+    }
+  }
+
+  const backoff = parseBackoff(opts.backoff)
+
+  return {
+    delay: String(delay),
+    attempts: opts.attempts ? String(opts.attempts) : defaults.attempts,
+    priority: opts.priority ? String(opts.priority) : defaults.priority,
+    backoffMode: backoff.backoffMode,
+    backoffDelay: backoff.backoffDelay,
+    removeOnCompleteMode: getRetentionMode(opts.removeOnComplete as boolean | number | undefined),
+    removeOnCompleteCount: getRetentionCount(opts.removeOnComplete as boolean | number | undefined),
+    removeOnFailMode: getRetentionMode(opts.removeOnFail as boolean | number | undefined),
+    removeOnFailCount: getRetentionCount(opts.removeOnFail as boolean | number | undefined),
+  }
+}
+
+export function templateOptionsToFormValue(
+  templateOptions: JobTemplateOptionsInput | undefined
+): Omit<JobOptionsFormValue, 'delay'> {
+  const { delay: _delay, ...rest } = jobOptsToFormValue(
+    templateOptions as Record<string, unknown> | undefined
+  )
+  return rest
+}
+
+export function validateJobOptionsFormValue(
+  value: JobOptionsFormValue,
+  options: { includeDelay?: boolean } = {}
+): JobOptionsValidationErrors {
+  const errors: JobOptionsValidationErrors = {}
+  const includeDelay = options.includeDelay ?? false
+
+  if (includeDelay) {
+    const delayValue = parseOptionalWholeNumber(value.delay)
+    if (delayValue === undefined) {
+      errors.delay = 'Delay must be a whole number.'
+    }
+  }
+
+  const attemptsValue = parseOptionalWholeNumber(value.attempts)
+  if (attemptsValue === undefined || attemptsValue < 1) {
+    errors.attempts = 'Attempts must be at least 1.'
+  }
+
+  const priorityValue = parseOptionalWholeNumber(value.priority)
+  if (priorityValue === undefined) {
+    errors.priority = 'Priority must be a whole number.'
+  }
+
+  const backoffDelayValue = parseOptionalWholeNumber(value.backoffDelay)
+  if (
+    value.backoffMode !== 'none' &&
+    (backoffDelayValue === undefined || backoffDelayValue < 1)
+  ) {
+    errors.backoff = 'Backoff delay must be greater than 0.'
+  }
+
+  const removeOnCompleteCountValue = parseOptionalWholeNumber(value.removeOnCompleteCount)
+  if (
+    value.removeOnCompleteMode === 'count' &&
+    (removeOnCompleteCountValue === undefined || removeOnCompleteCountValue < 1)
+  ) {
+    errors.removeOnComplete = 'Enter how many completed jobs to retain.'
+  }
+
+  const removeOnFailCountValue = parseOptionalWholeNumber(value.removeOnFailCount)
+  if (
+    value.removeOnFailMode === 'count' &&
+    (removeOnFailCountValue === undefined || removeOnFailCountValue < 1)
+  ) {
+    errors.removeOnFail = 'Enter how many failed jobs to retain.'
+  }
+
+  return errors
+}
+
+export function hasJobOptionsValidationErrors(errors: JobOptionsValidationErrors): boolean {
+  return Object.values(errors).some(Boolean)
+}
+
+export function formValueToTemplateOptions(
+  value: Pick<JobOptionsFormValue, keyof Omit<JobOptionsFormValue, 'delay'>>
+): JobTemplateOptionsInput | undefined {
+  const attemptsValue = parseOptionalWholeNumber(value.attempts)
+  const priorityValue = parseOptionalWholeNumber(value.priority)
+  const backoffDelayValue = parseOptionalWholeNumber(value.backoffDelay)
+  const removeOnCompleteCountValue = parseOptionalWholeNumber(value.removeOnCompleteCount)
+  const removeOnFailCountValue = parseOptionalWholeNumber(value.removeOnFailCount)
+
+  const options: JobTemplateOptionsInput = {}
+
+  if ((attemptsValue ?? 1) > 1) {
+    options.attempts = attemptsValue
+  }
+
+  if ((priorityValue ?? 0) > 0) {
+    options.priority = priorityValue
+  }
+
+  if (value.backoffMode !== 'none' && backoffDelayValue) {
+    options.backoff = {
+      type: value.backoffMode,
+      delay: backoffDelayValue,
+    }
+  }
+
+  if (value.removeOnCompleteMode === 'remove') {
+    options.removeOnComplete = true
+  } else if (value.removeOnCompleteMode === 'count' && removeOnCompleteCountValue) {
+    options.removeOnComplete = removeOnCompleteCountValue
+  }
+
+  if (value.removeOnFailMode === 'remove') {
+    options.removeOnFail = true
+  } else if (value.removeOnFailMode === 'count' && removeOnFailCountValue) {
+    options.removeOnFail = removeOnFailCountValue
+  }
+
+  return Object.keys(options).length > 0 ? options : undefined
+}
+
+export function formValueToJobOptions(value: JobOptionsFormValue): JobOptionsInput | undefined {
+  const templateOptions = formValueToTemplateOptions(value)
+  const delayValue = parseOptionalWholeNumber(value.delay)
+  const options: JobOptionsInput = { ...templateOptions }
+
+  if (delayValue !== undefined && delayValue > 0) {
+    options.delay = delayValue
+  }
+
+  return Object.keys(options).length > 0 ? options : undefined
+}

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -597,11 +597,8 @@ function JobDetailPage() {
           originalJobId={job.id}
           originalJobName={job.name}
           originalJobData={job.data}
-          originalOptions={{
-            delay: job.delay,
-            priority: job.priority,
-            attempts: job.maxAttempts,
-          }}
+          originalJobOpts={job.opts}
+          originalDelay={job.delay}
           onSuccess={() => {
             navigate({
               to: '/$orgSlug/c/$connectionId/queues/$queueName',


### PR DESCRIPTION
## Summary
- Extend `POST /queues/:queueName/jobs` to accept backoff and retention options (`removeOnComplete`, `removeOnFail`) alongside existing delay, priority, and attempts fields
- Add shared `JobOptionsFields` UI used by Add Job, Duplicate Job, and scheduled job forms
- Fix Duplicate Job to prefill from full `job.opts` so duplicated jobs preserve retry and retention behavior

Fixes durabullhq/durabull#61

## Test plan
- [x] `bun test apps/api/src/lib/job-options.test.ts apps/api/src/lib/scheduled-jobs.test.ts`
- [x] `vitest run apps/web/src/lib/job-options.test.ts`
- [x] `tsc --noEmit` in `apps/web`
- [ ] Manual: add job with backoff + retention and verify Options tab
- [ ] Manual: duplicate a job with non-default options and confirm values are preserved


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for backoff strategies and job retention settings when creating and duplicating jobs.
  * Introduced unified job options form with improved input validation and error feedback.

* **Documentation**
  * Updated HTTP API reference to document all supported job options including scheduling, priority, and retention controls.

* **Refactor**
  * Consolidated job option handling across API and UI for consistency and reduced duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->