### PR TITLE
Fix stat card counts to aggregate across all queues

### DIFF
--- a/apps/api/src/routes/queues.ts
+++ b/apps/api/src/routes/queues.ts
@@ -285,16 +285,21 @@ const app = new Hono()
       limit: pageSize,
     })
 
-    const queuesData = await Promise.all(
-      indexedQueues.map(async (indexedQueue) => {
-        const queue = await getQueue(connectionId, connectionUrl, indexedQueue.name, connectionPrefix, redisOptions)
-        const [counts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()])
+    const allIndexedQueues = total > pageSize
+      ? await redisDiscoveredQueueRepository.listByConnection(connectionId, { offset: 0, limit: total })
+      : indexedQueues
 
-        const status: 'paused' | 'active' = isPaused ? 'paused' : 'active'
-        return {
-          name: indexedQueue.name,
-          status,
-          jobCounts: {
+    const pageQueueNames = new Set(indexedQueues.map((q) => q.name))
+    const totalJobCounts = { waiting: 0, active: 0, delayed: 0, completed: 0, failed: 0 }
+
+    const [queuesData] = await Promise.all([
+      Promise.all(
+        indexedQueues.map(async (indexedQueue) => {
+          const queue = await getQueue(connectionId, connectionUrl, indexedQueue.name, connectionPrefix, redisOptions)
+          const [counts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()])
+
+          const status: 'paused' | 'active' = isPaused ? 'paused' : 'active'
+          const jobCounts = {
             waiting: counts.waiting ?? 0,
             active: counts.active ?? 0,
             delayed: counts.delayed ?? 0,
@@ -302,12 +307,37 @@ const app = new Hono()
             failed: counts.failed ?? 0,
             paused: counts.paused ?? 0,
             prioritized: counts.prioritized ?? 0,
-          },
-          isPaused,
-          discoveryState: indexedQueue.state,
-        }
-      })
-    )
+          }
+
+          totalJobCounts.waiting += jobCounts.waiting
+          totalJobCounts.active += jobCounts.active
+          totalJobCounts.delayed += jobCounts.delayed
+          totalJobCounts.completed += jobCounts.completed
+          totalJobCounts.failed += jobCounts.failed
+
+          return {
+            name: indexedQueue.name,
+            status,
+            jobCounts,
+            isPaused,
+            discoveryState: indexedQueue.state,
+          }
+        })
+      ),
+      Promise.all(
+        allIndexedQueues
+          .filter((iq) => !pageQueueNames.has(iq.name))
+          .map(async (iq) => {
+            const queue = await getQueue(connectionId, connectionUrl, iq.name, connectionPrefix, redisOptions)
+            const counts = await queue.getJobCounts()
+            totalJobCounts.waiting += counts.waiting ?? 0
+            totalJobCounts.active += counts.active ?? 0
+            totalJobCounts.delayed += counts.delayed ?? 0
+            totalJobCounts.completed += counts.completed ?? 0
+            totalJobCounts.failed += counts.failed ?? 0
+          })
+      ),
+    ])
 
     return c.json({
       queues: queuesData,
@@ -316,6 +346,7 @@ const app = new Hono()
       pageSize,
       totalPages: Math.ceil(total / pageSize),
       hasMore: end < total,
+      totalJobCounts,
       discovery,
     })
   })

--- a/apps/api/src/routes/queues.ts
+++ b/apps/api/src/routes/queues.ts
@@ -250,12 +250,9 @@ const app = new Hono()
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
-    const pageStr = c.req.query('page')
-    const pageSizeStr = c.req.query('pageSize')
-
-    const page = pageStr ? parseInt(pageStr, 10) : 1
+    const page = Math.max(1, parseInteger(c.req.query('page')) ?? 1)
     const pageSize = Math.min(
-      pageSizeStr ? parseInt(pageSizeStr, 10) : DEFAULT_PAGE_SIZE,
+      parseInteger(c.req.query('pageSize')) ?? DEFAULT_PAGE_SIZE,
       MAX_PAGE_SIZE
     )
 
@@ -292,6 +289,14 @@ const app = new Hono()
     const pageQueueNames = new Set(indexedQueues.map((q) => q.name))
     const totalJobCounts = { waiting: 0, active: 0, delayed: 0, completed: 0, failed: 0 }
 
+    function accumulateCounts(counts: Record<string, number>) {
+      totalJobCounts.waiting += counts.waiting ?? 0
+      totalJobCounts.active += counts.active ?? 0
+      totalJobCounts.delayed += counts.delayed ?? 0
+      totalJobCounts.completed += counts.completed ?? 0
+      totalJobCounts.failed += counts.failed ?? 0
+    }
+
     const [queuesData] = await Promise.all([
       Promise.all(
         indexedQueues.map(async (indexedQueue) => {
@@ -309,11 +314,7 @@ const app = new Hono()
             prioritized: counts.prioritized ?? 0,
           }
 
-          totalJobCounts.waiting += jobCounts.waiting
-          totalJobCounts.active += jobCounts.active
-          totalJobCounts.delayed += jobCounts.delayed
-          totalJobCounts.completed += jobCounts.completed
-          totalJobCounts.failed += jobCounts.failed
+          accumulateCounts(jobCounts)
 
           return {
             name: indexedQueue.name,
@@ -329,12 +330,7 @@ const app = new Hono()
           .filter((iq) => !pageQueueNames.has(iq.name))
           .map(async (iq) => {
             const queue = await getQueue(connectionId, connectionUrl, iq.name, connectionPrefix, redisOptions)
-            const counts = await queue.getJobCounts()
-            totalJobCounts.waiting += counts.waiting ?? 0
-            totalJobCounts.active += counts.active ?? 0
-            totalJobCounts.delayed += counts.delayed ?? 0
-            totalJobCounts.completed += counts.completed ?? 0
-            totalJobCounts.failed += counts.failed ?? 0
+            accumulateCounts(await queue.getJobCounts())
           })
       ),
     ])

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -2,6 +2,8 @@ import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
 import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import {
   AlertCircle,
+  ChevronLeft,
+  ChevronRight,
   ExternalLink,
   Eye,
   EyeOff,
@@ -55,6 +57,11 @@ interface QueueSummary {
 interface QueueTableProps {
   queues: QueueSummary[]
   className?: string
+  page?: number
+  totalPages?: number
+  total?: number
+  isPlaceholderData?: boolean
+  onPageChange?: (page: number) => void
 }
 
 /**
@@ -71,8 +78,17 @@ function getTotalJobs(queue: QueueSummary): number {
   )
 }
 
-export function QueueTable({ queues, className }: QueueTableProps) {
+export function QueueTable({
+  queues,
+  className,
+  page = 1,
+  totalPages = 1,
+  total = 0,
+  isPlaceholderData,
+  onPageChange,
+}: QueueTableProps) {
   const [hideEmpty, setHideEmpty] = useState(false)
+  const hasPagination = totalPages > 1
 
   // Memoize filtered queues to avoid recalculating on unrelated re-renders
   const { filteredQueues, emptyCount } = useMemo(() => {
@@ -114,30 +130,62 @@ export function QueueTable({ queues, className }: QueueTableProps) {
           </TableBody>
         </Table>
 
-        {/* Empty queues toggle */}
-        {emptyCount > 0 && (
+        {/* Footer: empty toggle + pagination */}
+        {(emptyCount > 0 || hasPagination) && (
           <div className="border-t px-4 py-3 flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">
-              {emptyCount} empty queue{emptyCount !== 1 ? 's' : ''}
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={toggleHideEmpty}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              {hideEmpty ? (
-                <>
-                  <Eye className="mr-2 h-4 w-4" />
-                  Show empty
-                </>
-              ) : (
-                <>
-                  <EyeOff className="mr-2 h-4 w-4" />
-                  Hide empty
-                </>
+            <div>
+              {emptyCount > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={toggleHideEmpty}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  {hideEmpty ? (
+                    <>
+                      <Eye className="mr-2 h-4 w-4" />
+                      Show empty
+                    </>
+                  ) : (
+                    <>
+                      <EyeOff className="mr-2 h-4 w-4" />
+                      Hide empty
+                    </>
+                  )}
+                </Button>
               )}
-            </Button>
+            </div>
+
+            {hasPagination && (
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-muted-foreground">
+                  Page {page} of {totalPages}
+                  <span className="hidden sm:inline"> ({total} queues)</span>
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={page <= 1 || isPlaceholderData}
+                    onClick={() => onPageChange?.(page - 1)}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    <span className="sr-only">Previous page</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={page >= totalPages || isPlaceholderData}
+                    onClick={() => onPageChange?.(page + 1)}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                    <span className="sr-only">Next page</span>
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -12,7 +12,7 @@ import {
   Pause,
   Play,
 } from 'lucide-react'
-import { type KeyboardEvent, memo, type MouseEvent, useCallback, useMemo, useState } from 'react'
+import { type KeyboardEvent, memo, type MouseEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { useConnection } from '@/components/connection-provider'
 import { QueueNameTag } from '@/components/queue-name-tag'
 import { StatusIndicator } from '@/components/status-badge'
@@ -90,6 +90,10 @@ export function QueueTable({
   const [hideEmpty, setHideEmpty] = useState(false)
   const hasPagination = totalPages > 1
 
+  useEffect(() => {
+    setHideEmpty(false)
+  }, [page])
+
   // Memoize filtered queues to avoid recalculating on unrelated re-renders
   const { filteredQueues, emptyCount } = useMemo(() => {
     const empty = queues.filter((q) => getTotalJobs(q) === 0).length
@@ -110,7 +114,7 @@ export function QueueTable({
   return (
     <TooltipProvider delayDuration={200}>
       <div className={cn('rounded-lg border bg-card overflow-hidden flex flex-col h-[calc(100vh-18rem)]', className)}>
-        <div className="flex-1 overflow-y-auto min-h-0 [&>div]:overflow-x-visible">
+        <div className="flex-1 overflow-auto min-h-0 [&>div]:overflow-visible">
         <Table>
           <TableHeader className="sticky top-0 z-10 bg-card">
             <TableRow className="hover:bg-transparent">

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -109,9 +109,10 @@ export function QueueTable({
 
   return (
     <TooltipProvider delayDuration={200}>
-      <div className={cn('rounded-lg border bg-card', className)}>
+      <div className={cn('rounded-lg border bg-card overflow-hidden flex flex-col h-[calc(100vh-18rem)]', className)}>
+        <div className="flex-1 overflow-y-auto min-h-0 [&>div]:overflow-x-visible">
         <Table>
-          <TableHeader>
+          <TableHeader className="sticky top-0 z-10 bg-card">
             <TableRow className="hover:bg-transparent">
               <TableHead>Queue</TableHead>
               <TableHead>Status</TableHead>
@@ -129,6 +130,7 @@ export function QueueTable({
             ))}
           </TableBody>
         </Table>
+        </div>
 
         {/* Footer: empty toggle + pagination */}
         {(emptyCount > 0 || hasPagination) && (

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -203,7 +203,10 @@ export type {
  * Includes connection ID for proper cache isolation
  */
 export const queryKeys = {
-  queues: (connectionId: string) => ['queues', connectionId] as const,
+  queues: (connectionId: string, page?: number, pageSize?: number) =>
+    page !== undefined || pageSize !== undefined
+      ? (['queues', connectionId, { page, pageSize }] as const)
+      : (['queues', connectionId] as const),
   queueDiscovery: (connectionId: string) => ['queues', connectionId, 'discovery'] as const,
   queue: (connectionId: string, name: string) => ['queue', connectionId, name] as const,
   queueMetrics: (connectionId: string, name: string, options?: QueueMetricsOptions) =>
@@ -235,21 +238,28 @@ function useConnectionIdFromContextOrRoute(): string | undefined {
 }
 
 // Queue Queries
-export function useQueues() {
+export function useQueues(options?: { page?: number; pageSize?: number }) {
   const connectionId = useConnectionIdFromContextOrRoute()
+  const page = options?.page
+  const pageSize = options?.pageSize
 
   return useQuery({
-    queryKey: queryKeys.queues(connectionId ?? ''),
+    queryKey: queryKeys.queues(connectionId ?? '', page, pageSize),
     queryFn: async () => {
-      const res = await api.c[':connectionId'].queues.$get({
-        param: { connectionId: connectionId! },
-      })
-      return handleRes<ListQueuesResponse>(res)
+      const params = new URLSearchParams()
+      if (page !== undefined) params.set('page', String(page))
+      if (pageSize !== undefined) params.set('pageSize', String(pageSize))
+      const query = params.toString()
+
+      return fetchApi<ListQueuesResponse>(
+        `/api/c/${connectionId}/queues${query ? `?${query}` : ''}`
+      )
     },
     refetchInterval: (query) => {
       const hasPendingDiscoveryRows = (query.state.data?.discovery?.indexed.pending ?? 0) > 0
       return query.state.data?.discovery?.running || hasPendingDiscoveryRows ? 2000 : 10_000
     },
+    placeholderData: (previousData) => previousData,
     enabled: !!connectionId,
   })
 }

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -50,6 +50,8 @@ export type QueueStatus = (typeof QUEUE_STATUS)[keyof typeof QUEUE_STATUS]
 export const PAGINATION = {
   /** Default page size for job lists */
   DEFAULT_PAGE_SIZE: 20,
+  /** Page size for the queues list */
+  QUEUES_PAGE_SIZE: 50,
   /** Page size for log entries */
   LOGS_PAGE_SIZE: 50,
   /** Page size for stacktraces (smaller due to large content) */

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.tsx
@@ -19,7 +19,7 @@ export function EditAlertRuleRoute() {
   const navigate = useNavigate()
   const { currentConnection } = useConnection()
   const rulesQuery = useConnectionAlertRules(connectionId)
-  const queuesQuery = useQueues()
+  const queuesQuery = useQueues({ pageSize: 100 })
   const updateRuleMutation = useUpdateAlertRule(connectionId)
   const testRuleMutation = useTestAlertRule(connectionId)
   const linearIntegrationQuery = useLinearIntegration()

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.new.tsx
@@ -13,7 +13,7 @@ export function CreateAlertRuleRoute() {
   const { orgSlug, connectionId } = Route.useParams()
   const navigate = useNavigate()
   const { currentConnection } = useConnection()
-  const queuesQuery = useQueues()
+  const queuesQuery = useQueues({ pageSize: 100 })
   const createRuleMutation = useCreateAlertRule(connectionId)
   const linearIntegrationQuery = useLinearIntegration()
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
@@ -163,23 +163,7 @@ function Dashboard() {
 
   const queues = data?.queues ?? []
   type Queue = ListQueuesResponse['queues'][number]
-  type Totals = {
-    waiting: number
-    active: number
-    failed: number
-    delayed: number
-    completed: number
-  }
-  const totals = queues.reduce<Totals>(
-    (acc: Totals, q: Queue) => ({
-      waiting: acc.waiting + q.jobCounts.waiting,
-      active: acc.active + q.jobCounts.active,
-      failed: acc.failed + q.jobCounts.failed,
-      delayed: acc.delayed + q.jobCounts.delayed,
-      completed: acc.completed + q.jobCounts.completed,
-    }),
-    { waiting: 0, active: 0, failed: 0, delayed: 0, completed: 0 }
-  )
+  const totals = data?.totalJobCounts ?? { waiting: 0, active: 0, failed: 0, delayed: 0, completed: 0 }
 
   return (
     <TooltipProvider>

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
@@ -18,7 +18,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import {
-  type ListQueuesResponse,
   useDiscoverQueues,
   useQueueDiscoveryStatus,
   useQueues,
@@ -162,7 +161,6 @@ function Dashboard() {
   }
 
   const queues = data?.queues ?? []
-  type Queue = ListQueuesResponse['queues'][number]
   const totals = data?.totalJobCounts ?? { waiting: 0, active: 0, failed: 0, delayed: 0, completed: 0 }
 
   return (
@@ -237,14 +235,13 @@ function Dashboard() {
                 </span>
               )}
             </div>
-            {queues.some((q) => q.jobCounts.active > 0) && (
+            {totals.active > 0 && (
               <div className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400">
                 <span className="relative flex h-2 w-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
                 </span>
-                {queues.reduce((acc: number, q: Queue) => acc + q.jobCounts.active, 0)} jobs
-                processing
+                {formatNumber(totals.active)} jobs processing
               </div>
             )}
           </div>

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
@@ -285,7 +285,7 @@ function Dashboard() {
                 ))}
               </div>
             </div>
-          ) : queues.length === 0 ? (
+          ) : (data?.total ?? 0) === 0 ? (
             <EmptyState />
           ) : (
             <QueueTable

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
@@ -10,7 +10,7 @@ import {
   Timer,
   Zap,
 } from 'lucide-react'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useAppTopBar } from '@/components/app-top-bar'
 import { QueueTable } from '@/components/queue-table'
 import { Button } from '@/components/ui/button'
@@ -24,6 +24,7 @@ import {
   useQueues,
 } from '@/hooks/use-queues'
 import { REDIS_CONNECTION_ERROR_MESSAGE } from '@/lib/api'
+import { PAGINATION } from '@/lib/constants'
 import { cn, formatNumber } from '@/lib/utils'
 
 const AUTO_DISCOVERY_MIN_INTERVAL_MS = 5 * 60 * 1000
@@ -52,7 +53,11 @@ export const Route = createFileRoute('/$orgSlug/c/$connectionId/')({
 function Dashboard() {
   const routeParams = useParams({ strict: false }) as { connectionId?: string }
   const connectionId = routeParams.connectionId ?? ''
-  const { data, isLoading, error } = useQueues()
+  const [page, setPage] = useState(1)
+  const { data, isLoading, error, isPlaceholderData } = useQueues({
+    page,
+    pageSize: PAGINATION.QUEUES_PAGE_SIZE,
+  })
   const discoveryQuery = useQueueDiscoveryStatus()
   const discoverMutation = useDiscoverQueues()
   const hasAutoTriggeredDiscovery = useRef(false)
@@ -81,6 +86,7 @@ function Dashboard() {
   useEffect(() => {
     if (!connectionId) return
     hasAutoTriggeredDiscovery.current = false
+    setPage(1)
   }, [connectionId])
 
   useEffect(() => {
@@ -282,7 +288,14 @@ function Dashboard() {
           ) : queues.length === 0 ? (
             <EmptyState />
           ) : (
-            <QueueTable queues={queues} />
+            <QueueTable
+              queues={queues}
+              page={data?.page ?? 1}
+              totalPages={data?.totalPages ?? 1}
+              total={data?.total ?? 0}
+              isPlaceholderData={isPlaceholderData}
+              onPageChange={setPage}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Stat cards (Waiting, Active, Delayed, Completed, Failed) now show totals across **all** queues, not just the current page
- API response includes a new `totalJobCounts` field computed by fetching job counts for all queues in parallel with the page data
- Frontend uses `totalJobCounts` directly instead of reducing over the current page's queues

Depends on #92 (pagination).

## Test plan
- [ ] Verify stat card numbers are the same on every page (they reflect all queues)
- [ ] Verify stat card numbers match the sum of all queues across all pages
- [ ] Verify page load time is still acceptable with 100+ queues