### PR TITLE
NO-LINEAR: MCP PR-02 API /mcp ingress and transport

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,6 +32,7 @@
     "@durabull/analytics": "workspace:*",
     "@durabull/dal": "workspace:*",
     "@durabull/env": "workspace:*",
+    "@durabull/mcp": "workspace:*",
     "@durabull/email": "workspace:*",
     "@hono/zod-validator": "^0.4.2",
     "better-auth": "^1.4.9",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,12 +11,14 @@ import { secureHeaders } from 'hono/secure-headers'
 import { getAuth } from './lib/auth'
 import { isAuthlessMode } from './lib/authless'
 import { getAppVersionPayload } from './lib/build-info'
+import { mountMcpIngress } from './mcp/mount'
 import { RedisUnavailableError } from './lib/redis'
 import { createSessionMiddleware } from './middleware/auth'
 import { createConnectionMiddleware } from './middleware/connection'
 import {
   apiRateLimiter,
   authRateLimiter,
+  mcpRateLimiter,
   telemetryCollectRateLimiter,
 } from './middleware/rate-limit'
 import alertsRoutes from './routes/alerts'
@@ -410,6 +412,11 @@ export async function createApiApp(options: CreateApiAppOptions = {}) {
 
   // Mount API under /api prefix
   app.route('/api', api)
+
+  // MCP Streamable HTTP ingress (before SPA/static fallbacks in index.ts)
+  app.use('/mcp', mcpRateLimiter)
+  app.use('/mcp/*', mcpRateLimiter)
+  app.route('/mcp', mountMcpIngress())
 
   // PostHog reverse proxy to bypass ad blockers
   // See: https://posthog.com/docs/advanced/proxy

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -133,6 +133,7 @@ console.log(`
 🚀 Durabull API Server
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📡 API:    http://localhost:${port}/api
+🔌 MCP:    http://localhost:${port}/mcp
 🏥 Health: http://localhost:${port}/api/health
 ${dbBanner}
 ${authBanner}

--- a/apps/api/src/mcp/mount.test.ts
+++ b/apps/api/src/mcp/mount.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Hono } from 'hono'
+import { closeDb } from '@durabull/dal'
+import { MCP_PROTOCOL_VERSION } from '@durabull/mcp'
+import {
+  MCP_JSON_RPC_VERSION,
+  mcpHeaders,
+  parseSseJson,
+  postMcpJson,
+} from '@durabull/mcp/testing'
+import { env } from '@durabull/env'
+import { createApiApp } from '../app'
+
+const mutableEnv = env as {
+  APP_BASE_URL?: string
+  DURABULL_AUTHLESS?: boolean
+}
+
+const originalAppBaseUrl = mutableEnv.APP_BASE_URL
+const originalAuthless = mutableEnv.DURABULL_AUTHLESS
+const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+
+let tempPgliteDir = ''
+let app: Hono
+
+describe('api MCP ingress', () => {
+  beforeEach(async () => {
+    tempPgliteDir = await mkdtemp(join(tmpdir(), 'durabull-api-mcp-'))
+    process.env.DURABULL_PGLITE_DIR = tempPgliteDir
+    mutableEnv.APP_BASE_URL = 'http://localhost:3000'
+    mutableEnv.DURABULL_AUTHLESS = true
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+  })
+
+  afterEach(async () => {
+    await closeDb()
+    mutableEnv.APP_BASE_URL = originalAppBaseUrl
+    mutableEnv.DURABULL_AUTHLESS = originalAuthless
+
+    if (originalPgliteDir) {
+      process.env.DURABULL_PGLITE_DIR = originalPgliteDir
+    } else {
+      delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (tempPgliteDir) {
+      await rm(tempPgliteDir, { recursive: true, force: true })
+      tempPgliteDir = ''
+    }
+  })
+
+  const postMcp = (body: Parameters<typeof postMcpJson>[2], options?: Parameters<typeof postMcpJson>[3]) =>
+    postMcpJson((path, init) => app.request(path, init), '/mcp', body, options)
+
+  it('rejects /mcp requests with invalid Host header', async () => {
+    const response = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0.0' },
+        },
+      },
+      { host: 'attacker.example.com' }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('supports initialize, tools/list, and ping on one app instance', async () => {
+    const initResponse = await postMcp({
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+    })
+
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        method: 'notifications/initialized',
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    const listResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    expect(listResponse.status).toBe(200)
+    const listPayload = parseSseJson(await listResponse.text()) as {
+      result?: { tools?: Array<{ name: string }> }
+    }
+    expect(listPayload.result?.tools?.map((tool) => tool.name)).toContain('ping')
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'ping',
+          arguments: {},
+        },
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    expect(callResponse.status).toBe(200)
+    const callPayload = parseSseJson(await callResponse.text()) as {
+      result?: { content?: Array<{ type: string; text?: string }> }
+    }
+    expect(callPayload.result?.content?.[0]?.text).toBe('pong')
+  })
+
+  it('does not treat GET /mcp as SPA static fallback when web build is absent', async () => {
+    const response = await app.request('/mcp', {
+      method: 'GET',
+      headers: mcpHeaders(),
+    })
+
+    expect(response.headers.get('content-type')).not.toContain('text/html')
+  })
+})

--- a/apps/api/src/mcp/mount.ts
+++ b/apps/api/src/mcp/mount.ts
@@ -1,0 +1,22 @@
+import { createMcpRoutes, getDefaultAllowedHosts, getProductionAllowedHosts } from '@durabull/mcp'
+import { env } from '@durabull/env'
+
+import { APP_VERSION } from '../lib/build-info'
+
+/**
+ * Thin API ingress: mounts MCP Streamable HTTP transport at `/mcp`.
+ * All MCP protocol, transport, and tool logic lives in `@durabull/mcp`.
+ */
+export function mountMcpIngress() {
+  const appBaseUrl = env.APP_BASE_URL ?? 'http://localhost:5173'
+  const isProduction = env.NODE_ENV === 'production'
+
+  return createMcpRoutes({
+    version: APP_VERSION,
+    allowedHosts: isProduction
+      ? getProductionAllowedHosts(appBaseUrl)
+      : getDefaultAllowedHosts({ appBaseUrl, includeDevHosts: true }),
+    corsOrigins: [appBaseUrl],
+    allowHostnameWithoutPort: !isProduction,
+  })
+}

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -243,3 +243,22 @@ export const connectionTestRateLimiter = rateLimiter({
   limit: 10, // 10 connection tests per minute
   keyPrefix: 'rl:conn-test',
 })
+
+/**
+ * Rate limiter for MCP Streamable HTTP ingress at /mcp.
+ */
+export const mcpRateLimiter = rateLimiter({
+  windowMs: 60 * 1000,
+  limit: 120,
+  keyPrefix: 'rl:mcp',
+  onRateLimit: (c) =>
+    c.json(
+      {
+        error: 'Too Many Requests',
+        code: 'RATE_LIMITED',
+        message: 'MCP rate limit exceeded. Please slow down.',
+        retryAfter: 60,
+      },
+      429
+    ),
+})

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -251,6 +251,14 @@ export const mcpRateLimiter = rateLimiter({
   windowMs: 60 * 1000,
   limit: 120,
   keyPrefix: 'rl:mcp',
+  // Do not trust client-controlled x-forwarded-for for MCP throttling.
+  keyGenerator: (c) => {
+    const cfIp = c.req.header('cf-connecting-ip')
+    if (cfIp) return cfIp
+    const realIp = c.req.header('x-real-ip')
+    if (realIp) return realIp
+    return 'mcp-anonymous'
+  },
   onRateLimit: (c) =>
     c.json(
       {

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@durabull/dal": "workspace:*",
         "@durabull/email": "workspace:*",
         "@durabull/env": "workspace:*",
+        "@durabull/mcp": "workspace:*",
         "@hono/zod-validator": "^0.4.2",
         "better-auth": "^1.4.9",
         "bullmq": "^5.34.8",
@@ -222,6 +223,20 @@
         "ioredis": "^5.4.2",
       },
       "devDependencies": {
+        "@types/node": "^22.10.5",
+        "typescript": "^5.7.2",
+      },
+    },
+    "packages/mcp": {
+      "name": "@durabull/mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@hono/mcp": "^0.3.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "hono": "^4.6.14",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
         "@types/node": "^22.10.5",
         "typescript": "^5.7.2",
       },
@@ -437,6 +452,8 @@
 
     "@durabull/fleet-demo-workload": ["@durabull/fleet-demo-workload@workspace:packages/fleet-demo-workload"],
 
+    "@durabull/mcp": ["@durabull/mcp@workspace:packages/mcp"],
+
     "@durabull/scripts": ["@durabull/scripts@workspace:tooling/scripts"],
 
     "@durabull/utils": ["@durabull/utils@workspace:packages/utils"],
@@ -524,6 +541,10 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
     "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
+
+    "@hono/mcp": ["@hono/mcp@0.3.0", "", { "dependencies": { "pkce-challenge": "^5.0.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.1", "hono": "*", "hono-rate-limiter": "^0.5.3", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-UhSWFbZwRxHBdptOn2r1HyB8Vt6gU+BL3AbTis2t8TBW69ZhG4soJQ09yEL/t/ymxszJnWp5Rq6tOXXOjuK1qg=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
@@ -648,6 +669,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -1291,6 +1314,8 @@
 
     "bl": ["bl@6.1.6", "", { "dependencies": { "@types/readable-stream": "^4.0.0", "buffer": "^6.0.3", "inherits": "^2.0.4", "readable-stream": "^4.2.0" } }, "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
@@ -1319,6 +1344,8 @@
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -1330,6 +1357,8 @@
     "cacheable-request": ["cacheable-request@7.0.4", "", { "dependencies": { "clone-response": "^1.0.2", "get-stream": "^5.1.0", "http-cache-semantics": "^4.0.0", "keyv": "^4.0.0", "lowercase-keys": "^2.0.0", "normalize-url": "^6.0.1", "responselike": "^2.0.0" } }, "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001766", "", {}, "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA=="],
 
@@ -1419,11 +1448,17 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "core-js": ["core-js@3.48.0", "", {}, "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ=="],
 
@@ -1533,6 +1568,8 @@
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
@@ -1581,6 +1618,8 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
     "electron": ["electron@41.0.2", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-raotm/aO8kOs1jD8SI8ssJ7EKciQOY295AOOprl1TxW7B0At8m5Ae7qNU1xdMxofiHMR8cNEGi9PKD3U+yT/mA=="],
@@ -1596,6 +1635,8 @@
     "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
 
@@ -1637,6 +1678,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
@@ -1665,17 +1708,27 @@
 
     "eta": ["eta@4.5.0", "", {}, "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -1703,11 +1756,17 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
     "framer-motion": ["framer-motion@11.18.2", "", { "dependencies": { "motion-dom": "^11.18.1", "motion-utils": "^11.18.1", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
@@ -1795,6 +1854,8 @@
 
     "hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
 
+    "hono-rate-limiter": ["hono-rate-limiter@0.5.3", "", { "peerDependencies": { "hono": "^4.10.8", "unstorage": "^1.17.3" }, "optionalPeers": ["unstorage"] }, "sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A=="],
+
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
@@ -1806,6 +1867,8 @@
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -1841,7 +1904,9 @@
 
     "ioredis": ["ioredis@5.9.2", "", { "dependencies": { "@ioredis/commands": "1.5.0", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -1872,6 +1937,8 @@
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-ssh": ["is-ssh@1.4.1", "", { "dependencies": { "protocols": "^2.0.1" } }, "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg=="],
 
@@ -2055,6 +2122,10 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
@@ -2225,9 +2296,13 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -2269,6 +2344,8 @@
 
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -2308,6 +2385,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
@@ -2359,6 +2438,8 @@
 
     "protocols": ["protocols@2.0.2", "", {}, "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -2367,9 +2448,15 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
     "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
@@ -2475,6 +2562,8 @@
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -2503,13 +2592,19 @@
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "seroval": ["seroval@1.5.0", "", {}, "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
@@ -2518,6 +2613,14 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
@@ -2566,6 +2669,8 @@
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -2655,6 +2760,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
@@ -2689,6 +2796,8 @@
 
     "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
@@ -2722,6 +2831,8 @@
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
@@ -2831,6 +2942,8 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
@@ -2850,6 +2963,8 @@
     "@develar/schema-utils/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "@durabull/api/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@durabull/mcp/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@durabull/web/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -2880,6 +2995,8 @@
     "@inquirer/external-editor/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -2969,6 +3086,10 @@
 
     "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "better-call/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "c12/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "cacache/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -3014,6 +3135,8 @@
     "execa/get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
 
     "execa/onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
+
+    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
@@ -3067,6 +3190,8 @@
 
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "react-email/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "react-email/ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
@@ -3085,6 +3210,8 @@
 
     "socket.io/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
+    "socks/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -3096,6 +3223,8 @@
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "tsx/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "vite/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -3116,6 +3245,8 @@
     "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "@durabull/api/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@durabull/mcp/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@durabull/web/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -3417,6 +3548,8 @@
 
     "@durabull/api/@types/bun/bun-types/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
+    "@durabull/mcp/@types/bun/bun-types/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
     "@durabull/web/@types/bun/bun-types/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -3456,6 +3589,8 @@
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@durabull/api/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@durabull/mcp/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@durabull/web/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@durabull/mcp",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./testing": {
+      "types": "./src/testing/mcp-test-client.ts",
+      "import": "./src/testing/mcp-test-client.ts"
+    }
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint ./src",
+    "lint:fix": "biome lint --write ./src",
+    "format": "biome format --write ./src",
+    "format:check": "biome format ./src"
+  },
+  "dependencies": {
+    "@hono/mcp": "^0.3.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/mcp/src/config/allowed-hosts.test.ts
+++ b/packages/mcp/src/config/allowed-hosts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test'
+
+import { getDefaultAllowedHosts, getProductionAllowedHosts, isAllowedHost } from './allowed-hosts'
+
+describe('allowed hosts', () => {
+  it('includes dev hosts and APP_BASE_URL host', () => {
+    const hosts = getDefaultAllowedHosts({
+      appBaseUrl: 'https://app.durabull.io',
+      includeDevHosts: true,
+    })
+
+    expect(hosts.has('localhost')).toBe(true)
+    expect(hosts.has('127.0.0.1')).toBe(true)
+    expect(hosts.has('app.durabull.io')).toBe(true)
+  })
+
+  it('rejects fake port suffix in host header', () => {
+    const hosts = getDefaultAllowedHosts({
+      appBaseUrl: 'http://localhost:3000',
+      includeDevHosts: true,
+    })
+
+    expect(isAllowedHost('localhost:3000', hosts)).toBe(true)
+    expect(isAllowedHost('localhost:3000.evil', hosts)).toBe(false)
+    expect(isAllowedHost('evil.example.com', hosts)).toBe(false)
+  })
+
+  it('production allowlist omits dev hosts and requires exact host match', () => {
+    const hosts = getProductionAllowedHosts('https://app.durabull.io')
+
+    expect(hosts.has('localhost')).toBe(false)
+    expect(isAllowedHost('app.durabull.io', hosts, { allowHostnameWithoutPort: false })).toBe(
+      true
+    )
+    expect(isAllowedHost('app.durabull.io:443', hosts, { allowHostnameWithoutPort: false })).toBe(
+      false
+    )
+  })
+
+  it('rejects missing host header', () => {
+    const hosts = getDefaultAllowedHosts({ appBaseUrl: 'http://localhost:3000' })
+    expect(isAllowedHost(undefined, hosts)).toBe(false)
+  })
+})

--- a/packages/mcp/src/config/allowed-hosts.test.ts
+++ b/packages/mcp/src/config/allowed-hosts.test.ts
@@ -25,6 +25,14 @@ describe('allowed hosts', () => {
     expect(isAllowedHost('evil.example.com', hosts)).toBe(false)
   })
 
+  it('adds default-port host variants for https and http base URLs', () => {
+    const httpsHosts = getProductionAllowedHosts('https://app.durabull.io')
+    expect(httpsHosts.has('app.durabull.io:443')).toBe(true)
+
+    const httpHosts = getProductionAllowedHosts('http://app.durabull.io')
+    expect(httpHosts.has('app.durabull.io:80')).toBe(true)
+  })
+
   it('production allowlist omits dev hosts and requires exact host match', () => {
     const hosts = getProductionAllowedHosts('https://app.durabull.io')
 
@@ -33,7 +41,7 @@ describe('allowed hosts', () => {
       true
     )
     expect(isAllowedHost('app.durabull.io:443', hosts, { allowHostnameWithoutPort: false })).toBe(
-      false
+      true
     )
   })
 

--- a/packages/mcp/src/config/allowed-hosts.ts
+++ b/packages/mcp/src/config/allowed-hosts.ts
@@ -1,0 +1,86 @@
+import { parseHostHeader } from './parse-host'
+
+const DEV_HOST_ENTRIES = [
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  'localhost:3000',
+  'localhost:3001',
+  '127.0.0.1:3000',
+] as const
+
+export interface GetDefaultAllowedHostsOptions {
+  appBaseUrl: string
+  /** Include localhost / loopback entries (default: true outside production). */
+  includeDevHosts?: boolean
+  /**
+   * When true, a request with no port matches a bare hostname entry.
+   * When false, only exact `host` or `hostname:port` entries match (stricter).
+   */
+  allowHostnameWithoutPort?: boolean
+}
+
+function addHostFromUrl(hosts: Set<string>, rawUrl: string): void {
+  try {
+    const parsed = new URL(rawUrl)
+    if (parsed.host) {
+      hosts.add(parsed.host.toLowerCase())
+    }
+    if (!parsed.port && parsed.hostname) {
+      hosts.add(parsed.hostname.toLowerCase())
+    }
+  } catch {
+    // Caller should pass a valid app base URL.
+  }
+}
+
+export function getDefaultAllowedHosts(options: GetDefaultAllowedHostsOptions): ReadonlySet<string> {
+  const { appBaseUrl, includeDevHosts = true } = options
+
+  const hosts = new Set<string>()
+
+  if (includeDevHosts) {
+    for (const entry of DEV_HOST_ENTRIES) {
+      hosts.add(entry)
+    }
+  }
+
+  addHostFromUrl(hosts, appBaseUrl)
+
+  return hosts
+}
+
+export interface IsAllowedHostOptions {
+  allowHostnameWithoutPort?: boolean
+}
+
+/**
+ * Returns whether `hostHeader` matches the allowlist.
+ * Rejects malformed hosts (including `localhost:3000.evil`).
+ */
+export function isAllowedHost(
+  hostHeader: string | undefined,
+  allowedHosts: ReadonlySet<string>,
+  options: IsAllowedHostOptions = {}
+): boolean {
+  if (!hostHeader?.trim()) return false
+
+  const parsed = parseHostHeader(hostHeader)
+  if (!parsed) return false
+
+  if (allowedHosts.has(parsed.host)) return true
+
+  if (parsed.port === undefined && options.allowHostnameWithoutPort !== false) {
+    return allowedHosts.has(parsed.hostname)
+  }
+
+  return false
+}
+
+export function getProductionAllowedHosts(appBaseUrl: string): ReadonlySet<string> {
+  return getDefaultAllowedHosts({
+    appBaseUrl,
+    includeDevHosts: false,
+    allowHostnameWithoutPort: false,
+  })
+}

--- a/packages/mcp/src/config/allowed-hosts.ts
+++ b/packages/mcp/src/config/allowed-hosts.ts
@@ -27,7 +27,10 @@ function addHostFromUrl(hosts: Set<string>, rawUrl: string): void {
       hosts.add(parsed.host.toLowerCase())
     }
     if (!parsed.port && parsed.hostname) {
-      hosts.add(parsed.hostname.toLowerCase())
+      const hostname = parsed.hostname.toLowerCase()
+      hosts.add(hostname)
+      if (parsed.protocol === 'https:') hosts.add(`${hostname}:443`)
+      if (parsed.protocol === 'http:') hosts.add(`${hostname}:80`)
     }
   } catch {
     // Caller should pass a valid app base URL.

--- a/packages/mcp/src/config/parse-host.test.ts
+++ b/packages/mcp/src/config/parse-host.test.ts
@@ -23,4 +23,10 @@ describe('parseHostHeader', () => {
       host: '[::1]:3000',
     })
   })
+
+  it('rejects out-of-range ports', () => {
+    expect(parseHostHeader('localhost:0')).toBeNull()
+    expect(parseHostHeader('localhost:70000')).toBeNull()
+    expect(parseHostHeader('[::1]:0')).toBeNull()
+  })
 })

--- a/packages/mcp/src/config/parse-host.test.ts
+++ b/packages/mcp/src/config/parse-host.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test'
+
+import { parseHostHeader } from './parse-host'
+
+describe('parseHostHeader', () => {
+  it('parses host with port', () => {
+    expect(parseHostHeader('localhost:3000')).toEqual({
+      hostname: 'localhost',
+      port: '3000',
+      host: 'localhost:3000',
+    })
+  })
+
+  it('rejects fake port suffix attacks', () => {
+    expect(parseHostHeader('localhost:3000.evil.example')).toBeNull()
+    expect(parseHostHeader('app.durabull.io:443.attacker.tld')).toBeNull()
+  })
+
+  it('parses bracketed IPv6 with port', () => {
+    expect(parseHostHeader('[::1]:3000')).toEqual({
+      hostname: '[::1]',
+      port: '3000',
+      host: '[::1]:3000',
+    })
+  })
+})

--- a/packages/mcp/src/config/parse-host.ts
+++ b/packages/mcp/src/config/parse-host.ts
@@ -1,0 +1,50 @@
+export interface ParsedHostHeader {
+  /** Lowercase hostname or bracketed IPv6 (e.g. `[::1]`). */
+  hostname: string
+  /** Numeric port when present. */
+  port?: string
+  /** Full host value for exact allowlist matching (`hostname` or `hostname:port`). */
+  host: string
+}
+
+/**
+ * Parse an HTTP Host header without treating fake port suffixes as valid
+ * (e.g. `localhost:3000.evil` is rejected).
+ */
+export function parseHostHeader(hostHeader: string): ParsedHostHeader | null {
+  const trimmed = hostHeader.trim().toLowerCase()
+  if (!trimmed) return null
+
+  if (trimmed.includes('..') || /[^a-z0-9.:[\]-]/.test(trimmed)) {
+    return null
+  }
+
+  if (trimmed.startsWith('[')) {
+    const closeBracket = trimmed.indexOf(']')
+    if (closeBracket === -1) return null
+
+    const hostname = trimmed.slice(0, closeBracket + 1)
+    const after = trimmed.slice(closeBracket + 1)
+    if (after === '') {
+      return { hostname, host: hostname }
+    }
+    if (!after.startsWith(':')) return null
+
+    const port = after.slice(1)
+    if (!/^\d{1,5}$/.test(port)) return null
+
+    return { hostname, port, host: `${hostname}:${port}` }
+  }
+
+  const colonCount = (trimmed.match(/:/g) ?? []).length
+  if (colonCount > 1) return null
+
+  if (colonCount === 0) {
+    return { hostname: trimmed, host: trimmed }
+  }
+
+  const [hostname, port] = trimmed.split(':')
+  if (!hostname || !port || !/^\d{1,5}$/.test(port)) return null
+
+  return { hostname, port, host: `${hostname}:${port}` }
+}

--- a/packages/mcp/src/config/parse-host.ts
+++ b/packages/mcp/src/config/parse-host.ts
@@ -1,3 +1,9 @@
+function isValidPort(port: string): boolean {
+  if (!/^\d{1,5}$/.test(port)) return false
+  const value = Number(port)
+  return value >= 1 && value <= 65535
+}
+
 export interface ParsedHostHeader {
   /** Lowercase hostname or bracketed IPv6 (e.g. `[::1]`). */
   hostname: string
@@ -31,7 +37,7 @@ export function parseHostHeader(hostHeader: string): ParsedHostHeader | null {
     if (!after.startsWith(':')) return null
 
     const port = after.slice(1)
-    if (!/^\d{1,5}$/.test(port)) return null
+    if (!isValidPort(port)) return null
 
     return { hostname, port, host: `${hostname}:${port}` }
   }
@@ -44,7 +50,7 @@ export function parseHostHeader(hostHeader: string): ParsedHostHeader | null {
   }
 
   const [hostname, port] = trimmed.split(':')
-  if (!hostname || !port || !/^\d{1,5}$/.test(port)) return null
+  if (!hostname || !port || !isValidPort(port)) return null
 
   return { hostname, port, host: `${hostname}:${port}` }
 }

--- a/packages/mcp/src/constants.ts
+++ b/packages/mcp/src/constants.ts
@@ -1,0 +1,10 @@
+export const MCP_SERVER_NAME = 'durabull-mcp'
+
+/** Client `initialize` protocol version used in tests; server negotiates supported versions. */
+export const MCP_PROTOCOL_VERSION = '2024-11-05'
+
+export const MCP_JSON_RPC_VERSION = '2.0'
+
+export const MCP_ACCEPT_HEADER = 'application/json, text/event-stream'
+
+export const MCP_CONTENT_TYPE = 'application/json'

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  getDefaultAllowedHosts,
+  getProductionAllowedHosts,
+  type GetDefaultAllowedHostsOptions,
+} from './config/allowed-hosts'
+export { parseHostHeader } from './config/parse-host'
+export {
+  MCP_ACCEPT_HEADER,
+  MCP_CONTENT_TYPE,
+  MCP_JSON_RPC_VERSION,
+  MCP_PROTOCOL_VERSION,
+  MCP_SERVER_NAME,
+} from './constants'
+export { createMcpRoutes, type CreateMcpRoutesOptions } from './routes'

--- a/packages/mcp/src/middleware/host-validation.ts
+++ b/packages/mcp/src/middleware/host-validation.ts
@@ -1,0 +1,18 @@
+import type { MiddlewareHandler } from 'hono'
+
+import { isAllowedHost, type IsAllowedHostOptions } from '../config/allowed-hosts'
+
+export function createHostValidationMiddleware(
+  allowedHosts: ReadonlySet<string>,
+  options: IsAllowedHostOptions = {}
+): MiddlewareHandler {
+  return async (c, next) => {
+    const host = c.req.header('host')
+
+    if (!isAllowedHost(host, allowedHosts, options)) {
+      return c.json({ error: 'Forbidden', message: 'Invalid Host header' }, 403)
+    }
+
+    await next()
+  }
+}

--- a/packages/mcp/src/routes.test.ts
+++ b/packages/mcp/src/routes.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'bun:test'
+
+import { MCP_PROTOCOL_VERSION } from './constants'
+import { createMcpRoutes } from './routes'
+import {
+  MCP_JSON_RPC_VERSION,
+  postMcpJson,
+  readMcpJsonResponse,
+} from './testing/mcp-test-client'
+
+describe('createMcpRoutes', () => {
+  const app = createMcpRoutes({
+    version: 'test',
+    allowedHosts: new Set(['localhost', '127.0.0.1', 'localhost:3000']),
+    corsOrigins: ['http://localhost:3000'],
+  })
+
+  const postMcp = (body: Parameters<typeof postMcpJson>[2], options?: Parameters<typeof postMcpJson>[3]) =>
+    postMcpJson((path, init) => Promise.resolve(app.request(path, init)), '/', body, options)
+
+  it('rejects invalid Host header with 403', async () => {
+    const response = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0.0' },
+        },
+      },
+      { host: 'evil.example.com' }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects host header with fake port suffix', async () => {
+    const response = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0.0' },
+        },
+      },
+      { host: 'localhost:3000.evil' }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('initializes MCP session and lists ping tool', async () => {
+    const initResponse = await postMcp({
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+    })
+
+    expect(initResponse.status).toBe(200)
+    const initPayload = (await readMcpJsonResponse(initResponse)) as {
+      result?: { protocolVersion?: string }
+    }
+    expect(initPayload.result?.protocolVersion).toBeTruthy()
+
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        method: 'notifications/initialized',
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    const listResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    expect(listResponse.status).toBe(200)
+    const listPayload = (await readMcpJsonResponse(listResponse)) as {
+      result?: { tools?: Array<{ name: string }> }
+    }
+    expect(listPayload.result?.tools?.map((tool) => tool.name)).toContain('ping')
+  })
+
+  it('calls ping and returns pong', async () => {
+    const initResponse = await postMcp({
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+    })
+
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        method: 'notifications/initialized',
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'ping',
+          arguments: {},
+        },
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    expect(callResponse.status).toBe(200)
+    const callPayload = (await readMcpJsonResponse(callResponse)) as {
+      result?: { content?: Array<{ type: string; text?: string }> }
+    }
+    expect(callPayload.result?.content?.[0]?.text).toBe('pong')
+  })
+})

--- a/packages/mcp/src/routes.ts
+++ b/packages/mcp/src/routes.ts
@@ -39,10 +39,11 @@ export function createMcpRoutes(options: CreateMcpRoutesOptions): Hono {
         'Content-Type',
         'Authorization',
         'Accept',
-        'Mcp-Session-Id',
+        'mcp-session-id',
         'Mcp-Protocol-Version',
         'Last-Event-ID',
       ],
+      exposeHeaders: ['mcp-session-id'],
     })
   )
 

--- a/packages/mcp/src/routes.ts
+++ b/packages/mcp/src/routes.ts
@@ -1,0 +1,73 @@
+import { Hono } from 'hono'
+import { bodyLimit } from 'hono/body-limit'
+import { cors } from 'hono/cors'
+import type { MiddlewareHandler } from 'hono'
+
+import { createHostValidationMiddleware } from './middleware/host-validation'
+import { createMcpSessionRegistry } from './transport/session-registry'
+
+export interface CreateMcpRoutesOptions {
+  /** App version reported in MCP server metadata. */
+  version: string
+  /** Host allowlist (required — set at API ingress from APP_BASE_URL). */
+  allowedHosts: ReadonlySet<string>
+  /** CORS origins for /mcp. */
+  corsOrigins: string[]
+  /**
+   * Middleware applied after host validation and before body limit.
+   * PR-03: bearer token validation goes here.
+   */
+  middleware?: MiddlewareHandler[]
+  /** When false, only exact host entries match (recommended for production). */
+  allowHostnameWithoutPort?: boolean
+}
+
+export function createMcpRoutes(options: CreateMcpRoutesOptions): Hono {
+  const registry = createMcpSessionRegistry({
+    version: options.version,
+    allowedHosts: options.allowedHosts,
+  })
+
+  const routes = new Hono()
+
+  routes.use(
+    '*',
+    cors({
+      origin: options.corsOrigins,
+      allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+      allowHeaders: [
+        'Content-Type',
+        'Authorization',
+        'Accept',
+        'Mcp-Session-Id',
+        'Mcp-Protocol-Version',
+        'Last-Event-ID',
+      ],
+    })
+  )
+
+  routes.use(
+    '*',
+    createHostValidationMiddleware(options.allowedHosts, {
+      allowHostnameWithoutPort: options.allowHostnameWithoutPort,
+    })
+  )
+
+  for (const middleware of options.middleware ?? []) {
+    routes.use('*', middleware)
+  }
+
+  routes.use(
+    '*',
+    bodyLimit({
+      maxSize: 1024 * 1024,
+      onError: (c) =>
+        c.json({ error: 'Payload Too Large', message: 'Request body exceeds 1MB limit' }, 413),
+    })
+  )
+
+  // GET / POST / DELETE delegated to Streamable HTTP transport (@hono/mcp).
+  routes.all('/', async (c) => registry.handleRequest(c))
+
+  return routes
+}

--- a/packages/mcp/src/server/create-mcp-server.ts
+++ b/packages/mcp/src/server/create-mcp-server.ts
@@ -1,0 +1,19 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+import { MCP_SERVER_NAME } from '../constants'
+import { registerSmokeTools } from '../tools/register-smoke-tools'
+
+export interface CreateMcpServerOptions {
+  version: string
+}
+
+export function createMcpServer({ version }: CreateMcpServerOptions): McpServer {
+  const server = new McpServer({
+    name: MCP_SERVER_NAME,
+    version,
+  })
+
+  registerSmokeTools(server)
+
+  return server
+}

--- a/packages/mcp/src/testing/mcp-test-client.ts
+++ b/packages/mcp/src/testing/mcp-test-client.ts
@@ -21,16 +21,22 @@ export function mcpHeaders(host = 'localhost:3000', sessionId?: string): Record<
 }
 
 export function parseSseJson(body: string): unknown {
-  const dataLines = body
+  const trimmed = body.trim()
+  if (!trimmed) {
+    throw new SyntaxError('Empty MCP response body')
+  }
+
+  const lastEvent = trimmed.split('\n\n').at(-1) ?? trimmed
+  const dataLines = lastEvent
     .split('\n')
     .filter((line) => line.startsWith('data: '))
     .map((line) => line.slice('data: '.length))
 
   if (dataLines.length === 0) {
-    return JSON.parse(body)
+    return JSON.parse(trimmed)
   }
 
-  return JSON.parse(dataLines.at(-1) ?? dataLines[0] ?? '{}')
+  return JSON.parse(dataLines.join('\n'))
 }
 
 export async function readMcpJsonResponse(response: Response): Promise<unknown> {

--- a/packages/mcp/src/testing/mcp-test-client.ts
+++ b/packages/mcp/src/testing/mcp-test-client.ts
@@ -1,0 +1,58 @@
+import {
+  MCP_ACCEPT_HEADER,
+  MCP_CONTENT_TYPE,
+  MCP_JSON_RPC_VERSION,
+} from '../constants'
+
+export { MCP_ACCEPT_HEADER, MCP_CONTENT_TYPE, MCP_JSON_RPC_VERSION }
+
+export function mcpHeaders(host = 'localhost:3000', sessionId?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    host,
+    accept: MCP_ACCEPT_HEADER,
+    'content-type': MCP_CONTENT_TYPE,
+  }
+
+  if (sessionId) {
+    headers['mcp-session-id'] = sessionId
+  }
+
+  return headers
+}
+
+export function parseSseJson(body: string): unknown {
+  const dataLines = body
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => line.slice('data: '.length))
+
+  if (dataLines.length === 0) {
+    return JSON.parse(body)
+  }
+
+  return JSON.parse(dataLines.at(-1) ?? dataLines[0] ?? '{}')
+}
+
+export async function readMcpJsonResponse(response: Response): Promise<unknown> {
+  return parseSseJson(await response.text())
+}
+
+export interface JsonRpcRequest {
+  jsonrpc: typeof MCP_JSON_RPC_VERSION
+  id?: number | string
+  method: string
+  params?: Record<string, unknown>
+}
+
+export async function postMcpJson(
+  request: (path: string, init?: RequestInit) => Promise<Response>,
+  path: string,
+  body: JsonRpcRequest | Record<string, unknown>,
+  options: { host?: string; sessionId?: string } = {}
+): Promise<Response> {
+  return request(path, {
+    method: 'POST',
+    headers: mcpHeaders(options.host, options.sessionId),
+    body: JSON.stringify(body),
+  })
+}

--- a/packages/mcp/src/tools/register-smoke-tools.ts
+++ b/packages/mcp/src/tools/register-smoke-tools.ts
@@ -1,0 +1,12 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+/** Phase-1 smoke tools only (transport validation). Domain tools register in PR-05. */
+export function registerSmokeTools(server: McpServer): void {
+  server.tool(
+    'ping',
+    'Health check for MCP transport wiring (non-domain smoke tool).',
+    async () => ({
+      content: [{ type: 'text', text: 'pong' }],
+    })
+  )
+}

--- a/packages/mcp/src/transport/session-registry.ts
+++ b/packages/mcp/src/transport/session-registry.ts
@@ -1,0 +1,86 @@
+import { StreamableHTTPTransport } from '@hono/mcp'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { Context } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+
+import { createMcpServer } from '../server/create-mcp-server'
+
+interface McpSessionEntry {
+  transport: StreamableHTTPTransport
+  server: McpServer
+  connected: Promise<void>
+}
+
+export interface McpSessionRegistryOptions {
+  version: string
+  allowedHosts: ReadonlySet<string>
+}
+
+export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
+  const sessions = new Map<string, McpSessionEntry>()
+  const allowedHostList = [...options.allowedHosts]
+
+  function createSessionEntry(): McpSessionEntry {
+    const server = createMcpServer({ version: options.version })
+    const transport = new StreamableHTTPTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      enableDnsRebindingProtection: true,
+      allowedHosts: allowedHostList,
+      // Origin checks are handled by Hono CORS middleware (non-browser MCP clients omit Origin).
+      onsessioninitialized: async (sessionId) => {
+        sessions.set(sessionId, { transport, server, connected: connectPromise })
+      },
+      onsessionclosed: async (sessionId) => {
+        sessions.delete(sessionId)
+        try {
+          await server.close()
+        } catch {
+          // Session already torn down.
+        }
+      },
+    })
+
+    const connectPromise = server.connect(transport)
+    return { transport, server, connected: connectPromise }
+  }
+
+  async function handleRequest(c: Context): Promise<Response | undefined> {
+    const sessionId = c.req.header('mcp-session-id')
+
+    try {
+      if (sessionId) {
+        const session = sessions.get(sessionId)
+        if (!session) {
+          return jsonRpcErrorResponse(404, 'Session not found')
+        }
+
+        await session.connected
+        return session.transport.handleRequest(c)
+      }
+
+      const session = createSessionEntry()
+      await session.connected
+      return session.transport.handleRequest(c)
+    } catch (error) {
+      if (error instanceof HTTPException) {
+        throw error
+      }
+
+      console.error('[mcp] Request failed:', error)
+      return jsonRpcErrorResponse(-32603, 'Internal error')
+    }
+  }
+
+  return { handleRequest }
+}
+
+function jsonRpcErrorResponse(code: number, message: string): Response {
+  return Response.json(
+    {
+      jsonrpc: '2.0',
+      error: { code, message },
+      id: null,
+    },
+    { status: code === 404 ? 404 : 500 }
+  )
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun", "node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tasks/mcp-implementation-master-plan.md
+++ b/tasks/mcp-implementation-master-plan.md
@@ -27,7 +27,7 @@ Example cloud URL: `https://app.durabull.io/mcp`
 
 ### What this means for implementers
 
-- **Do:** implement MCP as a **logical module** under the API app (`apps/api/src/mcp/`).
+- **Do:** implement MCP as a **logical module** under the API app (`apps/api/src/mcp/` ingress) with protocol logic in `packages/mcp`.
 - **Do:** mount `/mcp` inside `createApiApp()` **before** SPA/static fallbacks (same precedence pattern as `/ingest/*`).
 - **Do:** keep domain/job logic out of MCP route handlers; use shared services/DTOs (see §2.2).
 - **Do not:** create or maintain a separate deployable `apps/mcp` process for phase 1.
@@ -200,7 +200,7 @@ flowchart LR
 ### 3.1 Runtime placement (phase 1)
 
 - **Deployable:** existing `apps/api` process (also serves web static/SPA in production).
-- **MCP module path:** `apps/api/src/mcp/` (transport wiring, tool registry, MCP middleware).
+- **MCP module path:** `packages/mcp` (transport, tools, auth/policy in later PRs) with thin mount at `apps/api/src/mcp/`.
 - **Ingress mount:** `createApiApp()` in `apps/api/src/app.ts` at `/mcp`.
 - **Shared packages:** domain/auth primitives in `packages/*` (and optional `packages/mcp-domain` later), not duplicated in a second app.
 

--- a/tasks/mcp-implementation-master-plan.md
+++ b/tasks/mcp-implementation-master-plan.md
@@ -19,7 +19,7 @@ Durabull ships MCP on the **same origin and same deployable** as the main API + 
 | Path | Purpose | Handler |
 | --- | --- | --- |
 | `/api/*` | REST/RPC API | `apps/api` Hono routes |
-| `/mcp` | MCP Streamable HTTP transport | `apps/api/src/mcp/*` mounted in `createApiApp()` |
+| `/mcp` | MCP Streamable HTTP transport | `packages/mcp` mounted via thin `apps/api/src/mcp/` ingress in `createApiApp()` |
 | `/ingest/*` | PostHog reverse proxy | `apps/api` (existing) |
 | `/`, `/assets/*` | Web SPA/static | `apps/api/src/index.ts` static serving |
 
@@ -213,7 +213,7 @@ flowchart LR
 
 ### 3.3 Module boundary rules (still required)
 
-- MCP transport/auth/policy code lives in `apps/api/src/mcp/*` (or extracted packages), not scattered across unrelated routes.
+- MCP transport/auth/policy code lives in `packages/mcp/*`; `apps/api/src/mcp/` is a thin ingress mount only (PR-03+ auth wiring at API boundary).
 - MCP tools call shared domain services; they do not import Hono `Context` into domain layers.
 - API REST routes and MCP tools must share tenancy checks and redaction utilities.
 
@@ -639,7 +639,7 @@ Do not mark phase complete until:
 
 Some branches may contain an experimental standalone `apps/mcp` package. Before continuing PR-03+:
 
-1. Move transport/tool code into `apps/api/src/mcp/`.
+1. Move transport/tool code into `packages/mcp/` (keep `apps/api/src/mcp/` as thin mount only).
 2. Mount `/mcp` in `createApiApp()`.
 3. Port tests to `apps/api` (request `/mcp` on `createApiApp()`).
 4. Remove standalone `apps/mcp` entrypoint and dual-process Docker runner.

--- a/tasks/mcp-pr-execution-playbook.md
+++ b/tasks/mcp-pr-execution-playbook.md
@@ -668,10 +668,10 @@ Finalize production quality and confirm spec/safety compliance.
 ### PR Record: PR-02
 
 - PR ID: `PR-02`
-- Branch: `main` (local implementation)
+- Branch: `cursor/mcp-pr02-api-ingress`
 - Linear issue: `NO-LINEAR (temporary)`
-- PR URL:
-- Status: `in progress`
+- PR URL: https://github.com/durabullhq/durabull/pull/88
+- Status: `in review`
 - Agent owner: `cursor`
 - Start date: `2026-05-26`
 - Merge date:
@@ -707,7 +707,7 @@ Finalize production quality and confirm spec/safety compliance.
 
 ## Live PR Tracker
 
-- [x] PR-01 Security architecture baseline (in progress on `feat/no-linear-mcp-pr01-security-baseline`)
+- [ ] PR-01 Security architecture baseline (in progress on `feat/no-linear-mcp-pr01-security-baseline`)
 - [x] PR-02 API `/mcp` ingress + transport (`@durabull/mcp` package + thin API mount)
 - [ ] PR-03 OAuth discovery + token validation
 - [ ] PR-04 Principals + policy engine

--- a/tasks/mcp-pr-execution-playbook.md
+++ b/tasks/mcp-pr-execution-playbook.md
@@ -665,10 +665,50 @@ Finalize production quality and confirm spec/safety compliance.
 
 ---
 
+### PR Record: PR-02
+
+- PR ID: `PR-02`
+- Branch: `main` (local implementation)
+- Linear issue: `NO-LINEAR (temporary)`
+- PR URL:
+- Status: `in progress`
+- Agent owner: `cursor`
+- Start date: `2026-05-26`
+- Merge date:
+
+#### Scope Completed
+
+- [x] `@durabull/mcp` package with transport, host validation, server bootstrap, and `ping` smoke tool.
+- [x] Thin ingress at `apps/api/src/mcp/mount.ts` mounted in `createApiApp()` at `/mcp`.
+- [x] Streamable HTTP on `/mcp` (`GET` + `POST` + `DELETE` via `@hono/mcp`).
+- [x] Host header validation including `APP_BASE_URL` host.
+- [x] Integration tests via `createApiApp()` (initialize, tools/list, tools/call ping).
+- [x] No standalone `apps/mcp` deployable or second public MCP port.
+
+#### Verification Evidence
+
+- [x] Commands run:
+  - [x] `bun run --filter @durabull/mcp test`
+  - [x] `bun run --filter @durabull/api test src/mcp/mount.test.ts`
+  - [x] `bun run --filter @durabull/mcp typecheck`
+  - [x] `bun run --filter @durabull/mcp lint`
+- [x] Tests added:
+  - [x] `packages/mcp/src/config/allowed-hosts.test.ts`
+  - [x] `packages/mcp/src/routes.test.ts`
+  - [x] `apps/api/src/mcp/mount.test.ts`
+
+#### Handoff To Next PR
+
+- Next PR: `PR-03`
+- Known risks: MCP transport is currently unauthenticated (auth deferred to PR-03).
+- Notes for next agent: add OAuth discovery + bearer validation on `/mcp`; canonical resource URI `${APP_BASE_URL}/mcp`.
+
+---
+
 ## Live PR Tracker
 
-- [ ] PR-01 Security architecture baseline (in progress on `feat/no-linear-mcp-pr01-security-baseline`)
-- [ ] PR-02 API `/mcp` ingress + transport (not standalone `apps/mcp`)
+- [x] PR-01 Security architecture baseline (in progress on `feat/no-linear-mcp-pr01-security-baseline`)
+- [x] PR-02 API `/mcp` ingress + transport (`@durabull/mcp` package + thin API mount)
 - [ ] PR-03 OAuth discovery + token validation
 - [ ] PR-04 Principals + policy engine
 - [ ] PR-05 Read-only diagnostic tools


### PR DESCRIPTION
## Objective

Mount MCP Streamable HTTP transport at `/mcp` on the existing `apps/api` Hono app (same deployment/port as API + web), with basic lifecycle and no privileged domain tools yet.

## Scope (In)

- [x] `@durabull/mcp` package (transport, host validation, session registry, `ping` smoke tool)
- [x] Thin ingress at `apps/api/src/mcp/mount.ts` mounted in `createApiApp()` at `/mcp` (before SPA fallback)
- [x] Streamable HTTP on `/mcp` (`GET` + `POST` + `DELETE` via `@hono/mcp`)
- [x] Host header validation including production host from `APP_BASE_URL`
- [x] MCP rate limiting on `/mcp`
- [x] Integration tests via `createApiApp()` (initialize, `tools/list`, `ping`)

## Scope (Out)

- [ ] OAuth discovery and bearer token validation (PR-03)
- [ ] Principals / policy engine (PR-04)
- [ ] Read-only diagnostic tools (PR-05)
- [ ] Standalone `apps/mcp` deployable or second public MCP port

## Implementation Notes

- Protocol logic lives in `packages/mcp/`; API only mounts ingress and passes `APP_BASE_URL` / version.
- Per-session `StreamableHTTPTransport` + `McpServer` registry (avoids shared singleton transport).
- Strict `Host` parsing blocks fake port suffixes (e.g. `localhost:3000.evil`).
- Middleware hook on `CreateMcpRoutesOptions.middleware` reserved for PR-03 auth.

## Safety

- [x] No destructive MCP tools introduced
- [x] Host allowlist enforced (custom middleware + transport DNS rebinding hosts)
- [x] Negative host header tests added
- [ ] AuthN/AuthZ — **deferred to PR-03**; do not expose `/mcp` on public production until then

## Validation

- [x] `bun run --filter @durabull/mcp test`
- [x] `bun run --filter @durabull/api test src/mcp/mount.test.ts`
- [x] `bun run --filter @durabull/mcp typecheck`
- [x] `bun run --filter @durabull/mcp lint`

## Known risks (follow-up)

- Unauthenticated `/mcp` is intentional for PR-02; PR-03 is the production gate.
- Requests without `Mcp-Session-Id` currently create a new session entry (session spam / resource use); tighten in PR-03 or a small follow-up.

## Acceptance

This PR establishes MCP transport at /mcp on the API app only and does not expose production domain tools.

## Handoff

- Next PR: `PR-03` OAuth discovery + token validation

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MCP endpoint at `/mcp` with built-in host validation for enhanced security
  * Implemented rate limiting (120 requests per 60-second window) on MCP traffic
  * Includes a ping tool for transport connectivity verification

* **Tests**
  * Added comprehensive integration tests for MCP ingress, host validation, and session lifecycle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->