### PR TITLE
Add pagination to queues list page

### DIFF
--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -2,6 +2,8 @@ import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
 import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import {
   AlertCircle,
+  ChevronLeft,
+  ChevronRight,
   ExternalLink,
   Eye,
   EyeOff,
@@ -55,6 +57,11 @@ interface QueueSummary {
 interface QueueTableProps {
   queues: QueueSummary[]
   className?: string
+  page?: number
+  totalPages?: number
+  total?: number
+  isPlaceholderData?: boolean
+  onPageChange?: (page: number) => void
 }
 
 /**
@@ -71,8 +78,17 @@ function getTotalJobs(queue: QueueSummary): number {
   )
 }
 
-export function QueueTable({ queues, className }: QueueTableProps) {
+export function QueueTable({
+  queues,
+  className,
+  page = 1,
+  totalPages = 1,
+  total = 0,
+  isPlaceholderData,
+  onPageChange,
+}: QueueTableProps) {
   const [hideEmpty, setHideEmpty] = useState(false)
+  const hasPagination = totalPages > 1
 
   // Memoize filtered queues to avoid recalculating on unrelated re-renders
   const { filteredQueues, emptyCount } = useMemo(() => {
@@ -114,30 +130,62 @@ export function QueueTable({ queues, className }: QueueTableProps) {
           </TableBody>
         </Table>
 
-        {/* Empty queues toggle */}
-        {emptyCount > 0 && (
+        {/* Footer: empty toggle + pagination */}
+        {(emptyCount > 0 || hasPagination) && (
           <div className="border-t px-4 py-3 flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">
-              {emptyCount} empty queue{emptyCount !== 1 ? 's' : ''}
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={toggleHideEmpty}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              {hideEmpty ? (
-                <>
-                  <Eye className="mr-2 h-4 w-4" />
-                  Show empty
-                </>
-              ) : (
-                <>
-                  <EyeOff className="mr-2 h-4 w-4" />
-                  Hide empty
-                </>
+            <div>
+              {emptyCount > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={toggleHideEmpty}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  {hideEmpty ? (
+                    <>
+                      <Eye className="mr-2 h-4 w-4" />
+                      Show empty
+                    </>
+                  ) : (
+                    <>
+                      <EyeOff className="mr-2 h-4 w-4" />
+                      Hide empty
+                    </>
+                  )}
+                </Button>
               )}
-            </Button>
+            </div>
+
+            {hasPagination && (
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-muted-foreground">
+                  Page {page} of {totalPages}
+                  <span className="hidden sm:inline"> ({total} queues)</span>
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={page <= 1 || isPlaceholderData}
+                    onClick={() => onPageChange?.(page - 1)}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    <span className="sr-only">Previous page</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={page >= totalPages || isPlaceholderData}
+                    onClick={() => onPageChange?.(page + 1)}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                    <span className="sr-only">Next page</span>
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -12,7 +12,7 @@ import {
   Pause,
   Play,
 } from 'lucide-react'
-import { type KeyboardEvent, memo, type MouseEvent, useCallback, useMemo, useState } from 'react'
+import { type KeyboardEvent, memo, type MouseEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { useConnection } from '@/components/connection-provider'
 import { QueueNameTag } from '@/components/queue-name-tag'
 import { StatusIndicator } from '@/components/status-badge'
@@ -90,6 +90,10 @@ export function QueueTable({
   const [hideEmpty, setHideEmpty] = useState(false)
   const hasPagination = totalPages > 1
 
+  useEffect(() => {
+    setHideEmpty(false)
+  }, [page])
+
   // Memoize filtered queues to avoid recalculating on unrelated re-renders
   const { filteredQueues, emptyCount } = useMemo(() => {
     const empty = queues.filter((q) => getTotalJobs(q) === 0).length
@@ -110,7 +114,7 @@ export function QueueTable({
   return (
     <TooltipProvider delayDuration={200}>
       <div className={cn('rounded-lg border bg-card overflow-hidden flex flex-col h-[calc(100vh-18rem)]', className)}>
-        <div className="flex-1 overflow-y-auto min-h-0 [&>div]:overflow-x-visible">
+        <div className="flex-1 overflow-auto min-h-0 [&>div]:overflow-visible">
         <Table>
           <TableHeader className="sticky top-0 z-10 bg-card">
             <TableRow className="hover:bg-transparent">

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -109,9 +109,10 @@ export function QueueTable({
 
   return (
     <TooltipProvider delayDuration={200}>
-      <div className={cn('rounded-lg border bg-card', className)}>
+      <div className={cn('rounded-lg border bg-card overflow-hidden flex flex-col h-[calc(100vh-18rem)]', className)}>
+        <div className="flex-1 overflow-y-auto min-h-0 [&>div]:overflow-x-visible">
         <Table>
-          <TableHeader>
+          <TableHeader className="sticky top-0 z-10 bg-card">
             <TableRow className="hover:bg-transparent">
               <TableHead>Queue</TableHead>
               <TableHead>Status</TableHead>
@@ -129,6 +130,7 @@ export function QueueTable({
             ))}
           </TableBody>
         </Table>
+        </div>
 
         {/* Footer: empty toggle + pagination */}
         {(emptyCount > 0 || hasPagination) && (

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -203,7 +203,10 @@ export type {
  * Includes connection ID for proper cache isolation
  */
 export const queryKeys = {
-  queues: (connectionId: string) => ['queues', connectionId] as const,
+  queues: (connectionId: string, page?: number, pageSize?: number) =>
+    page !== undefined || pageSize !== undefined
+      ? (['queues', connectionId, { page, pageSize }] as const)
+      : (['queues', connectionId] as const),
   queueDiscovery: (connectionId: string) => ['queues', connectionId, 'discovery'] as const,
   queue: (connectionId: string, name: string) => ['queue', connectionId, name] as const,
   queueMetrics: (connectionId: string, name: string, options?: QueueMetricsOptions) =>
@@ -235,21 +238,28 @@ function useConnectionIdFromContextOrRoute(): string | undefined {
 }
 
 // Queue Queries
-export function useQueues() {
+export function useQueues(options?: { page?: number; pageSize?: number }) {
   const connectionId = useConnectionIdFromContextOrRoute()
+  const page = options?.page
+  const pageSize = options?.pageSize
 
   return useQuery({
-    queryKey: queryKeys.queues(connectionId ?? ''),
+    queryKey: queryKeys.queues(connectionId ?? '', page, pageSize),
     queryFn: async () => {
-      const res = await api.c[':connectionId'].queues.$get({
-        param: { connectionId: connectionId! },
-      })
-      return handleRes<ListQueuesResponse>(res)
+      const params = new URLSearchParams()
+      if (page !== undefined) params.set('page', String(page))
+      if (pageSize !== undefined) params.set('pageSize', String(pageSize))
+      const query = params.toString()
+
+      return fetchApi<ListQueuesResponse>(
+        `/api/c/${connectionId}/queues${query ? `?${query}` : ''}`
+      )
     },
     refetchInterval: (query) => {
       const hasPendingDiscoveryRows = (query.state.data?.discovery?.indexed.pending ?? 0) > 0
       return query.state.data?.discovery?.running || hasPendingDiscoveryRows ? 2000 : 10_000
     },
+    placeholderData: (previousData) => previousData,
     enabled: !!connectionId,
   })
 }

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -50,6 +50,8 @@ export type QueueStatus = (typeof QUEUE_STATUS)[keyof typeof QUEUE_STATUS]
 export const PAGINATION = {
   /** Default page size for job lists */
   DEFAULT_PAGE_SIZE: 20,
+  /** Page size for the queues list */
+  QUEUES_PAGE_SIZE: 50,
   /** Page size for log entries */
   LOGS_PAGE_SIZE: 50,
   /** Page size for stacktraces (smaller due to large content) */

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
@@ -19,7 +19,7 @@ export function EditAlertRuleRoute() {
   const navigate = useNavigate()
   const { currentConnection } = useConnection()
   const rulesQuery = useConnectionAlertRules(connectionId)
-  const queuesQuery = useQueues()
+  const queuesQuery = useQueues({ pageSize: 100 })
   const updateRuleMutation = useUpdateAlertRule(connectionId)
   const testRuleMutation = useTestAlertRule(connectionId)
   const linearIntegrationQuery = useLinearIntegration()

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.tsx
@@ -13,7 +13,7 @@ export function CreateAlertRuleRoute() {
   const { orgSlug, connectionId } = Route.useParams()
   const navigate = useNavigate()
   const { currentConnection } = useConnection()
-  const queuesQuery = useQueues()
+  const queuesQuery = useQueues({ pageSize: 100 })
   const createRuleMutation = useCreateAlertRule(connectionId)
   const linearIntegrationQuery = useLinearIntegration()
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
@@ -285,7 +285,7 @@ function Dashboard() {
                 ))}
               </div>
             </div>
-          ) : queues.length === 0 ? (
+          ) : (data?.total ?? 0) === 0 ? (
             <EmptyState />
           ) : (
             <QueueTable

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
@@ -10,7 +10,7 @@ import {
   Timer,
   Zap,
 } from 'lucide-react'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useAppTopBar } from '@/components/app-top-bar'
 import { QueueTable } from '@/components/queue-table'
 import { Button } from '@/components/ui/button'
@@ -24,6 +24,7 @@ import {
   useQueues,
 } from '@/hooks/use-queues'
 import { REDIS_CONNECTION_ERROR_MESSAGE } from '@/lib/api'
+import { PAGINATION } from '@/lib/constants'
 import { cn, formatNumber } from '@/lib/utils'
 
 const AUTO_DISCOVERY_MIN_INTERVAL_MS = 5 * 60 * 1000
@@ -52,7 +53,11 @@ export const Route = createFileRoute('/$orgSlug/c/$connectionId/')({
 function Dashboard() {
   const routeParams = useParams({ strict: false }) as { connectionId?: string }
   const connectionId = routeParams.connectionId ?? ''
-  const { data, isLoading, error } = useQueues()
+  const [page, setPage] = useState(1)
+  const { data, isLoading, error, isPlaceholderData } = useQueues({
+    page,
+    pageSize: PAGINATION.QUEUES_PAGE_SIZE,
+  })
   const discoveryQuery = useQueueDiscoveryStatus()
   const discoverMutation = useDiscoverQueues()
   const hasAutoTriggeredDiscovery = useRef(false)
@@ -81,6 +86,7 @@ function Dashboard() {
   useEffect(() => {
     if (!connectionId) return
     hasAutoTriggeredDiscovery.current = false
+    setPage(1)
   }, [connectionId])
 
   useEffect(() => {
@@ -282,7 +288,14 @@ function Dashboard() {
           ) : queues.length === 0 ? (
             <EmptyState />
           ) : (
-            <QueueTable queues={queues} />
+            <QueueTable
+              queues={queues}
+              page={data?.page ?? 1}
+              totalPages={data?.totalPages ?? 1}
+              total={data?.total ?? 0}
+              isPlaceholderData={isPlaceholderData}
+              onPageChange={setPage}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Wire up page/pageSize params to the queues API (which already supported them server-side)
- Add prev/next pagination controls in the table footer
- Table fills remaining viewport height with internal scrolling and sticky header
- Pagination footer stays pinned at the bottom of the card

https://github.com/user-attachments/assets/5b9fb6dc-1e94-4fba-9c21-6fdc7c029df2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue list pagination now available with intuitive page navigation controls.
  * Queue results displayed at 50 items per page.

* **UI Improvements**
  * Enhanced table layout with sticky headers for better navigation.
  * Smoother data loading experience when switching between pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->