### PR TITLE
Add Google Analytics to marketing docs site

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -10,3 +10,6 @@ NEXT_PUBLIC_POSTHOG_KEY=phc_your_posthog_project_key
 
 # Docs always sends PostHog traffic through the web app proxy at:
 # ${NEXT_PUBLIC_WEB_APP_URL}/ingest
+
+# Google Analytics (production builds only; optional override)
+# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,6 +1,7 @@
 import { GeistMono } from 'geist/font/mono'
 import { GeistSans } from 'geist/font/sans'
 import type { Metadata } from 'next'
+import { MarketingGoogleAnalytics } from '@/components/google-analytics'
 import { PostHogProvider } from '@/components/posthog-provider'
 import '@/styles/globals.css'
 import '@/styles/landing.css'
@@ -69,6 +70,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body
         className={`${GeistSans.variable} ${GeistMono.variable} min-h-screen bg-background font-sans antialiased`}
       >
+        <MarketingGoogleAnalytics />
         <PostHogProvider>{children}</PostHogProvider>
       </body>
     </html>

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -14,6 +14,10 @@ function getFirstNonEmptyEnv(...keys: string[]) {
 
 const publicWebAppUrl = getFirstNonEmptyEnv('NEXT_PUBLIC_WEB_APP_URL', 'APP_BASE_URL')
 const publicPosthogKey = getFirstNonEmptyEnv('NEXT_PUBLIC_POSTHOG_KEY', 'POSTHOG_KEY')
+const publicGaMeasurementId = getFirstNonEmptyEnv(
+  'NEXT_PUBLIC_GA_MEASUREMENT_ID',
+  'GA_MEASUREMENT_ID',
+)
 
 const nextConfig: NextConfig = {
   output: isStaticExport ? 'export' : undefined,
@@ -26,6 +30,9 @@ const nextConfig: NextConfig = {
   env: {
     ...(publicWebAppUrl ? { NEXT_PUBLIC_WEB_APP_URL: publicWebAppUrl } : {}),
     ...(publicPosthogKey ? { NEXT_PUBLIC_POSTHOG_KEY: publicPosthogKey } : {}),
+    ...(publicGaMeasurementId
+      ? { NEXT_PUBLIC_GA_MEASUREMENT_ID: publicGaMeasurementId }
+      : {}),
   },
 }
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,6 +20,7 @@
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^16.1.6",
+    "@next/third-parties": "^15.3.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "framer-motion": "^11.15.0",

--- a/apps/docs/src/components/google-analytics.tsx
+++ b/apps/docs/src/components/google-analytics.tsx
@@ -1,0 +1,13 @@
+import { GoogleAnalytics } from '@next/third-parties/google'
+
+const DEFAULT_MEASUREMENT_ID = 'G-JJBKDXZNQX'
+
+export function MarketingGoogleAnalytics() {
+  if (process.env.NODE_ENV !== 'production') {
+    return null
+  }
+
+  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID?.trim() || DEFAULT_MEASUREMENT_ID
+
+  return <GoogleAnalytics gaId={gaId} />
+}

--- a/apps/docs/src/components/google-analytics.tsx
+++ b/apps/docs/src/components/google-analytics.tsx
@@ -1,13 +1,14 @@
 import { GoogleAnalytics } from '@next/third-parties/google'
 
-const DEFAULT_MEASUREMENT_ID = 'G-JJBKDXZNQX'
-
 export function MarketingGoogleAnalytics() {
   if (process.env.NODE_ENV !== 'production') {
     return null
   }
 
-  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID?.trim() || DEFAULT_MEASUREMENT_ID
+  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID?.trim()
+  if (!gaId) {
+    return null
+  }
 
   return <GoogleAnalytics gaId={gaId} />
 }

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.1.6",
+        "@next/third-parties": "^15.3.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "framer-motion": "^11.15.0",
@@ -705,6 +706,8 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.12", "", { "os": "win32", "cpu": "x64" }, "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw=="],
+
+    "@next/third-parties": ["@next/third-parties@15.5.18", "", { "dependencies": { "third-party-capital": "1.0.20" }, "peerDependencies": { "next": "^13.0.0 || ^14.0.0 || ^15.0.0", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0" } }, "sha512-Kp51CbeHgYelpkasFI1gAeAeMPfMTctLcmVIfE2MiRRfC6oYbR3+lO4S0NbNRppOZ7RkbB5P6uW/qOewxth6iA=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -2733,6 +2736,8 @@
     "temp": ["temp@0.9.4", "", { "dependencies": { "mkdirp": "^0.5.1", "rimraf": "~2.6.2" } }, "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA=="],
 
     "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
+
+    "third-party-capital": ["third-party-capital@1.0.20", "", {}, "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 


### PR DESCRIPTION
## Summary
- Adds Google Analytics to the docs/marketing Next.js app via `@next/third-parties/google`
- Loads only in production builds; supports optional `NEXT_PUBLIC_GA_MEASUREMENT_ID` override at build time
- Documents the env var in `.env.example` with a placeholder (no real ID)

## Test plan
- [ ] `bun run typecheck` in `apps/docs`
- [ ] Production build includes gtag loader and config in page source
- [ ] Local `bun run dev` does not load Google Analytics


Made with [Cursor](https://cursor.com)