### PR TITLE
Fix alerts sidebar badge scoping per connection

### DIFF
--- a/apps/web/src/components/alerts/connection-alerts-workspace.tsx
+++ b/apps/web/src/components/alerts/connection-alerts-workspace.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
+  getOpenAlertCount,
   useAlertSummary,
   useConnectionAlertEvents,
   useConnectionAlertRules,
@@ -66,8 +67,7 @@ export function ConnectionAlertsWorkspace({
   const deleteRuleMutation = useDeleteAlertRule(connectionId)
   const resolveEventMutation = useResolveAlertEvent()
 
-  const firingCount =
-    summaryQuery.data?.connections.find((entry) => entry.connectionId === connectionId)?.count ?? 0
+  const firingCount = getOpenAlertCount(summaryQuery.data?.connections, connectionId)
   const rules = rulesQuery.data?.rules ?? []
   const events = eventsQuery.data?.events ?? []
 

--- a/apps/web/src/hooks/use-alerts.test.tsx
+++ b/apps/web/src/hooks/use-alerts.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import type { PropsWithChildren } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  getOpenAlertCount,
   useConnectionAlertRules,
   useCreateAlertRule,
   useGlobalAlertEvents,
@@ -77,6 +78,35 @@ function createWrapper(queryClient: QueryClient) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   }
 }
+
+describe('getOpenAlertCount', () => {
+  it('returns org-wide total when connectionId is omitted', () => {
+    expect(
+      getOpenAlertCount([
+        { connectionId: 'conn-a', count: 2 },
+        { connectionId: 'conn-b', count: 1 },
+      ])
+    ).toBe(3)
+  })
+
+  it('returns only the selected connection count when connectionId is provided', () => {
+    expect(
+      getOpenAlertCount(
+        [
+          { connectionId: 'conn-a', count: 2 },
+          { connectionId: 'conn-b', count: 1 },
+        ],
+        'conn-b'
+      )
+    ).toBe(1)
+  })
+
+  it('returns zero when the connection has no open incidents', () => {
+    expect(
+      getOpenAlertCount([{ connectionId: 'conn-a', count: 2 }], 'conn-missing')
+    ).toBe(0)
+  })
+})
 
 function createQueryClient() {
   return new QueryClient({

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -360,6 +360,18 @@ function invalidateAlertQueries(queryClient: QueryClient, connectionId?: string)
   }
 }
 
+/** Open incident count for one connection, or org-wide when connectionId is omitted. */
+export function getOpenAlertCount(
+  connections: AlertSummaryConnection[] | undefined,
+  connectionId?: string
+): number {
+  const entries = connections ?? []
+  if (connectionId) {
+    return entries.find((entry) => entry.connectionId === connectionId)?.count ?? 0
+  }
+  return entries.reduce((sum, entry) => sum + entry.count, 0)
+}
+
 export function useAlertSummary(options?: { refetchInterval?: number }) {
   return useQuery({
     queryKey: alertKeys.summary(),

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -38,7 +38,7 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { Badge } from '@/components/ui/badge'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Toaster } from '@/components/ui/sonner'
-import { useAlertSummary } from '@/hooks/use-alerts'
+import { getOpenAlertCount, useAlertSummary } from '@/hooks/use-alerts'
 import { useAppConfig } from '@/hooks/use-app-config'
 import { useAppMode } from '@/hooks/use-app-mode'
 import { useAuth } from '@/hooks/use-auth'
@@ -377,14 +377,14 @@ function SidebarNav() {
   const { isAuthless } = useAppMode()
   const { currentConnection } = useConnection()
   const { data: alertSummary } = useAlertSummary()
+  const params = useParams({ strict: false }) as { connectionId?: string }
   const connectionId = currentConnection?.id
   // Get orgSlug from route params or fall back to active organization
   const orgSlug = useCurrentOrgSlug()
-  const totalOpenAlerts =
-    alertSummary?.connections.reduce(
-      (sum: number, entry: { count: number }) => sum + entry.count,
-      0
-    ) ?? 0
+  const openAlertsBadgeCount = useMemo(
+    () => getOpenAlertCount(alertSummary?.connections, params.connectionId),
+    [alertSummary?.connections, params.connectionId]
+  )
 
   // If no connection or org is selected, we can still show nav but links won't work
   // The index page will handle redirecting to a connection
@@ -399,7 +399,7 @@ function SidebarNav() {
       <NavLink to={basePath} icon={Layers}>
         Queues
       </NavLink>
-      <NavLink to={`${basePath}/alerts`} icon={BellRing} badge={totalOpenAlerts}>
+      <NavLink to={`${basePath}/alerts`} icon={BellRing} badge={openAlertsBadgeCount}>
         Alerts
       </NavLink>
       <NavLink to={`${basePath}/analytics`} icon={BarChart3}>
@@ -434,14 +434,14 @@ function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
   const { isAuthless } = useAppMode()
   const { currentConnection } = useConnection()
   const { data: alertSummary } = useAlertSummary()
+  const params = useParams({ strict: false }) as { connectionId?: string }
   const connectionId = currentConnection?.id
   // Get orgSlug from route params or fall back to active organization
   const orgSlug = useCurrentOrgSlug()
-  const totalOpenAlerts =
-    alertSummary?.connections.reduce(
-      (sum: number, entry: { count: number }) => sum + entry.count,
-      0
-    ) ?? 0
+  const openAlertsBadgeCount = useMemo(
+    () => getOpenAlertCount(alertSummary?.connections, params.connectionId),
+    [alertSummary?.connections, params.connectionId]
+  )
 
   const basePath =
     orgSlug && connectionId ? `/${orgSlug}/c/${connectionId}` : orgSlug ? `/${orgSlug}` : '/'
@@ -458,7 +458,7 @@ function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
         to={`${basePath}/alerts`}
         icon={BellRing}
         onNavigate={onNavigate}
-        badge={totalOpenAlerts}
+        badge={openAlertsBadgeCount}
       >
         Alerts
       </MobileNavLink>


### PR DESCRIPTION
## Summary
- Scope the Alerts nav badge to the active connection when viewing connection routes, instead of summing open incidents org-wide.
- Add `getOpenAlertCount()` helper and reuse it in the connection alerts workspace.

## Test plan
- [ ] Open a connection with firing incidents and confirm the sidebar badge matches that connection's count.
- [ ] Switch to a connection with no open incidents and confirm the badge clears (does not show counts from other connections).
- [ ] On org-level alerts routes (no `connectionId` in URL), confirm the badge still shows the org-wide total.


Made with [Cursor](https://cursor.com)