### PR TITLE
MCP PR-04/05 principals, policy, and read-tool hardening

### DIFF
--- a/apps/api/src/mcp/mount.test.ts
+++ b/apps/api/src/mcp/mount.test.ts
@@ -3,7 +3,19 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Hono } from 'hono'
-import { closeDb, getDb, oauthAccessToken, oauthApplication } from '@durabull/dal'
+import {
+  closeDb,
+  getDb,
+  mcpPolicyBinding,
+  mcpServiceAccount,
+  member,
+  oauthAccessToken,
+  oauthApplication,
+  organization,
+  redisConnection,
+  redisConnectionRepository,
+  user,
+} from '@durabull/dal'
 import { MCP_PROTOCOL_VERSION } from '@durabull/mcp'
 import {
   MCP_JSON_RPC_VERSION,
@@ -29,6 +41,9 @@ const mcpResource = 'http://localhost:3000/mcp'
 const resourceMetadataUrl =
   'http://localhost:3000/api/auth/.well-known/oauth-protected-resource'
 
+const TEST_REDIS_ENCRYPTION_KEY =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
 let tempPgliteDir = ''
 let app: Hono
 
@@ -38,6 +53,7 @@ describe('api MCP ingress', () => {
     process.env.DURABULL_PGLITE_DIR = tempPgliteDir
     mutableEnv.APP_BASE_URL = 'http://localhost:3000'
     mutableEnv.DURABULL_AUTHLESS = true
+    process.env.DURABULL_REDIS_URL_ENCRYPTION_KEY = TEST_REDIS_ENCRYPTION_KEY
     await closeDb()
     ;({ app } = await createApiApp({ enableLogging: false }))
   })
@@ -170,7 +186,15 @@ describe('api MCP ingress', () => {
     const listPayload = parseSseJson(await listResponse.text()) as {
       result?: { tools?: Array<{ name: string }> }
     }
-    expect(listPayload.result?.tools?.map((tool) => tool.name)).toContain('ping')
+    const toolNames = listPayload.result?.tools?.map((tool) => tool.name) ?? []
+    expect(toolNames).toContain('ping')
+    expect(toolNames).toContain('list_connections')
+    expect(toolNames).toContain('list_queues')
+    expect(toolNames).toContain('get_queue')
+    expect(toolNames).toContain('list_jobs')
+    expect(toolNames).toContain('get_job')
+    expect(toolNames).toContain('get_job_logs')
+    expect(toolNames).toContain('get_job_stacktraces')
 
     const callResponse = await postMcp(
       {
@@ -293,6 +317,778 @@ describe('api MCP ingress', () => {
     )
 
     expect(response.status).toBe(403)
+  })
+
+  it('returns 403 for tools requiring mcp:jobs:read when token only has mcp:discover', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const clientId = `scope-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'scope-test-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'public',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const token = `scope-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId: null,
+      scopes: 'mcp:discover',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'scope-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const response = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'list_connections',
+          arguments: {
+            pageSize: 10,
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('returns 403 for logs tools when token lacks mcp:logs:read scope', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const userId = `logs-user-${crypto.randomUUID().slice(0, 8)}`
+    const orgId = `logs-org-${crypto.randomUUID().slice(0, 8)}`
+
+    await db.insert(user).values({
+      id: userId,
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      name: 'Logs Scope User',
+      createdAt: now,
+      updatedAt: now,
+      image: null,
+      lastSignInAt: null,
+    })
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Logs Scope Org',
+      slug: `logs-scope-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [connection] = await db
+      .insert(redisConnection)
+      .values({
+        id: crypto.randomUUID(),
+        name: 'Logs Scope Connection',
+        url: 'redis://localhost:6379/3',
+        isDefault: true,
+        environment: 'development',
+        prefix: 'bull',
+        allowSelfSignedCerts: false,
+        organizationId: orgId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    await db.insert(member).values({
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      userId,
+      role: 'member',
+      createdAt: now,
+      updatedAt: now,
+    })
+    const clientId = `logs-scope-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'logs-scope-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'public',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const token = `logs-scope-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId,
+      scopes: 'mcp:discover mcp:jobs:read',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'logs-scope-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const response = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'get_job_logs',
+          arguments: {
+            connectionId: connection.id,
+            queueName: 'emails',
+            jobId: 'abc',
+            pageSize: 10,
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('denies service-account tool calls without policy bindings', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const orgId = `org-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Service Account Org',
+      slug: `service-account-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const clientId = `svc-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'service-account-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'confidential',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [serviceAccount] = await db
+      .insert(mcpServiceAccount)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: orgId,
+        name: 'svc-account',
+        oauthClientId: clientId,
+        disabled: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+
+    expect(serviceAccount.id).toBeDefined()
+
+    const token = `svc-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId: null,
+      scopes: 'mcp:discover',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'svc-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'ping',
+          arguments: {},
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+    expect(callResponse.status).toBe(403)
+  })
+
+  it('allows service-account ping when a matching policy binding exists', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const orgId = `org-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Service Account Allowed Org',
+      slug: `service-account-allowed-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const clientId = `svc-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'service-account-allowed-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'confidential',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [serviceAccount] = await db
+      .insert(mcpServiceAccount)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: orgId,
+        name: 'svc-account-allowed',
+        oauthClientId: clientId,
+        disabled: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    await db.insert(mcpPolicyBinding).values({
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: 'ping',
+      scope: 'mcp:discover',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const token = `svc-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId: null,
+      scopes: 'mcp:discover',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'svc-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'ping',
+          arguments: {},
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+
+    expect(callResponse.status).toBe(200)
+    const callPayload = parseSseJson(await callResponse.text()) as {
+      result?: { content?: Array<{ text?: string }> }
+    }
+    expect(callPayload.result?.content?.[0]?.text).toBe('pong')
+  })
+
+  it('denies delegated-user tool calls when connection is outside membership boundary', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const userId = `user-${crypto.randomUUID().slice(0, 8)}`
+    const memberOrgId = `org-${crypto.randomUUID().slice(0, 8)}`
+    const otherOrgId = `org-${crypto.randomUUID().slice(0, 8)}`
+
+    await db.insert(organization).values([
+      {
+        id: memberOrgId,
+        name: 'Member Org',
+        slug: `member-org-${crypto.randomUUID().slice(0, 8)}`,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: otherOrgId,
+        name: 'Other Org',
+        slug: `other-org-${crypto.randomUUID().slice(0, 8)}`,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+    await db.insert(user).values({
+      id: userId,
+      email: `user-${crypto.randomUUID().slice(0, 8)}@example.com`,
+      emailVerified: true,
+      name: 'MCP Delegated User',
+      createdAt: now,
+      updatedAt: now,
+      image: null,
+      lastSignInAt: null,
+    })
+    await db.insert(member).values({
+      id: crypto.randomUUID(),
+      organizationId: memberOrgId,
+      userId,
+      role: 'member',
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [otherConnection] = await db
+      .insert(redisConnection)
+      .values({
+        id: crypto.randomUUID(),
+        name: 'Other Connection',
+        url: 'redis://localhost:6379/1',
+        isDefault: true,
+        environment: 'development',
+        prefix: 'bull',
+        allowSelfSignedCerts: false,
+        organizationId: otherOrgId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+
+    const clientId = `delegated-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'delegated-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'public',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const token = `delegated-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId,
+      scopes: 'mcp:discover',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'delegated-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'ping',
+          arguments: {
+            connectionId: otherConnection.id,
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+    expect(callResponse.status).toBe(403)
+  })
+
+  it('returns paginated list_connections results for delegated users', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const userId = `user-${crypto.randomUUID().slice(0, 8)}`
+    const orgId = `org-${crypto.randomUUID().slice(0, 8)}`
+
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Delegated List Org',
+      slug: `delegated-list-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await db.insert(user).values({
+      id: userId,
+      email: `list-user-${crypto.randomUUID().slice(0, 8)}@example.com`,
+      emailVerified: true,
+      name: 'List User',
+      createdAt: now,
+      updatedAt: now,
+      image: null,
+      lastSignInAt: null,
+    })
+    await db.insert(member).values({
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      userId,
+      role: 'member',
+      createdAt: now,
+      updatedAt: now,
+    })
+    await db.insert(redisConnection).values([
+      {
+        id: crypto.randomUUID(),
+        name: 'Conn A',
+        url: 'redis://localhost:6379/0',
+        isDefault: true,
+        environment: 'development',
+        prefix: 'bull',
+        allowSelfSignedCerts: false,
+        organizationId: orgId,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: crypto.randomUUID(),
+        name: 'Conn B',
+        url: 'redis://localhost:6379/1',
+        isDefault: false,
+        environment: 'staging',
+        prefix: 'bull',
+        allowSelfSignedCerts: false,
+        organizationId: orgId,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+
+    const clientId = `delegated-list-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'delegated-list-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'public',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const token = `delegated-list-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId,
+      scopes: 'mcp:discover mcp:jobs:read',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'delegated-list-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const firstCall = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'list_connections',
+          arguments: {
+            pageSize: 1,
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+    expect(firstCall.status).toBe(200)
+    const firstPayload = parseSseJson(await firstCall.text()) as {
+      result?: { content?: Array<{ text?: string }> }
+    }
+    const firstResult = JSON.parse(firstPayload.result?.content?.[0]?.text ?? '{}') as {
+      connections?: Array<{ name: string }>
+      nextCursor?: string | null
+    }
+    expect(firstResult.connections?.length).toBe(1)
+    expect(firstResult.nextCursor).toBeDefined()
+
+    const secondCall = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'list_connections',
+          arguments: {
+            pageSize: 1,
+            cursor: firstResult.nextCursor,
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+    expect(secondCall.status).toBe(200)
+    const secondPayload = parseSseJson(await secondCall.text()) as {
+      result?: { content?: Array<{ text?: string }> }
+    }
+    const secondResult = JSON.parse(secondPayload.result?.content?.[0]?.text ?? '{}') as {
+      connections?: Array<{ name: string }>
+    }
+    expect(secondResult.connections?.length).toBe(1)
+  })
+
+  it('allows service-account list_connections with matching scope and policy binding', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const orgId = `org-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Service Account List Org',
+      slug: `service-account-list-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await redisConnectionRepository.create({
+      name: 'Service Account Conn',
+      url: 'redis://localhost:6379/2',
+      isDefault: true,
+      environment: 'development',
+      prefix: 'bull',
+      allowSelfSignedCerts: false,
+      organizationId: orgId,
+    })
+
+    const clientId = `svc-list-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'service-account-list-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'confidential',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [serviceAccount] = await db
+      .insert(mcpServiceAccount)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: orgId,
+        name: 'svc-list-account',
+        oauthClientId: clientId,
+        disabled: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    await db.insert(mcpPolicyBinding).values({
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: 'list_connections',
+      scope: 'mcp:jobs:read',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const token = `svc-list-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId: null,
+      scopes: 'mcp:discover mcp:jobs:read',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'svc-list-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'list_connections',
+          arguments: { pageSize: 10 },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+    expect(callResponse.status).toBe(200)
+    const payload = parseSseJson(await callResponse.text()) as {
+      result?: { content?: Array<{ text?: string }> }
+    }
+    const parsed = JSON.parse(payload.result?.content?.[0]?.text ?? '{}') as {
+      connections?: Array<{ name: string }>
+    }
+    expect(parsed.connections?.map((connection) => connection.name)).toContain('Service Account Conn')
   })
 
   it('does not treat GET /mcp as SPA static fallback when web build is absent', async () => {

--- a/apps/api/src/mcp/mount.test.ts
+++ b/apps/api/src/mcp/mount.test.ts
@@ -35,6 +35,7 @@ const mutableEnv = env as {
 const originalAppBaseUrl = mutableEnv.APP_BASE_URL
 const originalAuthless = mutableEnv.DURABULL_AUTHLESS
 const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+const originalRedisUrlEncryptionKey = process.env.DURABULL_REDIS_URL_ENCRYPTION_KEY
 
 const authlessAuthorization = `Bearer ${DEFAULT_AUTHLESS_MCP_BEARER_TOKEN}`
 const mcpResource = 'http://localhost:3000/mcp'
@@ -67,6 +68,12 @@ describe('api MCP ingress', () => {
       process.env.DURABULL_PGLITE_DIR = originalPgliteDir
     } else {
       delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (originalRedisUrlEncryptionKey) {
+      process.env.DURABULL_REDIS_URL_ENCRYPTION_KEY = originalRedisUrlEncryptionKey
+    } else {
+      delete process.env.DURABULL_REDIS_URL_ENCRYPTION_KEY
     }
 
     if (tempPgliteDir) {
@@ -326,6 +333,17 @@ describe('api MCP ingress', () => {
 
     const db = await getDb()
     const now = new Date()
+    const userId = `scope-user-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(user).values({
+      id: userId,
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      name: 'Scope Test User',
+      createdAt: now,
+      updatedAt: now,
+      image: null,
+      lastSignInAt: null,
+    })
     const clientId = `scope-client-${crypto.randomUUID().slice(0, 8)}`
     await db.insert(oauthApplication).values({
       id: crypto.randomUUID(),
@@ -347,7 +365,7 @@ describe('api MCP ingress', () => {
       accessTokenExpiresAt: future,
       refreshTokenExpiresAt: future,
       clientId,
-      userId: null,
+      userId,
       scopes: 'mcp:discover',
       resource: mcpResource,
       createdAt: now,
@@ -387,6 +405,9 @@ describe('api MCP ingress', () => {
     )
 
     expect(response.status).toBe(403)
+    const denialBody = await response.text()
+    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('mcp:jobs:read')
   })
 
   it('returns 403 for logs tools when token lacks mcp:logs:read scope', async () => {
@@ -502,6 +523,9 @@ describe('api MCP ingress', () => {
     )
 
     expect(response.status).toBe(403)
+    const denialBody = await response.text()
+    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('mcp:logs:read')
   })
 
   it('denies service-account tool calls without policy bindings', async () => {

--- a/apps/api/src/mcp/mount.test.ts
+++ b/apps/api/src/mcp/mount.test.ts
@@ -618,6 +618,105 @@ describe('api MCP ingress', () => {
     expect(callResponse.status).toBe(403)
   })
 
+  it('fails closed when a disabled service-account client presents a user token', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const userId = `disabled-svc-user-${crypto.randomUUID().slice(0, 8)}`
+    const orgId = `org-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(user).values({
+      id: userId,
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      name: 'Disabled Service Account User',
+      createdAt: now,
+      updatedAt: now,
+      image: null,
+      lastSignInAt: null,
+    })
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Disabled Service Account Org',
+      slug: `disabled-service-account-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const clientId = `disabled-svc-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'disabled-service-account-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'confidential',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await db.insert(mcpServiceAccount).values({
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      name: 'disabled-svc-account',
+      oauthClientId: clientId,
+      disabled: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const token = `disabled-svc-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId,
+      scopes: 'mcp:discover mcp:jobs:read',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'disabled-svc-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'list_connections',
+          arguments: { pageSize: 10 },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+
+    expect(callResponse.status).toBe(403)
+    const denialBody = await callResponse.text()
+    expect(denialBody).toContain('principal resolution failed')
+  })
+
   it('allows service-account ping when a matching policy binding exists', async () => {
     mutableEnv.DURABULL_AUTHLESS = false
     await closeDb()

--- a/apps/api/src/mcp/mount.ts
+++ b/apps/api/src/mcp/mount.ts
@@ -4,6 +4,14 @@ import { env } from '@durabull/env'
 import { APP_VERSION } from '../lib/build-info'
 import { assertMcpAuthConfiguration } from './auth/mcp-auth-config'
 import { createMcpSessionMiddleware } from './auth/mcp-session-middleware'
+import { createMcpPolicyMiddleware } from './policy/mcp-policy-middleware'
+import { getJobHandler } from './tools/get-job-handler'
+import { getJobLogsHandler } from './tools/get-job-logs-handler'
+import { getJobStacktracesHandler } from './tools/get-job-stacktraces-handler'
+import { getQueueHandler } from './tools/get-queue-handler'
+import { listConnectionsHandler } from './tools/list-connections-handler'
+import { listJobsHandler } from './tools/list-jobs-handler'
+import { listQueuesHandler } from './tools/list-queues-handler'
 
 /**
  * Thin API ingress: mounts MCP Streamable HTTP transport at `/mcp`.
@@ -15,6 +23,7 @@ export async function mountMcpIngress() {
   const appBaseUrl = env.APP_BASE_URL ?? 'http://localhost:5173'
   const isProduction = env.NODE_ENV === 'production'
   const authMiddleware = await createMcpSessionMiddleware(appBaseUrl)
+  const policyMiddleware = createMcpPolicyMiddleware()
 
   return createMcpRoutes({
     version: APP_VERSION,
@@ -23,6 +32,37 @@ export async function mountMcpIngress() {
       : getDefaultAllowedHosts({ appBaseUrl, includeDevHosts: true }),
     corsOrigins: [appBaseUrl],
     allowHostnameWithoutPort: !isProduction,
-    middleware: [authMiddleware],
+    readTools: {
+      listConnections: listConnectionsHandler,
+      listQueues: listQueuesHandler,
+      getQueue: getQueueHandler,
+      listJobs: listJobsHandler,
+      getJob: getJobHandler,
+      getJobLogs: getJobLogsHandler,
+      getJobStacktraces: getJobStacktracesHandler,
+    },
+    requestContextResolver: (c) => {
+      const principal = c.get('mcpPrincipal')
+      const decision = c.get('mcpPolicyDecision')
+      if (!principal) {
+        return undefined
+      }
+      return {
+        principal:
+          principal.type === 'delegated_user'
+            ? {
+                type: 'delegated_user' as const,
+                principalId: principal.principalId,
+                userId: principal.userId,
+              }
+            : {
+                type: 'service_account' as const,
+                principalId: principal.principalId,
+                organizationId: principal.organizationId,
+              },
+        correlationId: decision?.correlationId,
+      }
+    },
+    middleware: [authMiddleware, policyMiddleware],
   })
 }

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -1,4 +1,5 @@
 import { mcpPolicyRepository } from '@durabull/dal'
+import type { Context } from 'hono'
 import { createMiddleware } from 'hono/factory'
 
 import type { McpSession } from '../auth/mcp-session-middleware'
@@ -7,12 +8,32 @@ import { resolveMcpPrincipal } from './principal-resolver'
 import type { McpPolicyDecision, McpToolCallRequest, McpPrincipal } from './types'
 
 interface JsonRpcToolCallBody {
+  id?: string | number | null
   method?: string
   params?: {
     name?: string
     arguments?: Record<string, unknown>
   }
 }
+
+interface McpAuditEventInput {
+  correlationId: string
+  principalType: 'delegated_user' | 'service_account'
+  principalId: string
+  organizationId?: string | null
+  connectionId?: string | null
+  toolName: string
+  requiredScopes: string[]
+  granted: boolean
+  denialReason?: string | null
+}
+
+const MAX_AUDIT_IN_FLIGHT = 16
+const MAX_AUDIT_QUEUE_DEPTH = 1024
+const AUDIT_DROP_LOG_INTERVAL = 100
+let auditInFlight = 0
+let droppedAuditEvents = 0
+const pendingAuditEvents: McpAuditEventInput[] = []
 
 function parseToolCallBody(body: unknown): McpToolCallRequest | null {
   if (!body || typeof body !== 'object') return null
@@ -34,6 +55,69 @@ function buildCorrelationId(): string {
   return crypto.randomUUID()
 }
 
+function dispatchAuditEvent(input: McpAuditEventInput): void {
+  auditInFlight += 1
+  void mcpPolicyRepository
+    .createAuditEvent(input)
+    .catch((error) => {
+      console.error('[mcp-policy] failed to write audit event', error)
+    })
+    .finally(() => {
+      auditInFlight -= 1
+      flushPendingAuditEvents()
+    })
+}
+
+function flushPendingAuditEvents(): void {
+  while (auditInFlight < MAX_AUDIT_IN_FLIGHT && pendingAuditEvents.length > 0) {
+    const next = pendingAuditEvents.shift()
+    if (!next) break
+    dispatchAuditEvent(next)
+  }
+}
+
+function writeAuditEventNonBlocking(input: McpAuditEventInput): void {
+  if (auditInFlight < MAX_AUDIT_IN_FLIGHT && pendingAuditEvents.length === 0) {
+    dispatchAuditEvent(input)
+    return
+  }
+
+  if (pendingAuditEvents.length >= MAX_AUDIT_QUEUE_DEPTH) {
+    droppedAuditEvents += 1
+    if (droppedAuditEvents === 1 || droppedAuditEvents % AUDIT_DROP_LOG_INTERVAL === 0) {
+      console.warn(
+        `[mcp-policy] dropping audit events due to backpressure (dropped=${droppedAuditEvents}, inFlight=${auditInFlight}, queued=${pendingAuditEvents.length})`
+      )
+    }
+    return
+  }
+
+  pendingAuditEvents.push(input)
+  flushPendingAuditEvents()
+}
+
+function jsonRpcErrorResponse(
+  c: Context,
+  status: 400 | 403,
+  code: number,
+  message: string,
+  id: string | number | null,
+  data?: Record<string, unknown>
+) {
+  return c.json(
+    {
+      jsonrpc: '2.0',
+      error: {
+        code,
+        message,
+        ...(data ? { data } : {}),
+      },
+      id,
+    },
+    status
+  )
+}
+
 export function createMcpPolicyMiddleware() {
   return createMiddleware(async (c, next) => {
     if (c.req.method !== 'POST') {
@@ -44,16 +128,36 @@ export function createMcpPolicyMiddleware() {
       .clone()
       .json()
       .catch(() => null)
+    if (body !== null) {
+      c.set('mcpRequestJsonBody', body)
+    }
     if (Array.isArray(body)) {
-      return c.json(
-        {
-          error: 'Bad Request',
-          message: 'Batch MCP requests are not supported on this endpoint.',
-        },
-        400
+      return jsonRpcErrorResponse(
+        c,
+        400,
+        -32_600,
+        'Invalid Request: Batch MCP requests are not supported on this endpoint.',
+        null
       )
     }
+    const payloadId =
+      body && typeof body === 'object' && 'id' in body
+        ? (((body as JsonRpcToolCallBody).id as string | number | null | undefined) ?? null)
+        : null
+    const isToolsCallMethod =
+      body && typeof body === 'object' && !Array.isArray(body)
+        ? (body as JsonRpcToolCallBody).method === 'tools/call'
+        : false
     const toolCall = parseToolCallBody(body)
+    if (isToolsCallMethod && !toolCall) {
+      return jsonRpcErrorResponse(
+        c,
+        400,
+        -32_600,
+        'Invalid Request: tools/call requires a valid params.name and arguments object.',
+        payloadId
+      )
+    }
     if (!toolCall) {
       return next()
     }
@@ -63,7 +167,7 @@ export function createMcpPolicyMiddleware() {
     const correlationId = c.req.header('x-request-id') ?? buildCorrelationId()
 
     if (!principal) {
-      await mcpPolicyRepository.createAuditEvent({
+      writeAuditEventNonBlocking({
         correlationId,
         principalType: 'service_account',
         principalId: session.clientId,
@@ -75,12 +179,12 @@ export function createMcpPolicyMiddleware() {
         denialReason: 'principal_resolution_failed',
       })
 
-      return c.json(
-        {
-          error: 'Forbidden',
-          message: 'MCP principal resolution failed for this token.',
-        },
-        403
+      return jsonRpcErrorResponse(
+        c,
+        403,
+        -32_003,
+        'Forbidden: MCP principal resolution failed for this token.',
+        payloadId
       )
     }
 
@@ -91,7 +195,7 @@ export function createMcpPolicyMiddleware() {
       call: toolCall,
     })
 
-    await mcpPolicyRepository.createAuditEvent({
+    writeAuditEventNonBlocking({
       correlationId: decision.correlationId,
       principalType: decision.principalType,
       principalId: decision.principalId,
@@ -104,12 +208,12 @@ export function createMcpPolicyMiddleware() {
     })
 
     if (!decision.granted) {
-      return c.json(
-        {
-          error: 'Forbidden',
-          message: decision.denialReason ?? 'MCP policy denied this tool call.',
-        },
-        403
+      return jsonRpcErrorResponse(
+        c,
+        403,
+        -32_003,
+        decision.denialReason ?? 'Forbidden: MCP policy denied this tool call.',
+        payloadId
       )
     }
 
@@ -121,6 +225,7 @@ export function createMcpPolicyMiddleware() {
 
 declare module 'hono' {
   interface ContextVariableMap {
+    mcpRequestJsonBody: unknown
     mcpPrincipal: McpPrincipal
     mcpPolicyDecision: McpPolicyDecision
     mcpSession: McpSession

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -1,0 +1,128 @@
+import { mcpPolicyRepository } from '@durabull/dal'
+import { createMiddleware } from 'hono/factory'
+
+import type { McpSession } from '../auth/mcp-session-middleware'
+import { evaluateMcpToolPolicy } from './policy-engine'
+import { resolveMcpPrincipal } from './principal-resolver'
+import type { McpPolicyDecision, McpToolCallRequest, McpPrincipal } from './types'
+
+interface JsonRpcToolCallBody {
+  method?: string
+  params?: {
+    name?: string
+    arguments?: Record<string, unknown>
+  }
+}
+
+function parseToolCallBody(body: unknown): McpToolCallRequest | null {
+  if (!body || typeof body !== 'object') return null
+  const payload = body as JsonRpcToolCallBody
+  if (payload.method !== 'tools/call') return null
+  const toolName = payload.params?.name
+  if (!toolName || typeof toolName !== 'string') return null
+  const args = payload.params?.arguments
+  const safeArgs: Record<string, unknown> = args && typeof args === 'object' ? args : {}
+  const connectionId =
+    typeof safeArgs.connectionId === 'string' && safeArgs.connectionId.trim().length > 0
+      ? safeArgs.connectionId
+      : null
+
+  return { toolName, arguments: safeArgs, connectionId }
+}
+
+function buildCorrelationId(): string {
+  return crypto.randomUUID()
+}
+
+export function createMcpPolicyMiddleware() {
+  return createMiddleware(async (c, next) => {
+    if (c.req.method !== 'POST') {
+      return next()
+    }
+
+    const body = await c.req.raw
+      .clone()
+      .json()
+      .catch(() => null)
+    if (Array.isArray(body)) {
+      return c.json(
+        {
+          error: 'Bad Request',
+          message: 'Batch MCP requests are not supported on this endpoint.',
+        },
+        400
+      )
+    }
+    const toolCall = parseToolCallBody(body)
+    if (!toolCall) {
+      return next()
+    }
+
+    const session = c.get('mcpSession')
+    const principal = await resolveMcpPrincipal(session)
+    const correlationId = c.req.header('x-request-id') ?? buildCorrelationId()
+
+    if (!principal) {
+      await mcpPolicyRepository.createAuditEvent({
+        correlationId,
+        principalType: 'service_account',
+        principalId: session.clientId,
+        organizationId: null,
+        connectionId: toolCall.connectionId,
+        toolName: toolCall.toolName,
+        requiredScopes: [],
+        granted: false,
+        denialReason: 'principal_resolution_failed',
+      })
+
+      return c.json(
+        {
+          error: 'Forbidden',
+          message: 'MCP principal resolution failed for this token.',
+        },
+        403
+      )
+    }
+
+    const decision = await evaluateMcpToolPolicy({
+      correlationId,
+      principal,
+      session,
+      call: toolCall,
+    })
+
+    await mcpPolicyRepository.createAuditEvent({
+      correlationId: decision.correlationId,
+      principalType: decision.principalType,
+      principalId: decision.principalId,
+      organizationId: decision.organizationId,
+      connectionId: decision.connectionId,
+      toolName: decision.toolName,
+      requiredScopes: decision.requiredScopes,
+      granted: decision.granted,
+      denialReason: decision.denialReason,
+    })
+
+    if (!decision.granted) {
+      return c.json(
+        {
+          error: 'Forbidden',
+          message: decision.denialReason ?? 'MCP policy denied this tool call.',
+        },
+        403
+      )
+    }
+
+    c.set('mcpPrincipal', principal)
+    c.set('mcpPolicyDecision', decision)
+    return next()
+  })
+}
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    mcpPrincipal: McpPrincipal
+    mcpPolicyDecision: McpPolicyDecision
+    mcpSession: McpSession
+  }
+}

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -142,7 +142,15 @@ export function createMcpPolicyMiddleware() {
     }
     const payloadId =
       body && typeof body === 'object' && 'id' in body
-        ? (((body as JsonRpcToolCallBody).id as string | number | null | undefined) ?? null)
+        ? (() => {
+            const candidate = (body as { id?: unknown }).id
+            return typeof candidate === 'string' ||
+              typeof candidate === 'number' ||
+              candidate === null ||
+              candidate === undefined
+              ? (candidate ?? null)
+              : null
+          })()
         : null
     const isToolsCallMethod =
       body && typeof body === 'object' && !Array.isArray(body)

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -24,7 +24,7 @@ function parseToolCallBody(body: unknown): McpToolCallRequest | null {
   const safeArgs: Record<string, unknown> = args && typeof args === 'object' ? args : {}
   const connectionId =
     typeof safeArgs.connectionId === 'string' && safeArgs.connectionId.trim().length > 0
-      ? safeArgs.connectionId
+      ? safeArgs.connectionId.trim()
       : null
 
   return { toolName, arguments: safeArgs, connectionId }

--- a/apps/api/src/mcp/policy/policy-engine.test.ts
+++ b/apps/api/src/mcp/policy/policy-engine.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { McpSession } from '../auth/mcp-session-middleware'
+import { evaluateMcpToolPolicy } from './policy-engine'
+import type { McpPrincipal } from './types'
+
+const baseSession: McpSession = {
+  accessToken: 'token',
+  refreshToken: 'refresh',
+  accessTokenExpiresAt: new Date(),
+  refreshTokenExpiresAt: new Date(),
+  clientId: 'client-id',
+  userId: 'user-1',
+  scopes: 'mcp:discover mcp:jobs:read mcp:logs:read',
+}
+
+const delegatedPrincipal: McpPrincipal = {
+  type: 'delegated_user',
+  principalId: 'principal-1',
+  userId: 'user-1',
+  organizationId: null,
+}
+
+describe('evaluateMcpToolPolicy', () => {
+  it('denies tools without explicit scope mapping', async () => {
+    const decision = await evaluateMcpToolPolicy({
+      correlationId: 'corr-1',
+      principal: delegatedPrincipal,
+      session: baseSession,
+      call: {
+        toolName: 'unmapped_future_tool',
+        arguments: {},
+        connectionId: null,
+      },
+    })
+
+    expect(decision.granted).toBe(false)
+    expect(decision.denialReason).toBe('policy_configuration_missing')
+    expect(decision.requiredScopes).toEqual([])
+  })
+})

--- a/apps/api/src/mcp/policy/policy-engine.ts
+++ b/apps/api/src/mcp/policy/policy-engine.ts
@@ -1,0 +1,132 @@
+import { mcpPolicyRepository } from '@durabull/dal'
+
+import type { McpSession } from '../auth/mcp-session-middleware'
+import type { McpPolicyDecision, McpPrincipal, McpToolCallRequest } from './types'
+
+const TOOL_REQUIRED_SCOPES: Record<string, string[]> = {
+  ping: ['mcp:discover'],
+  list_connections: ['mcp:jobs:read'],
+  list_queues: ['mcp:jobs:read'],
+  get_queue: ['mcp:jobs:read'],
+  list_jobs: ['mcp:jobs:read'],
+  get_job: ['mcp:jobs:read'],
+  get_job_logs: ['mcp:logs:read'],
+  get_job_stacktraces: ['mcp:logs:read'],
+}
+
+function parseScopes(scopeString: string): string[] {
+  return scopeString
+    .split(/\s+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean)
+}
+
+function missingScopes(grantedScopes: string[], requiredScopes: string[]): string[] {
+  const grantedSet = new Set(grantedScopes)
+  return requiredScopes.filter((scope) => !grantedSet.has(scope))
+}
+
+function getRequiredScopes(toolName: string): string[] {
+  return TOOL_REQUIRED_SCOPES[toolName] ?? []
+}
+
+export async function evaluateMcpToolPolicy(input: {
+  correlationId: string
+  principal: McpPrincipal
+  session: McpSession
+  call: McpToolCallRequest
+}): Promise<McpPolicyDecision> {
+  const requiredScopes = getRequiredScopes(input.call.toolName)
+  const grantedScopes = parseScopes(input.session.scopes)
+  const missing = missingScopes(grantedScopes, requiredScopes)
+
+  if (missing.length > 0) {
+    return {
+      correlationId: input.correlationId,
+      principalType: input.principal.type,
+      principalId: input.principal.principalId,
+      organizationId: input.principal.organizationId,
+      connectionId: input.call.connectionId,
+      toolName: input.call.toolName,
+      requiredScopes,
+      granted: false,
+      denialReason: `missing_scopes:${missing.join(',')}`,
+    }
+  }
+
+  if (input.call.connectionId && input.principal.type === 'delegated_user') {
+    const canAccess = await mcpPolicyRepository.canDelegatedUserAccessConnection(
+      input.principal.userId,
+      input.call.connectionId
+    )
+    if (!canAccess) {
+      return {
+        correlationId: input.correlationId,
+        principalType: input.principal.type,
+        principalId: input.principal.principalId,
+        organizationId: null,
+        connectionId: input.call.connectionId,
+        toolName: input.call.toolName,
+        requiredScopes,
+        granted: false,
+        denialReason: 'connection_out_of_scope',
+      }
+    }
+  }
+
+  if (input.principal.type === 'service_account') {
+    const policyBindings = await mcpPolicyRepository.listPolicyBindings('service_account', input.principal.serviceAccountId)
+    const hasPolicyBinding = policyBindings.some(
+      (binding) =>
+        requiredScopes.includes(binding.scope) &&
+        (binding.toolName === null || binding.toolName === input.call.toolName) &&
+        (binding.organizationId === null || binding.organizationId === input.principal.organizationId)
+    )
+
+    if (!hasPolicyBinding) {
+      return {
+        correlationId: input.correlationId,
+        principalType: input.principal.type,
+        principalId: input.principal.principalId,
+        organizationId: input.principal.organizationId,
+        connectionId: input.call.connectionId,
+        toolName: input.call.toolName,
+        requiredScopes,
+        granted: false,
+        denialReason: 'service_account_policy_denied',
+      }
+    }
+
+    if (input.call.connectionId) {
+      const belongsToOrg = await mcpPolicyRepository.doesConnectionBelongToOrganization(
+        input.call.connectionId,
+        input.principal.organizationId
+      )
+      if (!belongsToOrg) {
+        return {
+          correlationId: input.correlationId,
+          principalType: input.principal.type,
+          principalId: input.principal.principalId,
+          organizationId: input.principal.organizationId,
+          connectionId: input.call.connectionId,
+          toolName: input.call.toolName,
+          requiredScopes,
+          granted: false,
+          denialReason: 'connection_out_of_scope',
+        }
+      }
+    }
+  }
+
+  return {
+    correlationId: input.correlationId,
+    principalType: input.principal.type,
+    principalId: input.principal.principalId,
+    organizationId: input.principal.organizationId,
+    connectionId: input.call.connectionId,
+    toolName: input.call.toolName,
+    requiredScopes,
+    granted: true,
+    denialReason: null,
+  }
+}

--- a/apps/api/src/mcp/policy/policy-engine.ts
+++ b/apps/api/src/mcp/policy/policy-engine.ts
@@ -26,8 +26,8 @@ function missingScopes(grantedScopes: string[], requiredScopes: string[]): strin
   return requiredScopes.filter((scope) => !grantedSet.has(scope))
 }
 
-function getRequiredScopes(toolName: string): string[] {
-  return TOOL_REQUIRED_SCOPES[toolName] ?? []
+function getRequiredScopes(toolName: string): string[] | null {
+  return TOOL_REQUIRED_SCOPES[toolName] ?? null
 }
 
 export async function evaluateMcpToolPolicy(input: {
@@ -37,6 +37,20 @@ export async function evaluateMcpToolPolicy(input: {
   call: McpToolCallRequest
 }): Promise<McpPolicyDecision> {
   const requiredScopes = getRequiredScopes(input.call.toolName)
+  if (!requiredScopes) {
+    return {
+      correlationId: input.correlationId,
+      principalType: input.principal.type,
+      principalId: input.principal.principalId,
+      organizationId: input.principal.organizationId,
+      connectionId: input.call.connectionId,
+      toolName: input.call.toolName,
+      requiredScopes: [],
+      granted: false,
+      denialReason: 'policy_configuration_missing',
+    }
+  }
+
   const grantedScopes = parseScopes(input.session.scopes)
   const missing = missingScopes(grantedScopes, requiredScopes)
 

--- a/apps/api/src/mcp/policy/principal-resolver.ts
+++ b/apps/api/src/mcp/policy/principal-resolver.ts
@@ -7,6 +7,24 @@ import type { McpPrincipal } from './types'
  * Resolves the authenticated MCP caller into a delegated-user or service-account principal.
  */
 export async function resolveMcpPrincipal(session: McpSession): Promise<McpPrincipal | null> {
+  const serviceAccount =
+    await mcpPolicyRepository.findServiceAccountByOauthClientIdIncludingDisabled(session.clientId)
+  if (serviceAccount) {
+    // Service-account oauth clients should resolve to machine principals only.
+    // If the linked service account is disabled or a token unexpectedly carries
+    // user identity, fail closed instead of falling back to delegated-user auth.
+    if (serviceAccount.disabled || session.userId) {
+      return null
+    }
+
+    return {
+      type: 'service_account',
+      principalId: serviceAccount.id,
+      serviceAccountId: serviceAccount.id,
+      organizationId: serviceAccount.organizationId,
+    }
+  }
+
   if (session.userId) {
     return {
       type: 'delegated_user',
@@ -16,15 +34,5 @@ export async function resolveMcpPrincipal(session: McpSession): Promise<McpPrinc
     }
   }
 
-  const serviceAccount = await mcpPolicyRepository.findServiceAccountByOauthClientId(session.clientId)
-  if (!serviceAccount) {
-    return null
-  }
-
-  return {
-    type: 'service_account',
-    principalId: serviceAccount.id,
-    serviceAccountId: serviceAccount.id,
-    organizationId: serviceAccount.organizationId,
-  }
+  return null
 }

--- a/apps/api/src/mcp/policy/principal-resolver.ts
+++ b/apps/api/src/mcp/policy/principal-resolver.ts
@@ -1,0 +1,30 @@
+import { mcpPolicyRepository } from '@durabull/dal'
+
+import type { McpSession } from '../auth/mcp-session-middleware'
+import type { McpPrincipal } from './types'
+
+/**
+ * Resolves the authenticated MCP caller into a delegated-user or service-account principal.
+ */
+export async function resolveMcpPrincipal(session: McpSession): Promise<McpPrincipal | null> {
+  if (session.userId) {
+    return {
+      type: 'delegated_user',
+      principalId: session.userId,
+      userId: session.userId,
+      organizationId: null,
+    }
+  }
+
+  const serviceAccount = await mcpPolicyRepository.findServiceAccountByOauthClientId(session.clientId)
+  if (!serviceAccount) {
+    return null
+  }
+
+  return {
+    type: 'service_account',
+    principalId: serviceAccount.id,
+    serviceAccountId: serviceAccount.id,
+    organizationId: serviceAccount.organizationId,
+  }
+}

--- a/apps/api/src/mcp/policy/types.ts
+++ b/apps/api/src/mcp/policy/types.ts
@@ -1,0 +1,33 @@
+import type { McpPrincipalType } from '@durabull/dal'
+
+export type McpPrincipal =
+  | {
+      type: 'delegated_user'
+      principalId: string
+      userId: string
+      organizationId: null
+    }
+  | {
+      type: 'service_account'
+      principalId: string
+      serviceAccountId: string
+      organizationId: string
+    }
+
+export interface McpPolicyDecision {
+  correlationId: string
+  principalType: McpPrincipalType
+  principalId: string
+  organizationId: string | null
+  connectionId: string | null
+  toolName: string
+  requiredScopes: string[]
+  granted: boolean
+  denialReason: string | null
+}
+
+export interface McpToolCallRequest {
+  toolName: string
+  arguments: Record<string, unknown>
+  connectionId: string | null
+}

--- a/apps/api/src/mcp/tools/get-job-handler.ts
+++ b/apps/api/src/mcp/tools/get-job-handler.ts
@@ -1,0 +1,46 @@
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import type { GetJobHandlerInput, GetJobHandlerOutput } from '@durabull/mcp'
+import { resolveConnectionForPrincipal } from './shared'
+
+export async function getJobHandler(input: GetJobHandlerInput): Promise<GetJobHandlerOutput> {
+  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
+  if (!connection) {
+    throw new Error(`Connection ${input.connectionId} not found.`)
+  }
+
+  const queue = await getQueue(
+    connection.id,
+    connection.url,
+    input.queueName,
+    connection.prefix,
+    toRedisConnectionOptions(connection.allowSelfSignedCerts)
+  )
+  const job = await queue.getJob(input.jobId)
+  if (!job) {
+    throw new Error(`Job ${input.jobId} not found in queue ${input.queueName}.`)
+  }
+
+  return {
+    connectionId: connection.id,
+    queueName: input.queueName,
+    job: {
+      id: String(job.id ?? ''),
+      name: job.name,
+      status: await job.getState(),
+      data: (job.data as Record<string, unknown>) ?? {},
+      progress: job.progress,
+      attemptsMade: job.attemptsMade,
+      maxAttempts: job.opts.attempts ?? 1,
+      failedReason: job.failedReason ?? null,
+      processedOn: job.processedOn ?? null,
+      finishedOn: job.finishedOn ?? null,
+      timestamp: job.timestamp ?? null,
+      delay: job.delay ?? 0,
+      priority: job.opts.priority ?? 0,
+      opts: (job.opts as Record<string, unknown>) ?? {},
+      returnvalue: job.returnvalue,
+      stacktraceCount: job.stacktrace?.length ?? 0,
+    },
+  }
+}

--- a/apps/api/src/mcp/tools/get-job-handler.ts
+++ b/apps/api/src/mcp/tools/get-job-handler.ts
@@ -1,46 +1,54 @@
 import { getQueue } from '../../lib/redis'
 import { toRedisConnectionOptions } from '../../lib/connection-options'
 import type { GetJobHandlerInput, GetJobHandlerOutput } from '@durabull/mcp'
-import { resolveConnectionForPrincipal } from './shared'
+import { McpToolError, requireConnectionForPrincipal } from './shared'
 
-export async function getJobHandler(input: GetJobHandlerInput): Promise<GetJobHandlerOutput> {
-  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
-  if (!connection) {
-    throw new Error(`Connection ${input.connectionId} not found.`)
-  }
+interface GetJobHandlerDeps {
+  getQueue: typeof getQueue
+  requireConnectionForPrincipal: typeof requireConnectionForPrincipal
+}
 
-  const queue = await getQueue(
-    connection.id,
-    connection.url,
-    input.queueName,
-    connection.prefix,
-    toRedisConnectionOptions(connection.allowSelfSignedCerts)
-  )
-  const job = await queue.getJob(input.jobId)
-  if (!job) {
-    throw new Error(`Job ${input.jobId} not found in queue ${input.queueName}.`)
-  }
+export function createGetJobHandler(
+  deps: GetJobHandlerDeps = { getQueue, requireConnectionForPrincipal }
+) {
+  return async function getJobHandler(input: GetJobHandlerInput): Promise<GetJobHandlerOutput> {
+    const connection = await deps.requireConnectionForPrincipal(input.principal, input.connectionId)
 
-  return {
-    connectionId: connection.id,
-    queueName: input.queueName,
-    job: {
-      id: String(job.id ?? ''),
-      name: job.name,
-      status: await job.getState(),
-      data: (job.data as Record<string, unknown>) ?? {},
-      progress: job.progress,
-      attemptsMade: job.attemptsMade,
-      maxAttempts: job.opts.attempts ?? 1,
-      failedReason: job.failedReason ?? null,
-      processedOn: job.processedOn ?? null,
-      finishedOn: job.finishedOn ?? null,
-      timestamp: job.timestamp ?? null,
-      delay: job.delay ?? 0,
-      priority: job.opts.priority ?? 0,
-      opts: (job.opts as Record<string, unknown>) ?? {},
-      returnvalue: job.returnvalue,
-      stacktraceCount: job.stacktrace?.length ?? 0,
-    },
+    const queue = await deps.getQueue(
+      connection.id,
+      connection.url,
+      input.queueName,
+      connection.prefix,
+      toRedisConnectionOptions(connection.allowSelfSignedCerts)
+    )
+    const job = await queue.getJob(input.jobId)
+    if (!job) {
+      throw new McpToolError('not_found', `Job ${input.jobId} not found in queue ${input.queueName}.`)
+    }
+
+    return {
+      connectionId: connection.id,
+      queueName: input.queueName,
+      job: {
+        id: String(job.id ?? ''),
+        name: job.name,
+        status: await job.getState(),
+        data: (job.data as Record<string, unknown>) ?? {},
+        progress: job.progress,
+        attemptsMade: job.attemptsMade,
+        maxAttempts: job.opts.attempts ?? 1,
+        failedReason: job.failedReason ?? null,
+        processedOn: job.processedOn ?? null,
+        finishedOn: job.finishedOn ?? null,
+        timestamp: job.timestamp ?? null,
+        delay: job.delay ?? 0,
+        priority: job.opts.priority ?? 0,
+        opts: (job.opts as Record<string, unknown>) ?? {},
+        returnvalue: job.returnvalue,
+        stacktraceCount: job.stacktrace?.length ?? 0,
+      },
+    }
   }
 }
+
+export const getJobHandler = createGetJobHandler()

--- a/apps/api/src/mcp/tools/get-job-logs-handler.ts
+++ b/apps/api/src/mcp/tools/get-job-logs-handler.ts
@@ -1,0 +1,36 @@
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import type { GetJobLogsHandlerInput, GetJobLogsHandlerOutput } from '@durabull/mcp'
+import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+
+export async function getJobLogsHandler(
+  input: GetJobLogsHandlerInput
+): Promise<GetJobLogsHandlerOutput> {
+  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
+  if (!connection) {
+    throw new Error(`Connection ${input.connectionId} not found.`)
+  }
+
+  const queue = await getQueue(
+    connection.id,
+    connection.url,
+    input.queueName,
+    connection.prefix,
+    toRedisConnectionOptions(connection.allowSelfSignedCerts)
+  )
+
+  const pageSize = Math.min(100, Math.max(1, input.pageSize))
+  const offset = decodeCursor(input.cursor)
+  const end = offset + pageSize - 1
+  const logs = await queue.getJobLogs(input.jobId, offset, end)
+  const nextOffset = offset + pageSize
+
+  return {
+    connectionId: connection.id,
+    queueName: input.queueName,
+    jobId: input.jobId,
+    logs: logs.logs ?? [],
+    total: logs.count ?? 0,
+    nextCursor: nextOffset < (logs.count ?? 0) ? encodeCursor(nextOffset) : null,
+  }
+}

--- a/apps/api/src/mcp/tools/get-job-logs-handler.ts
+++ b/apps/api/src/mcp/tools/get-job-logs-handler.ts
@@ -1,36 +1,48 @@
 import { getQueue } from '../../lib/redis'
 import { toRedisConnectionOptions } from '../../lib/connection-options'
 import type { GetJobLogsHandlerInput, GetJobLogsHandlerOutput } from '@durabull/mcp'
-import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+import { McpToolError, decodeCursor, encodeCursor, requireConnectionForPrincipal } from './shared'
 
-export async function getJobLogsHandler(
-  input: GetJobLogsHandlerInput
-): Promise<GetJobLogsHandlerOutput> {
-  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
-  if (!connection) {
-    throw new Error(`Connection ${input.connectionId} not found.`)
-  }
+interface GetJobLogsHandlerDeps {
+  getQueue: typeof getQueue
+  requireConnectionForPrincipal: typeof requireConnectionForPrincipal
+}
 
-  const queue = await getQueue(
-    connection.id,
-    connection.url,
-    input.queueName,
-    connection.prefix,
-    toRedisConnectionOptions(connection.allowSelfSignedCerts)
-  )
+export function createGetJobLogsHandler(
+  deps: GetJobLogsHandlerDeps = { getQueue, requireConnectionForPrincipal }
+) {
+  return async function getJobLogsHandler(
+    input: GetJobLogsHandlerInput
+  ): Promise<GetJobLogsHandlerOutput> {
+    const connection = await deps.requireConnectionForPrincipal(input.principal, input.connectionId)
 
-  const pageSize = Math.min(100, Math.max(1, input.pageSize))
-  const offset = decodeCursor(input.cursor)
-  const end = offset + pageSize - 1
-  const logs = await queue.getJobLogs(input.jobId, offset, end)
-  const nextOffset = offset + pageSize
+    const queue = await deps.getQueue(
+      connection.id,
+      connection.url,
+      input.queueName,
+      connection.prefix,
+      toRedisConnectionOptions(connection.allowSelfSignedCerts)
+    )
+    const job = await queue.getJob(input.jobId)
+    if (!job) {
+      throw new McpToolError('not_found', `Job ${input.jobId} not found in queue ${input.queueName}.`)
+    }
 
-  return {
-    connectionId: connection.id,
-    queueName: input.queueName,
-    jobId: input.jobId,
-    logs: logs.logs ?? [],
-    total: logs.count ?? 0,
-    nextCursor: nextOffset < (logs.count ?? 0) ? encodeCursor(nextOffset) : null,
+    const pageSize = Math.min(100, Math.max(1, input.pageSize))
+    const offset = decodeCursor(input.cursor)
+    const end = offset + pageSize - 1
+    const logs = await queue.getJobLogs(input.jobId, offset, end)
+    const nextOffset = offset + pageSize
+
+    return {
+      connectionId: connection.id,
+      queueName: input.queueName,
+      jobId: input.jobId,
+      logs: logs.logs ?? [],
+      total: logs.count ?? 0,
+      nextCursor: nextOffset < (logs.count ?? 0) ? encodeCursor(nextOffset) : null,
+    }
   }
 }
+
+export const getJobLogsHandler = createGetJobLogsHandler()

--- a/apps/api/src/mcp/tools/get-job-stacktraces-handler.ts
+++ b/apps/api/src/mcp/tools/get-job-stacktraces-handler.ts
@@ -4,45 +4,53 @@ import type {
   GetJobStacktracesHandlerInput,
   GetJobStacktracesHandlerOutput,
 } from '@durabull/mcp'
-import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+import { McpToolError, decodeCursor, encodeCursor, requireConnectionForPrincipal } from './shared'
 
-export async function getJobStacktracesHandler(
-  input: GetJobStacktracesHandlerInput
-): Promise<GetJobStacktracesHandlerOutput> {
-  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
-  if (!connection) {
-    throw new Error(`Connection ${input.connectionId} not found.`)
-  }
+interface GetJobStacktracesHandlerDeps {
+  getQueue: typeof getQueue
+  requireConnectionForPrincipal: typeof requireConnectionForPrincipal
+}
 
-  const queue = await getQueue(
-    connection.id,
-    connection.url,
-    input.queueName,
-    connection.prefix,
-    toRedisConnectionOptions(connection.allowSelfSignedCerts)
-  )
-  const job = await queue.getJob(input.jobId)
-  if (!job) {
-    throw new Error(`Job ${input.jobId} not found in queue ${input.queueName}.`)
-  }
+export function createGetJobStacktracesHandler(
+  deps: GetJobStacktracesHandlerDeps = { getQueue, requireConnectionForPrincipal }
+) {
+  return async function getJobStacktracesHandler(
+    input: GetJobStacktracesHandlerInput
+  ): Promise<GetJobStacktracesHandlerOutput> {
+    const connection = await deps.requireConnectionForPrincipal(input.principal, input.connectionId)
 
-  const allStacktraces = job.stacktrace ?? []
-  const pageSize = Math.min(100, Math.max(1, input.pageSize))
-  const offset = decodeCursor(input.cursor)
-  const reversed = [...allStacktraces].reverse()
-  const page = reversed.slice(offset, offset + pageSize)
-  const nextOffset = offset + page.length
+    const queue = await deps.getQueue(
+      connection.id,
+      connection.url,
+      input.queueName,
+      connection.prefix,
+      toRedisConnectionOptions(connection.allowSelfSignedCerts)
+    )
+    const job = await queue.getJob(input.jobId)
+    if (!job) {
+      throw new McpToolError('not_found', `Job ${input.jobId} not found in queue ${input.queueName}.`)
+    }
 
-  return {
-    connectionId: connection.id,
-    queueName: input.queueName,
-    jobId: input.jobId,
-    total: allStacktraces.length,
-    stacktraces: page.map((stacktrace, index) => ({
-      attemptNumber: allStacktraces.length - (offset + index),
-      stacktrace,
-      isLatest: offset + index === 0,
-    })),
-    nextCursor: nextOffset < allStacktraces.length ? encodeCursor(nextOffset) : null,
+    const allStacktraces = job.stacktrace ?? []
+    const pageSize = Math.min(100, Math.max(1, input.pageSize))
+    const offset = decodeCursor(input.cursor)
+    const reversed = [...allStacktraces].reverse()
+    const page = reversed.slice(offset, offset + pageSize)
+    const nextOffset = offset + page.length
+
+    return {
+      connectionId: connection.id,
+      queueName: input.queueName,
+      jobId: input.jobId,
+      total: allStacktraces.length,
+      stacktraces: page.map((stacktrace, index) => ({
+        attemptNumber: allStacktraces.length - (offset + index),
+        stacktrace,
+        isLatest: offset + index === 0,
+      })),
+      nextCursor: nextOffset < allStacktraces.length ? encodeCursor(nextOffset) : null,
+    }
   }
 }
+
+export const getJobStacktracesHandler = createGetJobStacktracesHandler()

--- a/apps/api/src/mcp/tools/get-job-stacktraces-handler.ts
+++ b/apps/api/src/mcp/tools/get-job-stacktraces-handler.ts
@@ -1,0 +1,48 @@
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import type {
+  GetJobStacktracesHandlerInput,
+  GetJobStacktracesHandlerOutput,
+} from '@durabull/mcp'
+import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+
+export async function getJobStacktracesHandler(
+  input: GetJobStacktracesHandlerInput
+): Promise<GetJobStacktracesHandlerOutput> {
+  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
+  if (!connection) {
+    throw new Error(`Connection ${input.connectionId} not found.`)
+  }
+
+  const queue = await getQueue(
+    connection.id,
+    connection.url,
+    input.queueName,
+    connection.prefix,
+    toRedisConnectionOptions(connection.allowSelfSignedCerts)
+  )
+  const job = await queue.getJob(input.jobId)
+  if (!job) {
+    throw new Error(`Job ${input.jobId} not found in queue ${input.queueName}.`)
+  }
+
+  const allStacktraces = job.stacktrace ?? []
+  const pageSize = Math.min(100, Math.max(1, input.pageSize))
+  const offset = decodeCursor(input.cursor)
+  const reversed = [...allStacktraces].reverse()
+  const page = reversed.slice(offset, offset + pageSize)
+  const nextOffset = offset + page.length
+
+  return {
+    connectionId: connection.id,
+    queueName: input.queueName,
+    jobId: input.jobId,
+    total: allStacktraces.length,
+    stacktraces: page.map((stacktrace, index) => ({
+      attemptNumber: allStacktraces.length - (offset + index),
+      stacktrace,
+      isLatest: offset + index === 0,
+    })),
+    nextCursor: nextOffset < allStacktraces.length ? encodeCursor(nextOffset) : null,
+  }
+}

--- a/apps/api/src/mcp/tools/get-queue-handler.ts
+++ b/apps/api/src/mcp/tools/get-queue-handler.ts
@@ -1,0 +1,50 @@
+import { getQueue, safeGetWorkers } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import type { GetQueueHandlerInput, GetQueueHandlerOutput } from '@durabull/mcp'
+import { resolveConnectionForPrincipal } from './shared'
+
+export async function getQueueHandler(input: GetQueueHandlerInput): Promise<GetQueueHandlerOutput> {
+  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
+  if (!connection) {
+    throw new Error(`Connection ${input.connectionId} not found.`)
+  }
+
+  const queue = await getQueue(
+    connection.id,
+    connection.url,
+    input.queueName,
+    connection.prefix,
+    toRedisConnectionOptions(connection.allowSelfSignedCerts)
+  )
+
+  const [counts, isPaused, workers, schedulers] = await Promise.all([
+    queue.getJobCounts(),
+    queue.isPaused(),
+    safeGetWorkers(queue),
+    queue.getJobSchedulers(),
+  ])
+
+  return {
+    connectionId: connection.id,
+    name: input.queueName,
+    status: isPaused ? 'paused' : 'active',
+    jobCounts: {
+      waiting: counts.waiting ?? 0,
+      active: counts.active ?? 0,
+      delayed: counts.delayed ?? 0,
+      completed: counts.completed ?? 0,
+      failed: counts.failed ?? 0,
+      paused: counts.paused ?? 0,
+      prioritized: counts.prioritized ?? 0,
+    },
+    isPaused,
+    scheduledJobsCount: schedulers.length,
+    workers: workers.map((worker) => ({
+      id: worker.id ?? '',
+      name: worker.name ?? '',
+      address: worker.addr ?? '',
+      ageMs: Number(worker.age ?? 0) || 0,
+      idleMs: Number(worker.idle ?? 0) || 0,
+    })),
+  }
+}

--- a/apps/api/src/mcp/tools/get-queue-handler.ts
+++ b/apps/api/src/mcp/tools/get-queue-handler.ts
@@ -1,13 +1,10 @@
 import { getQueue, safeGetWorkers } from '../../lib/redis'
 import { toRedisConnectionOptions } from '../../lib/connection-options'
 import type { GetQueueHandlerInput, GetQueueHandlerOutput } from '@durabull/mcp'
-import { resolveConnectionForPrincipal } from './shared'
+import { requireConnectionForPrincipal } from './shared'
 
 export async function getQueueHandler(input: GetQueueHandlerInput): Promise<GetQueueHandlerOutput> {
-  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
-  if (!connection) {
-    throw new Error(`Connection ${input.connectionId} not found.`)
-  }
+  const connection = await requireConnectionForPrincipal(input.principal, input.connectionId)
 
   const queue = await getQueue(
     connection.id,

--- a/apps/api/src/mcp/tools/job-read-handlers.test.ts
+++ b/apps/api/src/mcp/tools/job-read-handlers.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createGetJobHandler } from './get-job-handler'
+import { createGetJobLogsHandler } from './get-job-logs-handler'
+import { createGetJobStacktracesHandler } from './get-job-stacktraces-handler'
+import { McpToolError } from './shared'
+
+const principal = {
+  type: 'service_account' as const,
+  principalId: 'principal-1',
+  organizationId: 'org-1',
+}
+
+const connection = {
+  id: 'conn-1',
+  url: 'redis://localhost:6379',
+  prefix: 'bull',
+  allowSelfSignedCerts: false,
+}
+
+describe('MCP job read handlers', () => {
+  it('returns full payload for get_job', async () => {
+    const getJobHandler = createGetJobHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return {
+              id: 'job-1',
+              name: 'send-email',
+              data: { hello: 'world' },
+              progress: 50,
+              attemptsMade: 1,
+              opts: { attempts: 3, priority: 2 },
+              failedReason: null,
+              processedOn: 10,
+              finishedOn: 20,
+              timestamp: 1,
+              delay: 0,
+              returnvalue: { ok: true },
+              stacktrace: ['trace-line'],
+              async getState() {
+                return 'active'
+              },
+            }
+          },
+        } as never
+      },
+    })
+
+    const result = await getJobHandler({
+      principal,
+      connectionId: 'conn-1',
+      queueName: 'email',
+      jobId: 'job-1',
+    })
+
+    expect(result.job.id).toBe('job-1')
+    expect(result.job.status).toBe('active')
+    expect(result.job.stacktraceCount).toBe(1)
+    expect(result.job.data).toEqual({ hello: 'world' })
+  })
+
+  it('returns paginated logs for get_job_logs', async () => {
+    const getJobLogsHandler = createGetJobLogsHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return { id: 'job-1' }
+          },
+          async getJobLogs() {
+            return { logs: ['line-1', 'line-2'], count: 3 }
+          },
+        } as never
+      },
+    })
+
+    const result = await getJobLogsHandler({
+      principal,
+      connectionId: 'conn-1',
+      queueName: 'email',
+      jobId: 'job-1',
+      pageSize: 2,
+      cursor: '0',
+    })
+
+    expect(result.logs).toEqual(['line-1', 'line-2'])
+    expect(result.total).toBe(3)
+    expect(result.nextCursor).toBe('2')
+  })
+
+  it('returns latest-first stacktraces for get_job_stacktraces', async () => {
+    const getJobStacktracesHandler = createGetJobStacktracesHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return {
+              id: 'job-1',
+              stacktrace: ['first', 'second', 'third'],
+            }
+          },
+        } as never
+      },
+    })
+
+    const result = await getJobStacktracesHandler({
+      principal,
+      connectionId: 'conn-1',
+      queueName: 'email',
+      jobId: 'job-1',
+      pageSize: 2,
+      cursor: '0',
+    })
+
+    expect(result.total).toBe(3)
+    expect(result.stacktraces.map((row) => row.stacktrace)).toEqual(['third', 'second'])
+    expect(result.stacktraces[0]?.isLatest).toBe(true)
+    expect(result.nextCursor).toBe('2')
+  })
+
+  it('throws typed not_found when job is missing', async () => {
+    const getJobHandler = createGetJobHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return null
+          },
+        } as never
+      },
+    })
+
+    await expect(
+      getJobHandler({
+        principal,
+        connectionId: 'conn-1',
+        queueName: 'email',
+        jobId: 'missing',
+      })
+    ).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/apps/api/src/mcp/tools/list-connections-handler.ts
+++ b/apps/api/src/mcp/tools/list-connections-handler.ts
@@ -1,0 +1,34 @@
+import { mcpPolicyRepository, redisConnectionRepository } from '@durabull/dal'
+import type {
+  ListConnectionsHandlerInput,
+  ListConnectionsHandlerOutput,
+} from '@durabull/mcp'
+import { decodeCursor, encodeCursor } from './shared'
+
+export async function listConnectionsHandler(
+  input: ListConnectionsHandlerInput
+): Promise<ListConnectionsHandlerOutput> {
+  const offset = decodeCursor(input.cursor)
+  const pageSize = Math.min(100, Math.max(1, input.pageSize))
+
+  const allConnections =
+    input.principal.type === 'delegated_user'
+      ? await mcpPolicyRepository.listDelegatedUserConnections(input.principal.userId)
+      : (await redisConnectionRepository.findAll(input.principal.organizationId)).map((connection) => ({
+          id: connection.id,
+          name: connection.name,
+          environment: connection.environment ?? null,
+          prefix: connection.prefix,
+          isDefault: connection.isDefault,
+          organizationId: connection.organizationId,
+        }))
+
+  const page = allConnections.slice(offset, offset + pageSize)
+  const nextOffset = offset + page.length
+  const nextCursor = nextOffset < allConnections.length ? encodeCursor(nextOffset) : null
+
+  return {
+    connections: page,
+    nextCursor,
+  }
+}

--- a/apps/api/src/mcp/tools/list-jobs-handler.ts
+++ b/apps/api/src/mcp/tools/list-jobs-handler.ts
@@ -1,7 +1,7 @@
 import { getQueue } from '../../lib/redis'
 import { toRedisConnectionOptions } from '../../lib/connection-options'
 import type { ListJobsHandlerInput, ListJobsHandlerOutput } from '@durabull/mcp'
-import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+import { decodeCursor, encodeCursor, requireConnectionForPrincipal } from './shared'
 
 type JobState =
   | 'waiting'
@@ -23,10 +23,7 @@ const ALL_STATES: JobState[] = [
 ]
 
 export async function listJobsHandler(input: ListJobsHandlerInput): Promise<ListJobsHandlerOutput> {
-  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
-  if (!connection) {
-    throw new Error(`Connection ${input.connectionId} not found.`)
-  }
+  const connection = await requireConnectionForPrincipal(input.principal, input.connectionId)
 
   const queue = await getQueue(
     connection.id,

--- a/apps/api/src/mcp/tools/list-jobs-handler.ts
+++ b/apps/api/src/mcp/tools/list-jobs-handler.ts
@@ -1,7 +1,12 @@
 import { getQueue } from '../../lib/redis'
 import { toRedisConnectionOptions } from '../../lib/connection-options'
 import type { ListJobsHandlerInput, ListJobsHandlerOutput } from '@durabull/mcp'
-import { decodeCursor, encodeCursor, requireConnectionForPrincipal } from './shared'
+import {
+  McpToolError,
+  decodeCursor,
+  encodeCursor,
+  requireConnectionForPrincipal,
+} from './shared'
 
 type JobState =
   | 'waiting'
@@ -21,6 +26,9 @@ const ALL_STATES: JobState[] = [
   'paused',
   'prioritized',
 ]
+
+const FILTER_SCAN_BATCH_SIZE = 200
+const MAX_FILTER_SCAN_JOBS = 10_000
 
 export async function listJobsHandler(input: ListJobsHandlerInput): Promise<ListJobsHandlerOutput> {
   const connection = await requireConnectionForPrincipal(input.principal, input.connectionId)
@@ -92,14 +100,30 @@ export async function listJobsHandler(input: ListJobsHandlerInput): Promise<List
   const offset = decodeCursor(input.cursor)
 
   if (hasClientFilter) {
+    let scannedJobs = 0
     const jobsWithState: Array<{
       job: NonNullable<Awaited<ReturnType<typeof queue.getJobs>>[number]>
       state: JobState
     }> = []
     for (const state of states) {
-      const stateJobs = await queue.getJobs([state])
-      for (const job of stateJobs) {
-        if (job != null) {
+      for (let start = 0; ; start += FILTER_SCAN_BATCH_SIZE) {
+        const end = start + FILTER_SCAN_BATCH_SIZE - 1
+        const stateJobs = await queue.getJobs([state], start, end)
+        if (stateJobs.length === 0) {
+          break
+        }
+
+        for (const job of stateJobs) {
+          if (job == null) continue
+
+          scannedJobs += 1
+          if (scannedJobs > MAX_FILTER_SCAN_JOBS) {
+            throw new McpToolError(
+              'validation_error',
+              `Filtered job search exceeded ${MAX_FILTER_SCAN_JOBS} jobs. Narrow the query with status or jobId.`
+            )
+          }
+
           jobsWithState.push({ job, state })
         }
       }

--- a/apps/api/src/mcp/tools/list-jobs-handler.ts
+++ b/apps/api/src/mcp/tools/list-jobs-handler.ts
@@ -1,0 +1,166 @@
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import type { ListJobsHandlerInput, ListJobsHandlerOutput } from '@durabull/mcp'
+import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+
+type JobState =
+  | 'waiting'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'delayed'
+  | 'paused'
+  | 'prioritized'
+
+const ALL_STATES: JobState[] = [
+  'waiting',
+  'active',
+  'completed',
+  'failed',
+  'delayed',
+  'paused',
+  'prioritized',
+]
+
+export async function listJobsHandler(input: ListJobsHandlerInput): Promise<ListJobsHandlerOutput> {
+  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
+  if (!connection) {
+    throw new Error(`Connection ${input.connectionId} not found.`)
+  }
+
+  const queue = await getQueue(
+    connection.id,
+    connection.url,
+    input.queueName,
+    connection.prefix,
+    toRedisConnectionOptions(connection.allowSelfSignedCerts)
+  )
+
+  if (input.jobId) {
+    const exactJob = await queue.getJob(input.jobId)
+    if (!exactJob) {
+      return {
+        connectionId: connection.id,
+        queueName: input.queueName,
+        jobs: [],
+        total: 0,
+        nextCursor: null,
+      }
+    }
+    const exactState = await exactJob.getState()
+    if (input.status && exactState !== input.status) {
+      return {
+        connectionId: connection.id,
+        queueName: input.queueName,
+        jobs: [],
+        total: 0,
+        nextCursor: null,
+      }
+    }
+    if (input.name && !exactJob.name.toLowerCase().includes(input.name.toLowerCase())) {
+      return {
+        connectionId: connection.id,
+        queueName: input.queueName,
+        jobs: [],
+        total: 0,
+        nextCursor: null,
+      }
+    }
+    return {
+      connectionId: connection.id,
+      queueName: input.queueName,
+      jobs: [
+        {
+          id: String(exactJob.id ?? ''),
+          name: exactJob.name,
+          status: exactState,
+          attemptsMade: exactJob.attemptsMade,
+          maxAttempts: exactJob.opts.attempts ?? 1,
+          failedReason: exactJob.failedReason ?? null,
+          processedOn: exactJob.processedOn ?? null,
+          finishedOn: exactJob.finishedOn ?? null,
+          timestamp: exactJob.timestamp ?? null,
+          delay: exactJob.delay ?? 0,
+          priority: exactJob.opts.priority ?? 0,
+        },
+      ],
+      total: 1,
+      nextCursor: null,
+    }
+  }
+
+  const states: JobState[] = input.status ? [input.status as JobState] : [...ALL_STATES]
+  const hasClientFilter = Boolean(input.name || input.jobId)
+
+  if (hasClientFilter) {
+    const jobsWithState: Array<{
+      job: NonNullable<Awaited<ReturnType<typeof queue.getJobs>>[number]>
+      state: JobState
+    }> = []
+    for (const state of states) {
+      const stateJobs = await queue.getJobs([state])
+      for (const job of stateJobs) {
+        if (job != null) {
+          jobsWithState.push({ job, state })
+        }
+      }
+    }
+    const filtered = jobsWithState
+      .filter(({ job }) =>
+        input.name ? job.name.toLowerCase().includes(input.name.toLowerCase()) : true
+      )
+      .map(({ job, state }) => ({
+        id: String(job.id ?? ''),
+        name: job.name,
+        status: state,
+        attemptsMade: job.attemptsMade,
+        maxAttempts: job.opts.attempts ?? 1,
+        failedReason: job.failedReason ?? null,
+        processedOn: job.processedOn ?? null,
+        finishedOn: job.finishedOn ?? null,
+        timestamp: job.timestamp ?? null,
+        delay: job.delay ?? 0,
+        priority: job.opts.priority ?? 0,
+      }))
+    return {
+      connectionId: connection.id,
+      queueName: input.queueName,
+      jobs: filtered,
+      total: filtered.length,
+      nextCursor: null,
+    }
+  }
+
+  const pageSize = Math.min(100, Math.max(1, input.pageSize))
+  const offset = decodeCursor(input.cursor)
+  const end = offset + pageSize - 1
+
+  const jobs = await queue.getJobs(states, offset, end)
+  const mappedJobs = await Promise.all(
+    jobs
+      .filter((job): job is NonNullable<typeof job> => job != null)
+      .map(async (job) => ({
+        id: String(job.id ?? ''),
+        name: job.name,
+        status: await job.getState(),
+        attemptsMade: job.attemptsMade,
+        maxAttempts: job.opts.attempts ?? 1,
+        failedReason: job.failedReason ?? null,
+        processedOn: job.processedOn ?? null,
+        finishedOn: job.finishedOn ?? null,
+        timestamp: job.timestamp ?? null,
+        delay: job.delay ?? 0,
+        priority: job.opts.priority ?? 0,
+      }))
+  )
+
+  const total = await queue.getJobCountByTypes(...states)
+  const nextOffset = offset + pageSize
+  return {
+    connectionId: connection.id,
+    queueName: input.queueName,
+    jobs: mappedJobs,
+    total,
+    nextCursor: nextOffset < total ? encodeCursor(nextOffset) : null,
+  }
+}

--- a/apps/api/src/mcp/tools/list-jobs-handler.ts
+++ b/apps/api/src/mcp/tools/list-jobs-handler.ts
@@ -88,6 +88,8 @@ export async function listJobsHandler(input: ListJobsHandlerInput): Promise<List
 
   const states: JobState[] = input.status ? [input.status as JobState] : [...ALL_STATES]
   const hasClientFilter = Boolean(input.name || input.jobId)
+  const pageSize = Math.min(100, Math.max(1, input.pageSize))
+  const offset = decodeCursor(input.cursor)
 
   if (hasClientFilter) {
     const jobsWithState: Array<{
@@ -119,17 +121,18 @@ export async function listJobsHandler(input: ListJobsHandlerInput): Promise<List
         delay: job.delay ?? 0,
         priority: job.opts.priority ?? 0,
       }))
+
+    const page = filtered.slice(offset, offset + pageSize)
+    const nextOffset = offset + pageSize
     return {
       connectionId: connection.id,
       queueName: input.queueName,
-      jobs: filtered,
+      jobs: page,
       total: filtered.length,
-      nextCursor: null,
+      nextCursor: nextOffset < filtered.length ? encodeCursor(nextOffset) : null,
     }
   }
 
-  const pageSize = Math.min(100, Math.max(1, input.pageSize))
-  const offset = decodeCursor(input.cursor)
   const end = offset + pageSize - 1
 
   const jobs = await queue.getJobs(states, offset, end)

--- a/apps/api/src/mcp/tools/list-queues-handler.ts
+++ b/apps/api/src/mcp/tools/list-queues-handler.ts
@@ -1,0 +1,55 @@
+import { redisDiscoveredQueueRepository } from '@durabull/dal'
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import type { ListQueuesHandlerInput, ListQueuesHandlerOutput } from '@durabull/mcp'
+import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+
+export async function listQueuesHandler(input: ListQueuesHandlerInput): Promise<ListQueuesHandlerOutput> {
+  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
+  if (!connection) {
+    throw new Error(`Connection ${input.connectionId} not found.`)
+  }
+
+  const offset = decodeCursor(input.cursor)
+  const pageSize = Math.min(100, Math.max(1, input.pageSize))
+  const [total, indexedQueues] = await Promise.all([
+    redisDiscoveredQueueRepository.countByConnection(connection.id),
+    redisDiscoveredQueueRepository.listByConnection(connection.id, { offset, limit: pageSize }),
+  ])
+
+  const queues = await Promise.all(
+    indexedQueues.map(async (indexedQueue) => {
+      const queue = await getQueue(
+        connection.id,
+        connection.url,
+        indexedQueue.name,
+        connection.prefix,
+        toRedisConnectionOptions(connection.allowSelfSignedCerts)
+      )
+      const [counts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()])
+      return {
+        name: indexedQueue.name,
+        status: isPaused ? ('paused' as const) : ('active' as const),
+        jobCounts: {
+          waiting: counts.waiting ?? 0,
+          active: counts.active ?? 0,
+          delayed: counts.delayed ?? 0,
+          completed: counts.completed ?? 0,
+          failed: counts.failed ?? 0,
+          paused: counts.paused ?? 0,
+          prioritized: counts.prioritized ?? 0,
+        },
+        isPaused,
+        discoveryState: indexedQueue.state,
+      }
+    })
+  )
+
+  const nextOffset = offset + queues.length
+  return {
+    connectionId: connection.id,
+    total,
+    queues,
+    nextCursor: nextOffset < total ? encodeCursor(nextOffset) : null,
+  }
+}

--- a/apps/api/src/mcp/tools/list-queues-handler.ts
+++ b/apps/api/src/mcp/tools/list-queues-handler.ts
@@ -2,13 +2,10 @@ import { redisDiscoveredQueueRepository } from '@durabull/dal'
 import { getQueue } from '../../lib/redis'
 import { toRedisConnectionOptions } from '../../lib/connection-options'
 import type { ListQueuesHandlerInput, ListQueuesHandlerOutput } from '@durabull/mcp'
-import { decodeCursor, encodeCursor, resolveConnectionForPrincipal } from './shared'
+import { decodeCursor, encodeCursor, requireConnectionForPrincipal } from './shared'
 
 export async function listQueuesHandler(input: ListQueuesHandlerInput): Promise<ListQueuesHandlerOutput> {
-  const connection = await resolveConnectionForPrincipal(input.principal, input.connectionId)
-  if (!connection) {
-    throw new Error(`Connection ${input.connectionId} not found.`)
-  }
+  const connection = await requireConnectionForPrincipal(input.principal, input.connectionId)
 
   const offset = decodeCursor(input.cursor)
   const pageSize = Math.min(100, Math.max(1, input.pageSize))

--- a/apps/api/src/mcp/tools/shared.ts
+++ b/apps/api/src/mcp/tools/shared.ts
@@ -3,11 +3,32 @@ import type { ListConnectionsHandlerInput } from '@durabull/mcp'
 
 export type ToolPrincipal = ListConnectionsHandlerInput['principal']
 
+export class McpToolError extends Error {
+  readonly code: 'not_found' | 'validation_error' | 'internal_error'
+
+  constructor(code: 'not_found' | 'validation_error' | 'internal_error', message: string) {
+    super(message)
+    this.name = 'McpToolError'
+    this.code = code
+  }
+}
+
 export async function resolveConnectionForPrincipal(principal: ToolPrincipal, connectionId: string) {
   if (principal.type === 'service_account') {
     return redisConnectionRepository.findById(connectionId, principal.organizationId)
   }
   return redisConnectionRepository.findByIdUnsafe(connectionId)
+}
+
+export async function requireConnectionForPrincipal(
+  principal: ToolPrincipal,
+  connectionId: string
+) {
+  const connection = await resolveConnectionForPrincipal(principal, connectionId)
+  if (!connection) {
+    throw new McpToolError('not_found', `Connection ${connectionId} not found.`)
+  }
+  return connection
 }
 
 export function decodeCursor(cursor: string | undefined): number {

--- a/apps/api/src/mcp/tools/shared.ts
+++ b/apps/api/src/mcp/tools/shared.ts
@@ -1,4 +1,4 @@
-import { redisConnectionRepository } from '@durabull/dal'
+import { mcpPolicyRepository, redisConnectionRepository } from '@durabull/dal'
 import type { ListConnectionsHandlerInput } from '@durabull/mcp'
 
 export type ToolPrincipal = ListConnectionsHandlerInput['principal']
@@ -16,6 +16,14 @@ export class McpToolError extends Error {
 export async function resolveConnectionForPrincipal(principal: ToolPrincipal, connectionId: string) {
   if (principal.type === 'service_account') {
     return redisConnectionRepository.findById(connectionId, principal.organizationId)
+  }
+
+  const hasAccess = await mcpPolicyRepository.canDelegatedUserAccessConnection(
+    principal.userId,
+    connectionId
+  )
+  if (!hasAccess) {
+    return null
   }
   return redisConnectionRepository.findByIdUnsafe(connectionId)
 }

--- a/apps/api/src/mcp/tools/shared.ts
+++ b/apps/api/src/mcp/tools/shared.ts
@@ -1,0 +1,21 @@
+import { redisConnectionRepository } from '@durabull/dal'
+import type { ListConnectionsHandlerInput } from '@durabull/mcp'
+
+export type ToolPrincipal = ListConnectionsHandlerInput['principal']
+
+export async function resolveConnectionForPrincipal(principal: ToolPrincipal, connectionId: string) {
+  if (principal.type === 'service_account') {
+    return redisConnectionRepository.findById(connectionId, principal.organizationId)
+  }
+  return redisConnectionRepository.findByIdUnsafe(connectionId)
+}
+
+export function decodeCursor(cursor: string | undefined): number {
+  if (!cursor) return 0
+  const parsed = Number.parseInt(cursor, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+}
+
+export function encodeCursor(offset: number): string {
+  return String(offset)
+}

--- a/bun.lock
+++ b/bun.lock
@@ -235,6 +235,7 @@
         "@hono/mcp": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "hono": "^4.6.14",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -2967,6 +2968,8 @@
     "@durabull/api/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@durabull/mcp/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@durabull/mcp/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@durabull/web/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 

--- a/packages/dal/src/db/migrations/20260527020000_mcp_pr04_principals_policy/migration.sql
+++ b/packages/dal/src/db/migrations/20260527020000_mcp_pr04_principals_policy/migration.sql
@@ -1,0 +1,80 @@
+CREATE TABLE "mcp_service_account" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "organization_id" text NOT NULL,
+  "name" text NOT NULL,
+  "description" text,
+  "oauth_client_id" text,
+  "disabled" boolean DEFAULT false NOT NULL,
+  CONSTRAINT "mcp_service_account_organization_id_organization_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade,
+  CONSTRAINT "mcp_service_account_oauth_client_id_oauth_application_client_id_fk"
+    FOREIGN KEY ("oauth_client_id") REFERENCES "oauth_application"("client_id") ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX "mcp_service_account_org_idx" ON "mcp_service_account" ("organization_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "mcp_service_account_oauth_client_id_unique"
+  ON "mcp_service_account" ("oauth_client_id");
+--> statement-breakpoint
+CREATE TABLE "mcp_service_account_secret" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "service_account_id" uuid NOT NULL,
+  "label" text DEFAULT 'primary' NOT NULL,
+  "secret_hash" text NOT NULL,
+  "secret_last_four" text NOT NULL,
+  "created_by_user_id" text,
+  "expires_at" timestamp with time zone,
+  "revoked_at" timestamp with time zone,
+  CONSTRAINT "mcp_service_account_secret_service_account_id_mcp_service_account_id_fk"
+    FOREIGN KEY ("service_account_id") REFERENCES "mcp_service_account"("id") ON DELETE cascade,
+  CONSTRAINT "mcp_service_account_secret_created_by_user_id_user_id_fk"
+    FOREIGN KEY ("created_by_user_id") REFERENCES "user"("id") ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX "mcp_service_account_secret_account_idx"
+  ON "mcp_service_account_secret" ("service_account_id");
+--> statement-breakpoint
+CREATE TABLE "mcp_policy_binding" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "principal_type" text NOT NULL,
+  "principal_id" text NOT NULL,
+  "organization_id" text,
+  "tool_name" text,
+  "scope" text NOT NULL,
+  "disabled" boolean DEFAULT false NOT NULL,
+  CONSTRAINT "mcp_policy_binding_organization_id_organization_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX "mcp_policy_binding_principal_idx"
+  ON "mcp_policy_binding" ("principal_type", "principal_id");
+--> statement-breakpoint
+CREATE INDEX "mcp_policy_binding_org_idx" ON "mcp_policy_binding" ("organization_id");
+--> statement-breakpoint
+CREATE TABLE "mcp_audit_event" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "correlation_id" text NOT NULL,
+  "principal_type" text NOT NULL,
+  "principal_id" text NOT NULL,
+  "organization_id" text,
+  "connection_id" text,
+  "tool_name" text NOT NULL,
+  "required_scopes" text NOT NULL,
+  "granted" boolean NOT NULL,
+  "denial_reason" text
+);
+--> statement-breakpoint
+CREATE INDEX "mcp_audit_event_correlation_idx" ON "mcp_audit_event" ("correlation_id");
+--> statement-breakpoint
+CREATE INDEX "mcp_audit_event_principal_idx"
+  ON "mcp_audit_event" ("principal_type", "principal_id");
+--> statement-breakpoint
+CREATE INDEX "mcp_audit_event_tool_idx" ON "mcp_audit_event" ("tool_name");

--- a/packages/dal/src/db/migrations/20260527020000_mcp_pr04_principals_policy/migration.sql
+++ b/packages/dal/src/db/migrations/20260527020000_mcp_pr04_principals_policy/migration.sql
@@ -42,7 +42,9 @@ CREATE TABLE "mcp_policy_binding" (
   "id" uuid PRIMARY KEY NOT NULL,
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-  "principal_type" text NOT NULL,
+  "principal_type" text NOT NULL
+    CONSTRAINT "mcp_policy_binding_principal_type_check"
+    CHECK ("principal_type" IN ('delegated_user', 'service_account')),
   "principal_id" text NOT NULL,
   "organization_id" text,
   "tool_name" text,
@@ -62,7 +64,9 @@ CREATE TABLE "mcp_audit_event" (
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
   "correlation_id" text NOT NULL,
-  "principal_type" text NOT NULL,
+  "principal_type" text NOT NULL
+    CONSTRAINT "mcp_audit_event_principal_type_check"
+    CHECK ("principal_type" IN ('delegated_user', 'service_account')),
   "principal_id" text NOT NULL,
   "organization_id" text,
   "connection_id" text,

--- a/packages/dal/src/db/schemas/index.ts
+++ b/packages/dal/src/db/schemas/index.ts
@@ -47,6 +47,24 @@ export type {
 } from './linear-job-issue-event/types'
 export { linearOauthState } from './linear-oauth-state/schema'
 export type { LinearOauthState, NewLinearOauthState } from './linear-oauth-state/types'
+export {
+  type McpPrincipalType,
+  mcpAuditEvent,
+  mcpPolicyBinding,
+  mcpPrincipalTypes,
+  mcpServiceAccount,
+  mcpServiceAccountSecret,
+} from './mcp-policy/schema'
+export type {
+  McpAuditEvent,
+  McpPolicyBinding,
+  McpServiceAccount,
+  McpServiceAccountSecret,
+  NewMcpAuditEvent,
+  NewMcpPolicyBinding,
+  NewMcpServiceAccount,
+  NewMcpServiceAccountSecret,
+} from './mcp-policy/types'
 export { oauthAccessToken, oauthApplication, oauthConsent } from './oauth-mcp/schema'
 export type {
   NewOauthAccessToken,

--- a/packages/dal/src/db/schemas/mcp-policy/schema.ts
+++ b/packages/dal/src/db/schemas/mcp-policy/schema.ts
@@ -1,0 +1,101 @@
+import { boolean, index, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
+
+import { baseColumns } from '../common'
+import { oauthApplication } from '../oauth-mcp/schema'
+import { organization } from '../organization/schema'
+import { user } from '../user/schema'
+
+export const mcpPrincipalTypes = ['delegated_user', 'service_account'] as const
+export type McpPrincipalType = (typeof mcpPrincipalTypes)[number]
+
+/**
+ * Machine principal scoped to a single organization.
+ * Optionally links to an OAuth client used by Better Auth token issuance.
+ */
+export const mcpServiceAccount = pgTable(
+  'mcp_service_account',
+  {
+    ...baseColumns,
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    description: text('description'),
+    oauthClientId: text('oauth_client_id').references(() => oauthApplication.clientId, {
+      onDelete: 'set null',
+    }),
+    disabled: boolean('disabled').notNull().default(false),
+  },
+  (table) => [
+    index('mcp_service_account_org_idx').on(table.organizationId),
+    uniqueIndex('mcp_service_account_oauth_client_id_unique').on(table.oauthClientId),
+  ]
+)
+
+/**
+ * Rotatable secrets for service accounts.
+ * Only hashed values are stored; raw tokens are returned once at creation time.
+ */
+export const mcpServiceAccountSecret = pgTable(
+  'mcp_service_account_secret',
+  {
+    ...baseColumns,
+    serviceAccountId: uuid('service_account_id')
+      .notNull()
+      .references(() => mcpServiceAccount.id, { onDelete: 'cascade' }),
+    label: text('label').notNull().default('primary'),
+    secretHash: text('secret_hash').notNull(),
+    secretLastFour: text('secret_last_four').notNull(),
+    createdByUserId: text('created_by_user_id').references(() => user.id, { onDelete: 'set null' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+  },
+  (table) => [index('mcp_service_account_secret_account_idx').on(table.serviceAccountId)]
+)
+
+/**
+ * Explicit policy bindings per principal (delegated user or service account).
+ * toolName null means scope is granted for all tools.
+ */
+export const mcpPolicyBinding = pgTable(
+  'mcp_policy_binding',
+  {
+    ...baseColumns,
+    principalType: text('principal_type').$type<McpPrincipalType>().notNull(),
+    principalId: text('principal_id').notNull(),
+    organizationId: text('organization_id').references(() => organization.id, {
+      onDelete: 'cascade',
+    }),
+    toolName: text('tool_name'),
+    scope: text('scope').notNull(),
+    disabled: boolean('disabled').notNull().default(false),
+  },
+  (table) => [
+    index('mcp_policy_binding_principal_idx').on(table.principalType, table.principalId),
+    index('mcp_policy_binding_org_idx').on(table.organizationId),
+  ]
+)
+
+/**
+ * Policy decision audit trail (written for every MCP tools/call authorization decision).
+ */
+export const mcpAuditEvent = pgTable(
+  'mcp_audit_event',
+  {
+    ...baseColumns,
+    correlationId: text('correlation_id').notNull(),
+    principalType: text('principal_type').$type<McpPrincipalType>().notNull(),
+    principalId: text('principal_id').notNull(),
+    organizationId: text('organization_id'),
+    connectionId: text('connection_id'),
+    toolName: text('tool_name').notNull(),
+    requiredScopes: text('required_scopes').notNull(),
+    granted: boolean('granted').notNull(),
+    denialReason: text('denial_reason'),
+  },
+  (table) => [
+    index('mcp_audit_event_correlation_idx').on(table.correlationId),
+    index('mcp_audit_event_principal_idx').on(table.principalType, table.principalId),
+    index('mcp_audit_event_tool_idx').on(table.toolName),
+  ]
+)

--- a/packages/dal/src/db/schemas/mcp-policy/types.ts
+++ b/packages/dal/src/db/schemas/mcp-policy/types.ts
@@ -1,0 +1,18 @@
+import type {
+  mcpAuditEvent,
+  mcpPolicyBinding,
+  mcpServiceAccount,
+  mcpServiceAccountSecret,
+} from './schema'
+
+export type McpServiceAccount = typeof mcpServiceAccount.$inferSelect
+export type NewMcpServiceAccount = typeof mcpServiceAccount.$inferInsert
+
+export type McpServiceAccountSecret = typeof mcpServiceAccountSecret.$inferSelect
+export type NewMcpServiceAccountSecret = typeof mcpServiceAccountSecret.$inferInsert
+
+export type McpPolicyBinding = typeof mcpPolicyBinding.$inferSelect
+export type NewMcpPolicyBinding = typeof mcpPolicyBinding.$inferInsert
+
+export type McpAuditEvent = typeof mcpAuditEvent.$inferSelect
+export type NewMcpAuditEvent = typeof mcpAuditEvent.$inferInsert

--- a/packages/dal/src/db/schemas/relations.ts
+++ b/packages/dal/src/db/schemas/relations.ts
@@ -62,6 +62,27 @@ export const relations = defineRelations(tables, (r) => ({
       to: r.user.id,
     }),
   },
+  mcpServiceAccount: {
+    organization: r.one.organization({
+      from: r.mcpServiceAccount.organizationId,
+      to: r.organization.id,
+    }),
+    oauthApplication: r.one.oauthApplication({
+      from: r.mcpServiceAccount.oauthClientId,
+      to: r.oauthApplication.clientId,
+    }),
+    secrets: r.many.mcpServiceAccountSecret(),
+  },
+  mcpServiceAccountSecret: {
+    serviceAccount: r.one.mcpServiceAccount({
+      from: r.mcpServiceAccountSecret.serviceAccountId,
+      to: r.mcpServiceAccount.id,
+    }),
+    createdByUser: r.one.user({
+      from: r.mcpServiceAccountSecret.createdByUserId,
+      to: r.user.id,
+    }),
+  },
   organization: {
     members: r.many.member(),
     invitations: r.many.invitation(),
@@ -71,6 +92,7 @@ export const relations = defineRelations(tables, (r) => ({
     linearIntegration: r.one.linearIntegration(),
     linearOauthStates: r.many.linearOauthState(),
     linearJobIssues: r.many.linearJobIssue(),
+    mcpServiceAccounts: r.many.mcpServiceAccount(),
   },
   member: {
     user: r.one.user({

--- a/packages/dal/src/db/schemas/tables.ts
+++ b/packages/dal/src/db/schemas/tables.ts
@@ -14,6 +14,12 @@ export { linearIntegration } from './linear-integration/schema'
 export { linearJobIssue } from './linear-job-issue/schema'
 export { linearJobIssueEvent } from './linear-job-issue-event/schema'
 export { linearOauthState } from './linear-oauth-state/schema'
+export {
+  mcpAuditEvent,
+  mcpPolicyBinding,
+  mcpServiceAccount,
+  mcpServiceAccountSecret,
+} from './mcp-policy/schema'
 export { oauthAccessToken, oauthApplication, oauthConsent } from './oauth-mcp/schema'
 // Organization schema tables
 export { invitation, member, organization } from './organization/schema'

--- a/packages/dal/src/index.ts
+++ b/packages/dal/src/index.ts
@@ -86,6 +86,24 @@ export type {
 export { linearOauthState } from './db/schemas/linear-oauth-state/schema'
 export type { LinearOauthState, NewLinearOauthState } from './db/schemas/linear-oauth-state/types'
 export {
+  type McpPrincipalType,
+  mcpAuditEvent,
+  mcpPolicyBinding,
+  mcpPrincipalTypes,
+  mcpServiceAccount,
+  mcpServiceAccountSecret,
+} from './db/schemas/mcp-policy/schema'
+export type {
+  McpAuditEvent,
+  McpPolicyBinding,
+  McpServiceAccount,
+  McpServiceAccountSecret,
+  NewMcpAuditEvent,
+  NewMcpPolicyBinding,
+  NewMcpServiceAccount,
+  NewMcpServiceAccountSecret,
+} from './db/schemas/mcp-policy/types'
+export {
   oauthAccessToken,
   oauthApplication,
   oauthConsent,
@@ -144,6 +162,7 @@ export { alertRuleRepository } from './repositories/alert-rule'
 export { linearIntegrationRepository } from './repositories/linear-integration'
 export { linearJobIssueRepository } from './repositories/linear-job-issue'
 export { linearOauthStateRepository } from './repositories/linear-oauth-state'
+export { mcpPolicyRepository } from './repositories/mcp-policy'
 // Repositories
 export { redisConnectionRepository } from './repositories/redis-connection'
 export { redisDiscoveredQueueRepository } from './repositories/redis-discovered-queue'

--- a/packages/dal/src/repositories/mcp-policy.test.ts
+++ b/packages/dal/src/repositories/mcp-policy.test.ts
@@ -13,6 +13,7 @@ const mutableEnv = env as {
 }
 
 const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalProcessDatabaseUrl = process.env.DATABASE_URL
 const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
 let tempPgliteDir = ''
 
@@ -28,6 +29,11 @@ describe('mcpPolicyRepository', () => {
   afterEach(async () => {
     await closeDb()
     mutableEnv.DATABASE_URL = originalDatabaseUrl
+    if (originalProcessDatabaseUrl) {
+      process.env.DATABASE_URL = originalProcessDatabaseUrl
+    } else {
+      delete process.env.DATABASE_URL
+    }
 
     if (originalPgliteDir) {
       process.env.DURABULL_PGLITE_DIR = originalPgliteDir

--- a/packages/dal/src/repositories/mcp-policy.test.ts
+++ b/packages/dal/src/repositories/mcp-policy.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { env } from '@durabull/env'
+
+import { closeDb, getDb } from '../db/client'
+import { mcpServiceAccount, organization } from '../db/schemas'
+import { mcpPolicyRepository } from './mcp-policy'
+
+const mutableEnv = env as {
+  DATABASE_URL?: string
+}
+
+const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+let tempPgliteDir = ''
+
+describe('mcpPolicyRepository', () => {
+  beforeEach(async () => {
+    tempPgliteDir = await mkdtemp(join(tmpdir(), 'durabull-mcp-policy-'))
+    process.env.DURABULL_PGLITE_DIR = tempPgliteDir
+    delete process.env.DATABASE_URL
+    mutableEnv.DATABASE_URL = undefined
+    await closeDb()
+  })
+
+  afterEach(async () => {
+    await closeDb()
+    mutableEnv.DATABASE_URL = originalDatabaseUrl
+
+    if (originalPgliteDir) {
+      process.env.DURABULL_PGLITE_DIR = originalPgliteDir
+    } else {
+      delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (tempPgliteDir) {
+      await rm(tempPgliteDir, { recursive: true, force: true })
+      tempPgliteDir = ''
+    }
+  })
+
+  it('issues and verifies hashed service-account secrets', async () => {
+    const db = await getDb()
+    const now = new Date()
+    const orgId = 'mcp-policy-org'
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'MCP Policy Org',
+      slug: 'mcp-policy-org',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const [serviceAccount] = await db
+      .insert(mcpServiceAccount)
+      .values({
+        organizationId: orgId,
+        name: 'automation-sa',
+        disabled: false,
+      })
+      .returning()
+
+    const { secret, record } = await mcpPolicyRepository.issueServiceAccountSecret(serviceAccount.id, {
+      label: 'initial',
+    })
+
+    expect(secret.startsWith('dbsa_')).toBe(true)
+    expect(record.secretHash.includes(secret)).toBe(false)
+    expect(await mcpPolicyRepository.verifyServiceAccountSecret(serviceAccount.id, secret)).toBe(true)
+    expect(await mcpPolicyRepository.verifyServiceAccountSecret(serviceAccount.id, 'dbsa_invalid')).toBe(
+      false
+    )
+  })
+
+  it('rotates service-account secrets and revokes previous active ones', async () => {
+    const db = await getDb()
+    const now = new Date()
+    const orgId = 'mcp-policy-org-rotate'
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'MCP Policy Org Rotate',
+      slug: 'mcp-policy-org-rotate',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const [serviceAccount] = await db
+      .insert(mcpServiceAccount)
+      .values({
+        organizationId: orgId,
+        name: 'rotation-sa',
+        disabled: false,
+      })
+      .returning()
+
+    const initial = await mcpPolicyRepository.issueServiceAccountSecret(serviceAccount.id, {
+      label: 'initial',
+    })
+    const rotated = await mcpPolicyRepository.rotateServiceAccountSecret(serviceAccount.id, {
+      label: 'rotated',
+    })
+
+    expect(await mcpPolicyRepository.verifyServiceAccountSecret(serviceAccount.id, initial.secret)).toBe(
+      false
+    )
+    expect(await mcpPolicyRepository.verifyServiceAccountSecret(serviceAccount.id, rotated.secret)).toBe(
+      true
+    )
+  })
+})

--- a/packages/dal/src/repositories/mcp-policy.ts
+++ b/packages/dal/src/repositories/mcp-policy.ts
@@ -1,4 +1,5 @@
-import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto'
+import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto'
+import { promisify } from 'node:util'
 import { uuidv7 } from '@durabull/utils/uuid'
 import { and, eq, gt, isNull, or } from 'drizzle-orm'
 
@@ -15,18 +16,21 @@ import { member } from '../db/schemas/organization/schema'
 import { redisConnection } from '../db/schemas/redis-connection/schema'
 
 const MCP_SECRET_PREFIX = 'dbsa'
+const scryptAsync = promisify(scrypt)
 
-function hashSecret(secret: string): string {
+async function hashSecret(secret: string): Promise<string> {
   const salt = randomBytes(16).toString('hex')
-  const digest = scryptSync(secret, salt, 64).toString('hex')
+  const digestBuffer = (await scryptAsync(secret, salt, 64)) as Buffer
+  const digest = digestBuffer.toString('hex')
   return `scrypt:${salt}:${digest}`
 }
 
-function verifySecretHash(secret: string, storedHash: string): boolean {
+async function verifySecretHash(secret: string, storedHash: string): Promise<boolean> {
   const [algo, salt, expectedDigest] = storedHash.split(':')
   if (algo !== 'scrypt' || !salt || !expectedDigest) return false
 
-  const actualDigest = scryptSync(secret, salt, 64).toString('hex')
+  const digestBuffer = (await scryptAsync(secret, salt, 64)) as Buffer
+  const actualDigest = digestBuffer.toString('hex')
   if (actualDigest.length !== expectedDigest.length) {
     return false
   }
@@ -97,7 +101,7 @@ export const mcpPolicyRepository = {
         updatedAt: now,
         serviceAccountId,
         label: opts?.label ?? 'primary',
-        secretHash: hashSecret(secret),
+        secretHash: await hashSecret(secret),
         secretLastFour: secret.slice(-4),
         createdByUserId: opts?.createdByUserId ?? null,
         expiresAt: opts?.expiresAt ?? null,
@@ -111,22 +115,37 @@ export const mcpPolicyRepository = {
   async rotateServiceAccountSecret(serviceAccountId: string, opts?: { createdByUserId?: string | null; label?: string | null; revokeActiveSecrets?: boolean }) {
     const db = await getDb()
     const now = new Date()
-
-    if (opts?.revokeActiveSecrets ?? true) {
-      await db
-        .update(mcpServiceAccountSecret)
-        .set({ revokedAt: now, updatedAt: now })
-        .where(
-          and(
-            eq(mcpServiceAccountSecret.serviceAccountId, serviceAccountId),
-            isNull(mcpServiceAccountSecret.revokedAt)
+    return db.transaction(async (tx) => {
+      if (opts?.revokeActiveSecrets ?? true) {
+        await tx
+          .update(mcpServiceAccountSecret)
+          .set({ revokedAt: now, updatedAt: now })
+          .where(
+            and(
+              eq(mcpServiceAccountSecret.serviceAccountId, serviceAccountId),
+              isNull(mcpServiceAccountSecret.revokedAt)
+            )
           )
-        )
-    }
+      }
 
-    return this.issueServiceAccountSecret(serviceAccountId, {
-      createdByUserId: opts?.createdByUserId,
-      label: opts?.label ?? 'rotated',
+      const secret = generateServiceAccountSecret()
+      const [record] = await tx
+        .insert(mcpServiceAccountSecret)
+        .values({
+          id: uuidv7(),
+          createdAt: now,
+          updatedAt: now,
+          serviceAccountId,
+          label: opts?.label ?? 'rotated',
+          secretHash: await hashSecret(secret),
+          secretLastFour: secret.slice(-4),
+          createdByUserId: opts?.createdByUserId ?? null,
+          expiresAt: null,
+          revokedAt: null,
+        })
+        .returning()
+
+      return { secret, record }
     })
   },
 
@@ -146,7 +165,12 @@ export const mcpPolicyRepository = {
         )
       )
 
-    return rows.some((row) => verifySecretHash(secret, row.secretHash))
+    for (const row of rows) {
+      if (await verifySecretHash(secret, row.secretHash)) {
+        return true
+      }
+    }
+    return false
   },
 
   async createPolicyBinding(input: CreateMcpPolicyBindingInput) {

--- a/packages/dal/src/repositories/mcp-policy.ts
+++ b/packages/dal/src/repositories/mcp-policy.ts
@@ -1,9 +1,13 @@
 import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto'
 import { promisify } from 'node:util'
 import { uuidv7 } from '@durabull/utils/uuid'
-import { and, eq, gt, isNull, or } from 'drizzle-orm'
+import { and, eq, gt, inArray, isNull, or } from 'drizzle-orm'
 
 import { getDb } from '../db/client'
+import {
+  getEnvRedisConnectionIdsForOrganization,
+  shouldUseEnvConnections,
+} from '../db/env-redis-connections'
 import {
   type McpPrincipalType,
   mcpAuditEvent,
@@ -84,6 +88,16 @@ export const mcpPolicyRepository = {
       .select()
       .from(mcpServiceAccount)
       .where(and(eq(mcpServiceAccount.oauthClientId, oauthClientId), eq(mcpServiceAccount.disabled, false)))
+      .limit(1)
+    return rows[0] ?? null
+  },
+
+  async findServiceAccountByOauthClientIdIncludingDisabled(oauthClientId: string) {
+    const db = await getDb()
+    const rows = await db
+      .select()
+      .from(mcpServiceAccount)
+      .where(eq(mcpServiceAccount.oauthClientId, oauthClientId))
       .limit(1)
     return rows[0] ?? null
   },
@@ -249,10 +263,24 @@ export const mcpPolicyRepository = {
 
   async doesConnectionBelongToOrganization(connectionId: string, organizationId: string): Promise<boolean> {
     const db = await getDb()
+    const envConnectionIds = shouldUseEnvConnections()
+      ? getEnvRedisConnectionIdsForOrganization(organizationId)
+      : null
+
+    if (envConnectionIds && !envConnectionIds.includes(connectionId)) {
+      return false
+    }
+
     const rows = await db
       .select({ id: redisConnection.id })
       .from(redisConnection)
-      .where(and(eq(redisConnection.id, connectionId), eq(redisConnection.organizationId, organizationId)))
+      .where(
+        and(
+          eq(redisConnection.id, connectionId),
+          eq(redisConnection.organizationId, organizationId),
+          ...(envConnectionIds ? [inArray(redisConnection.id, envConnectionIds)] : [])
+        )
+      )
       .limit(1)
     return rows.length > 0
   },

--- a/packages/dal/src/repositories/mcp-policy.ts
+++ b/packages/dal/src/repositories/mcp-policy.ts
@@ -1,0 +1,268 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto'
+import { uuidv7 } from '@durabull/utils/uuid'
+import { and, eq, gt, isNull, or } from 'drizzle-orm'
+
+import { getDb } from '../db/client'
+import {
+  type McpPrincipalType,
+  mcpAuditEvent,
+  mcpPolicyBinding,
+  mcpServiceAccount,
+  mcpServiceAccountSecret,
+} from '../db/schemas/mcp-policy/schema'
+import type { NewMcpPolicyBinding } from '../db/schemas/mcp-policy/types'
+import { member } from '../db/schemas/organization/schema'
+import { redisConnection } from '../db/schemas/redis-connection/schema'
+
+const MCP_SECRET_PREFIX = 'dbsa'
+
+function hashSecret(secret: string): string {
+  const salt = randomBytes(16).toString('hex')
+  const digest = scryptSync(secret, salt, 64).toString('hex')
+  return `scrypt:${salt}:${digest}`
+}
+
+function verifySecretHash(secret: string, storedHash: string): boolean {
+  const [algo, salt, expectedDigest] = storedHash.split(':')
+  if (algo !== 'scrypt' || !salt || !expectedDigest) return false
+
+  const actualDigest = scryptSync(secret, salt, 64).toString('hex')
+  if (actualDigest.length !== expectedDigest.length) {
+    return false
+  }
+  return timingSafeEqual(Buffer.from(actualDigest, 'utf8'), Buffer.from(expectedDigest, 'utf8'))
+}
+
+function generateServiceAccountSecret(): string {
+  return `${MCP_SECRET_PREFIX}_${randomBytes(24).toString('base64url')}`
+}
+
+export interface CreateMcpServiceAccountInput {
+  organizationId: string
+  name: string
+  description?: string | null
+  oauthClientId?: string | null
+}
+
+export interface CreateMcpPolicyBindingInput {
+  principalType: McpPrincipalType
+  principalId: string
+  organizationId?: string | null
+  toolName?: string | null
+  scope: string
+}
+
+export const mcpPolicyRepository = {
+  async createServiceAccount(input: CreateMcpServiceAccountInput) {
+    const db = await getDb()
+    const now = new Date()
+
+    const [record] = await db
+      .insert(mcpServiceAccount)
+      .values({
+        id: uuidv7(),
+        createdAt: now,
+        updatedAt: now,
+        organizationId: input.organizationId,
+        name: input.name,
+        description: input.description ?? null,
+        oauthClientId: input.oauthClientId ?? null,
+        disabled: false,
+      })
+      .returning()
+
+    return record
+  },
+
+  async findServiceAccountByOauthClientId(oauthClientId: string) {
+    const db = await getDb()
+    const rows = await db
+      .select()
+      .from(mcpServiceAccount)
+      .where(and(eq(mcpServiceAccount.oauthClientId, oauthClientId), eq(mcpServiceAccount.disabled, false)))
+      .limit(1)
+    return rows[0] ?? null
+  },
+
+  async issueServiceAccountSecret(serviceAccountId: string, opts?: { createdByUserId?: string | null; label?: string | null; expiresAt?: Date | null }) {
+    const db = await getDb()
+    const secret = generateServiceAccountSecret()
+    const now = new Date()
+
+    const [record] = await db
+      .insert(mcpServiceAccountSecret)
+      .values({
+        id: uuidv7(),
+        createdAt: now,
+        updatedAt: now,
+        serviceAccountId,
+        label: opts?.label ?? 'primary',
+        secretHash: hashSecret(secret),
+        secretLastFour: secret.slice(-4),
+        createdByUserId: opts?.createdByUserId ?? null,
+        expiresAt: opts?.expiresAt ?? null,
+        revokedAt: null,
+      })
+      .returning()
+
+    return { secret, record }
+  },
+
+  async rotateServiceAccountSecret(serviceAccountId: string, opts?: { createdByUserId?: string | null; label?: string | null; revokeActiveSecrets?: boolean }) {
+    const db = await getDb()
+    const now = new Date()
+
+    if (opts?.revokeActiveSecrets ?? true) {
+      await db
+        .update(mcpServiceAccountSecret)
+        .set({ revokedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(mcpServiceAccountSecret.serviceAccountId, serviceAccountId),
+            isNull(mcpServiceAccountSecret.revokedAt)
+          )
+        )
+    }
+
+    return this.issueServiceAccountSecret(serviceAccountId, {
+      createdByUserId: opts?.createdByUserId,
+      label: opts?.label ?? 'rotated',
+    })
+  },
+
+  async verifyServiceAccountSecret(serviceAccountId: string, secret: string): Promise<boolean> {
+    const db = await getDb()
+    const now = new Date()
+    const rows = await db
+      .select({
+        secretHash: mcpServiceAccountSecret.secretHash,
+      })
+      .from(mcpServiceAccountSecret)
+      .where(
+        and(
+          eq(mcpServiceAccountSecret.serviceAccountId, serviceAccountId),
+          isNull(mcpServiceAccountSecret.revokedAt),
+          or(isNull(mcpServiceAccountSecret.expiresAt), gt(mcpServiceAccountSecret.expiresAt, now))
+        )
+      )
+
+    return rows.some((row) => verifySecretHash(secret, row.secretHash))
+  },
+
+  async createPolicyBinding(input: CreateMcpPolicyBindingInput) {
+    const db = await getDb()
+    const now = new Date()
+    const values: NewMcpPolicyBinding = {
+      id: uuidv7(),
+      createdAt: now,
+      updatedAt: now,
+      principalType: input.principalType,
+      principalId: input.principalId,
+      organizationId: input.organizationId ?? null,
+      toolName: input.toolName ?? null,
+      scope: input.scope,
+      disabled: false,
+    }
+    const [record] = await db.insert(mcpPolicyBinding).values(values).returning()
+    return record
+  },
+
+  async listPolicyBindings(principalType: McpPrincipalType, principalId: string) {
+    const db = await getDb()
+    return db
+      .select()
+      .from(mcpPolicyBinding)
+      .where(
+        and(
+          eq(mcpPolicyBinding.principalType, principalType),
+          eq(mcpPolicyBinding.principalId, principalId),
+          eq(mcpPolicyBinding.disabled, false)
+        )
+      )
+  },
+
+  async canDelegatedUserAccessConnection(userId: string, connectionId: string): Promise<boolean> {
+    const db = await getDb()
+    const rows = await db
+      .select({ id: redisConnection.id })
+      .from(redisConnection)
+      .innerJoin(
+        member,
+        and(eq(member.organizationId, redisConnection.organizationId), eq(member.userId, userId))
+      )
+      .where(eq(redisConnection.id, connectionId))
+      .limit(1)
+    return rows.length > 0
+  },
+
+  async listDelegatedUserConnections(userId: string): Promise<
+    Array<{
+      id: string
+      name: string
+      environment: string | null
+      prefix: string
+      isDefault: boolean
+      organizationId: string
+    }>
+  > {
+    const db = await getDb()
+    const rows = await db
+      .select({
+        id: redisConnection.id,
+        name: redisConnection.name,
+        environment: redisConnection.environment,
+        prefix: redisConnection.prefix,
+        isDefault: redisConnection.isDefault,
+        organizationId: redisConnection.organizationId,
+      })
+      .from(redisConnection)
+      .innerJoin(
+        member,
+        and(eq(member.organizationId, redisConnection.organizationId), eq(member.userId, userId))
+      )
+    return rows
+  },
+
+  async doesConnectionBelongToOrganization(connectionId: string, organizationId: string): Promise<boolean> {
+    const db = await getDb()
+    const rows = await db
+      .select({ id: redisConnection.id })
+      .from(redisConnection)
+      .where(and(eq(redisConnection.id, connectionId), eq(redisConnection.organizationId, organizationId)))
+      .limit(1)
+    return rows.length > 0
+  },
+
+  async createAuditEvent(input: {
+    correlationId: string
+    principalType: McpPrincipalType
+    principalId: string
+    organizationId?: string | null
+    connectionId?: string | null
+    toolName: string
+    requiredScopes: string[]
+    granted: boolean
+    denialReason?: string | null
+  }) {
+    const db = await getDb()
+    const now = new Date()
+    const [record] = await db
+      .insert(mcpAuditEvent)
+      .values({
+        id: uuidv7(),
+        createdAt: now,
+        updatedAt: now,
+        correlationId: input.correlationId,
+        principalType: input.principalType,
+        principalId: input.principalId,
+        organizationId: input.organizationId ?? null,
+        connectionId: input.connectionId ?? null,
+        toolName: input.toolName,
+        requiredScopes: input.requiredScopes.join(' '),
+        granted: input.granted,
+        denialReason: input.denialReason ?? null,
+      })
+      .returning()
+    return record
+  },
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "@hono/mcp": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "hono": "^4.6.14"
+    "hono": "^4.6.14",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,8 +12,26 @@ export {
   MCP_SERVER_NAME,
 } from './constants'
 export { createMcpRoutes, type CreateMcpRoutesOptions } from './routes'
+export type { McpRequestContext, McpRequestPrincipal } from './request-context'
 export {
   getCanonicalMcpResourceUri,
   getMcpProtectedResourceMetadataUrl,
   MCP_TRANSPORT_REQUIRED_SCOPES,
 } from './auth'
+export type {
+  GetJobHandlerInput,
+  GetJobHandlerOutput,
+  GetJobLogsHandlerInput,
+  GetJobLogsHandlerOutput,
+  GetJobStacktracesHandlerInput,
+  GetJobStacktracesHandlerOutput,
+  GetQueueHandlerInput,
+  GetQueueHandlerOutput,
+  ListConnectionsHandlerInput,
+  ListConnectionsHandlerOutput,
+  ListJobsHandlerInput,
+  ListJobsHandlerOutput,
+  ListQueuesHandlerInput,
+  ListQueuesHandlerOutput,
+  RegisterReadToolsOptions,
+} from './tools/register-read-tools'

--- a/packages/mcp/src/request-context.ts
+++ b/packages/mcp/src/request-context.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+export interface McpRequestPrincipal {
+  type: 'delegated_user' | 'service_account'
+  principalId: string
+  userId?: string
+  organizationId?: string
+}
+
+export interface McpRequestContext {
+  principal?: McpRequestPrincipal
+  correlationId?: string
+}
+
+const store = new AsyncLocalStorage<McpRequestContext>()
+
+export function runWithMcpRequestContext<T>(
+  context: McpRequestContext | undefined,
+  fn: () => Promise<T> | T
+): Promise<T> | T {
+  if (!context) {
+    return fn()
+  }
+  return store.run(context, fn)
+}
+
+export function getMcpRequestContext(): McpRequestContext | undefined {
+  return store.getStore()
+}

--- a/packages/mcp/src/routes.test.ts
+++ b/packages/mcp/src/routes.test.ts
@@ -205,4 +205,92 @@ describe('createMcpRoutes', () => {
     }
     expect(callPayload.result?.content?.[0]?.text).toBe('pong')
   })
+
+  it('returns isError envelope for typed tool not_found errors', async () => {
+    class NotFoundToolError extends Error {
+      readonly code = 'not_found'
+    }
+
+    const appWithReadTool = createMcpRoutes({
+      version: 'test',
+      allowedHosts: new Set(['localhost', '127.0.0.1', 'localhost:3000']),
+      corsOrigins: ['http://localhost:3000'],
+      middleware: [createTestAuthMiddleware()],
+      requestContextResolver: () => ({
+        principal: {
+          type: 'delegated_user',
+          principalId: 'principal-test',
+          userId: 'user',
+        },
+        correlationId: 'corr-test',
+      }),
+      readTools: {
+        listConnections: async () => {
+          throw new NotFoundToolError('Connection missing for test')
+        },
+      },
+    })
+
+    const postMcpReadTool = (
+      body: Parameters<typeof postMcpJson>[2],
+      options?: Parameters<typeof postMcpJson>[3]
+    ) =>
+      postMcpJson((path, init) => Promise.resolve(appWithReadTool.request(path, init)), '/', body, {
+        authorization: validAuthorization,
+        ...options,
+      })
+
+    const initResponse = await postMcpReadTool({
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+    })
+
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    await postMcpReadTool(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        method: 'notifications/initialized',
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    const callResponse = await postMcpReadTool(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'list_connections',
+          arguments: {
+            pageSize: 10,
+          },
+        },
+      },
+      { sessionId: sessionId ?? undefined }
+    )
+
+    expect(callResponse.status).toBe(200)
+    const payload = (await readMcpJsonResponse(callResponse)) as {
+      result?: {
+        isError?: boolean
+        structuredContent?: {
+          error?: {
+            code?: string
+            message?: string
+          }
+        }
+      }
+    }
+    expect(payload.result?.isError).toBe(true)
+    expect(payload.result?.structuredContent?.error?.code).toBe('not_found')
+    expect(payload.result?.structuredContent?.error?.message).toContain('Connection missing for test')
+  })
 })

--- a/packages/mcp/src/routes.ts
+++ b/packages/mcp/src/routes.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { cors } from 'hono/cors'
 import type { MiddlewareHandler } from 'hono'
+import type { McpRequestContext } from './request-context'
 
 import { createHostValidationMiddleware } from './middleware/host-validation'
+import type { RegisterReadToolsOptions } from './tools/register-read-tools'
 import { createMcpSessionRegistry } from './transport/session-registry'
 
 export interface CreateMcpRoutesOptions {
@@ -18,6 +21,9 @@ export interface CreateMcpRoutesOptions {
    * PR-03: bearer token validation goes here.
    */
   middleware?: MiddlewareHandler[]
+  readTools?: RegisterReadToolsOptions
+  /** Optional request-scoped context resolver used by MCP tool handlers. */
+  requestContextResolver?: (context: Context) => McpRequestContext | undefined
   /** When false, only exact host entries match (recommended for production). */
   allowHostnameWithoutPort?: boolean
 }
@@ -26,6 +32,7 @@ export function createMcpRoutes(options: CreateMcpRoutesOptions): Hono {
   const registry = createMcpSessionRegistry({
     version: options.version,
     allowedHosts: options.allowedHosts,
+    serverOptions: { readTools: options.readTools },
   })
 
   const routes = new Hono()
@@ -68,7 +75,7 @@ export function createMcpRoutes(options: CreateMcpRoutesOptions): Hono {
   )
 
   // GET / POST / DELETE delegated to Streamable HTTP transport (@hono/mcp).
-  routes.all('/', async (c) => registry.handleRequest(c))
+  routes.all('/', async (c) => registry.handleRequest(c, options.requestContextResolver?.(c)))
 
   return routes
 }

--- a/packages/mcp/src/routes.ts
+++ b/packages/mcp/src/routes.ts
@@ -17,7 +17,7 @@ export interface CreateMcpRoutesOptions {
   /** CORS origins for /mcp. */
   corsOrigins: string[]
   /**
-   * Middleware applied after host validation and before body limit.
+   * Middleware applied after host validation and body limit.
    * PR-03: bearer token validation goes here.
    */
   middleware?: MiddlewareHandler[]
@@ -61,10 +61,6 @@ export function createMcpRoutes(options: CreateMcpRoutesOptions): Hono {
     })
   )
 
-  for (const middleware of options.middleware ?? []) {
-    routes.use('*', middleware)
-  }
-
   routes.use(
     '*',
     bodyLimit({
@@ -73,6 +69,10 @@ export function createMcpRoutes(options: CreateMcpRoutesOptions): Hono {
         c.json({ error: 'Payload Too Large', message: 'Request body exceeds 1MB limit' }, 413),
     })
   )
+
+  for (const middleware of options.middleware ?? []) {
+    routes.use('*', middleware)
+  }
 
   // GET / POST / DELETE delegated to Streamable HTTP transport (@hono/mcp).
   routes.all('/', async (c) => registry.handleRequest(c, options.requestContextResolver?.(c)))

--- a/packages/mcp/src/server/create-mcp-server.ts
+++ b/packages/mcp/src/server/create-mcp-server.ts
@@ -1,19 +1,22 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 import { MCP_SERVER_NAME } from '../constants'
+import { type RegisterReadToolsOptions, registerReadTools } from '../tools/register-read-tools'
 import { registerSmokeTools } from '../tools/register-smoke-tools'
 
 export interface CreateMcpServerOptions {
   version: string
+  readTools?: RegisterReadToolsOptions
 }
 
-export function createMcpServer({ version }: CreateMcpServerOptions): McpServer {
+export function createMcpServer({ version, readTools }: CreateMcpServerOptions): McpServer {
   const server = new McpServer({
     name: MCP_SERVER_NAME,
     version,
   })
 
   registerSmokeTools(server)
+  registerReadTools(server, readTools ?? {})
 
   return server
 }

--- a/packages/mcp/src/tools/register-read-tools.ts
+++ b/packages/mcp/src/tools/register-read-tools.ts
@@ -218,6 +218,57 @@ function parseCursor(raw: unknown): string | undefined {
   return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : undefined
 }
 
+type ToolPrincipal = ListConnectionsHandlerInput['principal']
+
+function getPrincipalFromContext(): ToolPrincipal {
+  const requestContext = getMcpRequestContext()
+  const principal = requestContext?.principal
+  if (!principal) {
+    throw new Error('MCP principal context is unavailable for this request.')
+  }
+  if (principal.type === 'delegated_user' && !principal.userId) {
+    throw new Error('Delegated principal is missing user id.')
+  }
+  if (principal.type === 'service_account' && !principal.organizationId) {
+    throw new Error('Service account principal is missing organization id.')
+  }
+  return principal.type === 'delegated_user'
+    ? {
+        type: 'delegated_user',
+        principalId: principal.principalId,
+        userId: principal.userId!,
+      }
+    : {
+        type: 'service_account',
+        principalId: principal.principalId,
+        organizationId: principal.organizationId!,
+      }
+}
+
+function toToolError(error: unknown): { code: string; message: string } {
+  const INTERNAL_ERROR_MESSAGE = 'Tool invocation failed.'
+  const KNOWN_CODES = new Set(['not_found', 'validation_error', 'forbidden'])
+
+  if (
+    typeof error === 'object' &&
+    error != null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string'
+  ) {
+    const code = (error as { code: string }).code
+    return {
+      code: KNOWN_CODES.has(code) ? code : 'internal_error',
+      message:
+        KNOWN_CODES.has(code) && error instanceof Error ? error.message : INTERNAL_ERROR_MESSAGE,
+    }
+  }
+
+  return {
+    code: 'internal_error',
+    message: INTERNAL_ERROR_MESSAGE,
+  }
+}
+
 export function registerReadTools(server: McpServer, options: RegisterReadToolsOptions): void {
   const listConnections = options.listConnections
   if (listConnections) {
@@ -230,47 +281,23 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
       'list_connections',
       listConnectionsSchema,
       async (args) => {
-        const requestContext = getMcpRequestContext()
-        const principal = requestContext?.principal
-        if (!principal) {
-          throw new Error('MCP principal context is unavailable for this request.')
-        }
-
-        if (principal.type === 'delegated_user' && !principal.userId) {
-          throw new Error('Delegated principal is missing user id.')
-        }
-        if (principal.type === 'service_account' && !principal.organizationId) {
-          throw new Error('Service account principal is missing organization id.')
-        }
-
-        const pageSize = parsePageSize(args.pageSize)
-        const cursor = parseCursor(args.cursor)
-
-        const result = await listConnections({
-          principal:
-            principal.type === 'delegated_user'
-              ? {
-                  type: 'delegated_user',
-                  principalId: principal.principalId,
-                  userId: principal.userId!,
-                }
-              : {
-                  type: 'service_account',
-                  principalId: principal.principalId,
-                  organizationId: principal.organizationId!,
-                },
-          cursor,
-          pageSize,
-        })
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result),
-            },
-          ],
-          structuredContent: result,
+        try {
+          const result = await listConnections({
+            principal: getPrincipalFromContext(),
+            cursor: parseCursor(args.cursor),
+            pageSize: parsePageSize(args.pageSize),
+          })
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const toolError = toToolError(error)
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
+            structuredContent: { error: toolError },
+          }
         }
       }
     )
@@ -286,33 +313,24 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         pageSize: z.number().int().min(1).max(100).optional(),
       },
       async (args) => {
-        const requestContext = getMcpRequestContext()
-        const principal = requestContext?.principal
-        if (!principal) {
-          throw new Error('MCP principal context is unavailable for this request.')
-        }
-
-        const result = await listQueues({
-          principal:
-            principal.type === 'delegated_user'
-              ? {
-                  type: 'delegated_user',
-                  principalId: principal.principalId,
-                  userId: principal.userId!,
-                }
-              : {
-                  type: 'service_account',
-                  principalId: principal.principalId,
-                  organizationId: principal.organizationId!,
-                },
-          connectionId: args.connectionId,
-          cursor: parseCursor(args.cursor),
-          pageSize: parsePageSize(args.pageSize),
-        })
-
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-          structuredContent: result,
+        try {
+          const result = await listQueues({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            cursor: parseCursor(args.cursor),
+            pageSize: parsePageSize(args.pageSize),
+          })
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const toolError = toToolError(error)
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
+            structuredContent: { error: toolError },
+          }
         }
       }
     )
@@ -327,32 +345,23 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         queueName: z.string().min(1),
       },
       async (args) => {
-        const requestContext = getMcpRequestContext()
-        const principal = requestContext?.principal
-        if (!principal) {
-          throw new Error('MCP principal context is unavailable for this request.')
-        }
-
-        const result = await getQueue({
-          principal:
-            principal.type === 'delegated_user'
-              ? {
-                  type: 'delegated_user',
-                  principalId: principal.principalId,
-                  userId: principal.userId!,
-                }
-              : {
-                  type: 'service_account',
-                  principalId: principal.principalId,
-                  organizationId: principal.organizationId!,
-                },
-          connectionId: args.connectionId,
-          queueName: args.queueName,
-        })
-
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-          structuredContent: result,
+        try {
+          const result = await getQueue({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+          })
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const toolError = toToolError(error)
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
+            structuredContent: { error: toolError },
+          }
         }
       }
     )
@@ -372,37 +381,28 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         pageSize: z.number().int().min(1).max(100).optional(),
       },
       async (args) => {
-        const requestContext = getMcpRequestContext()
-        const principal = requestContext?.principal
-        if (!principal) {
-          throw new Error('MCP principal context is unavailable for this request.')
-        }
-
-        const result = await listJobs({
-          principal:
-            principal.type === 'delegated_user'
-              ? {
-                  type: 'delegated_user',
-                  principalId: principal.principalId,
-                  userId: principal.userId!,
-                }
-              : {
-                  type: 'service_account',
-                  principalId: principal.principalId,
-                  organizationId: principal.organizationId!,
-                },
-          connectionId: args.connectionId,
-          queueName: args.queueName,
-          status: args.status,
-          name: args.name,
-          jobId: args.jobId,
-          cursor: parseCursor(args.cursor),
-          pageSize: parsePageSize(args.pageSize),
-        })
-
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-          structuredContent: result,
+        try {
+          const result = await listJobs({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            status: args.status,
+            name: args.name,
+            jobId: args.jobId,
+            cursor: parseCursor(args.cursor),
+            pageSize: parsePageSize(args.pageSize),
+          })
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const toolError = toToolError(error)
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
+            structuredContent: { error: toolError },
+          }
         }
       }
     )
@@ -418,33 +418,24 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         jobId: z.string().min(1),
       },
       async (args) => {
-        const requestContext = getMcpRequestContext()
-        const principal = requestContext?.principal
-        if (!principal) {
-          throw new Error('MCP principal context is unavailable for this request.')
-        }
-
-        const result = await getJob({
-          principal:
-            principal.type === 'delegated_user'
-              ? {
-                  type: 'delegated_user',
-                  principalId: principal.principalId,
-                  userId: principal.userId!,
-                }
-              : {
-                  type: 'service_account',
-                  principalId: principal.principalId,
-                  organizationId: principal.organizationId!,
-                },
-          connectionId: args.connectionId,
-          queueName: args.queueName,
-          jobId: args.jobId,
-        })
-
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-          structuredContent: result,
+        try {
+          const result = await getJob({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            jobId: args.jobId,
+          })
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const toolError = toToolError(error)
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
+            structuredContent: { error: toolError },
+          }
         }
       }
     )
@@ -462,35 +453,26 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         pageSize: z.number().int().min(1).max(100).optional(),
       },
       async (args) => {
-        const requestContext = getMcpRequestContext()
-        const principal = requestContext?.principal
-        if (!principal) {
-          throw new Error('MCP principal context is unavailable for this request.')
-        }
-
-        const result = await getJobLogs({
-          principal:
-            principal.type === 'delegated_user'
-              ? {
-                  type: 'delegated_user',
-                  principalId: principal.principalId,
-                  userId: principal.userId!,
-                }
-              : {
-                  type: 'service_account',
-                  principalId: principal.principalId,
-                  organizationId: principal.organizationId!,
-                },
-          connectionId: args.connectionId,
-          queueName: args.queueName,
-          jobId: args.jobId,
-          cursor: parseCursor(args.cursor),
-          pageSize: parsePageSize(args.pageSize),
-        })
-
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-          structuredContent: result,
+        try {
+          const result = await getJobLogs({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            jobId: args.jobId,
+            cursor: parseCursor(args.cursor),
+            pageSize: parsePageSize(args.pageSize),
+          })
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const toolError = toToolError(error)
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
+            structuredContent: { error: toolError },
+          }
         }
       }
     )
@@ -508,35 +490,26 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         pageSize: z.number().int().min(1).max(100).optional(),
       },
       async (args) => {
-        const requestContext = getMcpRequestContext()
-        const principal = requestContext?.principal
-        if (!principal) {
-          throw new Error('MCP principal context is unavailable for this request.')
-        }
-
-        const result = await getJobStacktraces({
-          principal:
-            principal.type === 'delegated_user'
-              ? {
-                  type: 'delegated_user',
-                  principalId: principal.principalId,
-                  userId: principal.userId!,
-                }
-              : {
-                  type: 'service_account',
-                  principalId: principal.principalId,
-                  organizationId: principal.organizationId!,
-                },
-          connectionId: args.connectionId,
-          queueName: args.queueName,
-          jobId: args.jobId,
-          cursor: parseCursor(args.cursor),
-          pageSize: parsePageSize(args.pageSize),
-        })
-
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-          structuredContent: result,
+        try {
+          const result = await getJobStacktraces({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            jobId: args.jobId,
+            cursor: parseCursor(args.cursor),
+            pageSize: parsePageSize(args.pageSize),
+          })
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const toolError = toToolError(error)
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
+            structuredContent: { error: toolError },
+          }
         }
       }
     )

--- a/packages/mcp/src/tools/register-read-tools.ts
+++ b/packages/mcp/src/tools/register-read-tools.ts
@@ -1,0 +1,544 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+
+import { getMcpRequestContext } from '../request-context'
+
+export interface ListConnectionsHandlerInput {
+  principal:
+    | {
+        type: 'delegated_user'
+        principalId: string
+        userId: string
+      }
+    | {
+        type: 'service_account'
+        principalId: string
+        organizationId: string
+      }
+  cursor?: string
+  pageSize: number
+}
+
+export interface ListConnectionsHandlerOutput {
+  [key: string]: unknown
+  connections: Array<{
+    id: string
+    name: string
+    environment: string | null
+    prefix: string
+    isDefault: boolean
+    organizationId: string
+  }>
+  nextCursor: string | null
+}
+
+export interface ListQueuesHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  cursor?: string
+  pageSize: number
+}
+
+export interface ListQueuesHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  total: number
+  queues: Array<{
+    name: string
+    status: 'paused' | 'active'
+    isPaused: boolean
+    discoveryState: string
+    jobCounts: {
+      waiting: number
+      active: number
+      delayed: number
+      completed: number
+      failed: number
+      paused: number
+      prioritized: number
+    }
+  }>
+  nextCursor: string | null
+}
+
+export interface GetQueueHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName: string
+}
+
+export interface GetQueueHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  name: string
+  status: 'paused' | 'active'
+  isPaused: boolean
+  scheduledJobsCount: number
+  jobCounts: {
+    waiting: number
+    active: number
+    delayed: number
+    completed: number
+    failed: number
+    paused: number
+    prioritized: number
+  }
+  workers: Array<{
+    id: string
+    name: string
+    address: string
+    ageMs: number
+    idleMs: number
+  }>
+}
+
+export interface ListJobsHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName: string
+  status?: string
+  name?: string
+  jobId?: string
+  cursor?: string
+  pageSize: number
+}
+
+export interface ListJobsHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  queueName: string
+  total: number
+  jobs: Array<{
+    id: string
+    name: string
+    status: string
+    attemptsMade: number
+    maxAttempts: number
+    failedReason: string | null
+    processedOn: number | null
+    finishedOn: number | null
+    timestamp: number | null
+    delay: number
+    priority: number
+  }>
+  nextCursor: string | null
+}
+
+export interface GetJobHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName: string
+  jobId: string
+}
+
+export interface GetJobHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  queueName: string
+  job: {
+    id: string
+    name: string
+    status: string
+    data: Record<string, unknown>
+    progress: unknown
+    attemptsMade: number
+    maxAttempts: number
+    failedReason: string | null
+    processedOn: number | null
+    finishedOn: number | null
+    timestamp: number | null
+    delay: number
+    priority: number
+    opts: Record<string, unknown>
+    returnvalue: unknown
+    stacktraceCount: number
+  }
+}
+
+export interface GetJobLogsHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName: string
+  jobId: string
+  cursor?: string
+  pageSize: number
+}
+
+export interface GetJobLogsHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  queueName: string
+  jobId: string
+  logs: string[]
+  total: number
+  nextCursor: string | null
+}
+
+export interface GetJobStacktracesHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName: string
+  jobId: string
+  cursor?: string
+  pageSize: number
+}
+
+export interface GetJobStacktracesHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  queueName: string
+  jobId: string
+  total: number
+  stacktraces: Array<{
+    attemptNumber: number
+    stacktrace: string
+    isLatest: boolean
+  }>
+  nextCursor: string | null
+}
+
+export interface RegisterReadToolsOptions {
+  listConnections?: (input: ListConnectionsHandlerInput) => Promise<ListConnectionsHandlerOutput>
+  listQueues?: (input: ListQueuesHandlerInput) => Promise<ListQueuesHandlerOutput>
+  getQueue?: (input: GetQueueHandlerInput) => Promise<GetQueueHandlerOutput>
+  listJobs?: (input: ListJobsHandlerInput) => Promise<ListJobsHandlerOutput>
+  getJob?: (input: GetJobHandlerInput) => Promise<GetJobHandlerOutput>
+  getJobLogs?: (input: GetJobLogsHandlerInput) => Promise<GetJobLogsHandlerOutput>
+  getJobStacktraces?: (
+    input: GetJobStacktracesHandlerInput
+  ) => Promise<GetJobStacktracesHandlerOutput>
+}
+
+function parsePageSize(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return 25
+  return Math.min(100, Math.max(1, Math.floor(raw)))
+}
+
+function parseCursor(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : undefined
+}
+
+export function registerReadTools(server: McpServer, options: RegisterReadToolsOptions): void {
+  const listConnections = options.listConnections
+  if (listConnections) {
+    const listConnectionsSchema = {
+      cursor: z.string().optional(),
+      pageSize: z.number().int().min(1).max(100).optional(),
+    }
+
+    server.tool(
+      'list_connections',
+      listConnectionsSchema,
+      async (args) => {
+        const requestContext = getMcpRequestContext()
+        const principal = requestContext?.principal
+        if (!principal) {
+          throw new Error('MCP principal context is unavailable for this request.')
+        }
+
+        if (principal.type === 'delegated_user' && !principal.userId) {
+          throw new Error('Delegated principal is missing user id.')
+        }
+        if (principal.type === 'service_account' && !principal.organizationId) {
+          throw new Error('Service account principal is missing organization id.')
+        }
+
+        const pageSize = parsePageSize(args.pageSize)
+        const cursor = parseCursor(args.cursor)
+
+        const result = await listConnections({
+          principal:
+            principal.type === 'delegated_user'
+              ? {
+                  type: 'delegated_user',
+                  principalId: principal.principalId,
+                  userId: principal.userId!,
+                }
+              : {
+                  type: 'service_account',
+                  principalId: principal.principalId,
+                  organizationId: principal.organizationId!,
+                },
+          cursor,
+          pageSize,
+        })
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result),
+            },
+          ],
+          structuredContent: result,
+        }
+      }
+    )
+  }
+
+  const listQueues = options.listQueues
+  if (listQueues) {
+    server.tool(
+      'list_queues',
+      {
+        connectionId: z.string().min(1),
+        cursor: z.string().optional(),
+        pageSize: z.number().int().min(1).max(100).optional(),
+      },
+      async (args) => {
+        const requestContext = getMcpRequestContext()
+        const principal = requestContext?.principal
+        if (!principal) {
+          throw new Error('MCP principal context is unavailable for this request.')
+        }
+
+        const result = await listQueues({
+          principal:
+            principal.type === 'delegated_user'
+              ? {
+                  type: 'delegated_user',
+                  principalId: principal.principalId,
+                  userId: principal.userId!,
+                }
+              : {
+                  type: 'service_account',
+                  principalId: principal.principalId,
+                  organizationId: principal.organizationId!,
+                },
+          connectionId: args.connectionId,
+          cursor: parseCursor(args.cursor),
+          pageSize: parsePageSize(args.pageSize),
+        })
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+          structuredContent: result,
+        }
+      }
+    )
+  }
+
+  const getQueue = options.getQueue
+  if (getQueue) {
+    server.tool(
+      'get_queue',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1),
+      },
+      async (args) => {
+        const requestContext = getMcpRequestContext()
+        const principal = requestContext?.principal
+        if (!principal) {
+          throw new Error('MCP principal context is unavailable for this request.')
+        }
+
+        const result = await getQueue({
+          principal:
+            principal.type === 'delegated_user'
+              ? {
+                  type: 'delegated_user',
+                  principalId: principal.principalId,
+                  userId: principal.userId!,
+                }
+              : {
+                  type: 'service_account',
+                  principalId: principal.principalId,
+                  organizationId: principal.organizationId!,
+                },
+          connectionId: args.connectionId,
+          queueName: args.queueName,
+        })
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+          structuredContent: result,
+        }
+      }
+    )
+  }
+
+  const listJobs = options.listJobs
+  if (listJobs) {
+    server.tool(
+      'list_jobs',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1),
+        status: z.string().optional(),
+        name: z.string().optional(),
+        jobId: z.string().optional(),
+        cursor: z.string().optional(),
+        pageSize: z.number().int().min(1).max(100).optional(),
+      },
+      async (args) => {
+        const requestContext = getMcpRequestContext()
+        const principal = requestContext?.principal
+        if (!principal) {
+          throw new Error('MCP principal context is unavailable for this request.')
+        }
+
+        const result = await listJobs({
+          principal:
+            principal.type === 'delegated_user'
+              ? {
+                  type: 'delegated_user',
+                  principalId: principal.principalId,
+                  userId: principal.userId!,
+                }
+              : {
+                  type: 'service_account',
+                  principalId: principal.principalId,
+                  organizationId: principal.organizationId!,
+                },
+          connectionId: args.connectionId,
+          queueName: args.queueName,
+          status: args.status,
+          name: args.name,
+          jobId: args.jobId,
+          cursor: parseCursor(args.cursor),
+          pageSize: parsePageSize(args.pageSize),
+        })
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+          structuredContent: result,
+        }
+      }
+    )
+  }
+
+  const getJob = options.getJob
+  if (getJob) {
+    server.tool(
+      'get_job',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1),
+        jobId: z.string().min(1),
+      },
+      async (args) => {
+        const requestContext = getMcpRequestContext()
+        const principal = requestContext?.principal
+        if (!principal) {
+          throw new Error('MCP principal context is unavailable for this request.')
+        }
+
+        const result = await getJob({
+          principal:
+            principal.type === 'delegated_user'
+              ? {
+                  type: 'delegated_user',
+                  principalId: principal.principalId,
+                  userId: principal.userId!,
+                }
+              : {
+                  type: 'service_account',
+                  principalId: principal.principalId,
+                  organizationId: principal.organizationId!,
+                },
+          connectionId: args.connectionId,
+          queueName: args.queueName,
+          jobId: args.jobId,
+        })
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+          structuredContent: result,
+        }
+      }
+    )
+  }
+
+  const getJobLogs = options.getJobLogs
+  if (getJobLogs) {
+    server.tool(
+      'get_job_logs',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1),
+        jobId: z.string().min(1),
+        cursor: z.string().optional(),
+        pageSize: z.number().int().min(1).max(100).optional(),
+      },
+      async (args) => {
+        const requestContext = getMcpRequestContext()
+        const principal = requestContext?.principal
+        if (!principal) {
+          throw new Error('MCP principal context is unavailable for this request.')
+        }
+
+        const result = await getJobLogs({
+          principal:
+            principal.type === 'delegated_user'
+              ? {
+                  type: 'delegated_user',
+                  principalId: principal.principalId,
+                  userId: principal.userId!,
+                }
+              : {
+                  type: 'service_account',
+                  principalId: principal.principalId,
+                  organizationId: principal.organizationId!,
+                },
+          connectionId: args.connectionId,
+          queueName: args.queueName,
+          jobId: args.jobId,
+          cursor: parseCursor(args.cursor),
+          pageSize: parsePageSize(args.pageSize),
+        })
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+          structuredContent: result,
+        }
+      }
+    )
+  }
+
+  const getJobStacktraces = options.getJobStacktraces
+  if (getJobStacktraces) {
+    server.tool(
+      'get_job_stacktraces',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1),
+        jobId: z.string().min(1),
+        cursor: z.string().optional(),
+        pageSize: z.number().int().min(1).max(100).optional(),
+      },
+      async (args) => {
+        const requestContext = getMcpRequestContext()
+        const principal = requestContext?.principal
+        if (!principal) {
+          throw new Error('MCP principal context is unavailable for this request.')
+        }
+
+        const result = await getJobStacktraces({
+          principal:
+            principal.type === 'delegated_user'
+              ? {
+                  type: 'delegated_user',
+                  principalId: principal.principalId,
+                  userId: principal.userId!,
+                }
+              : {
+                  type: 'service_account',
+                  principalId: principal.principalId,
+                  organizationId: principal.organizationId!,
+                },
+          connectionId: args.connectionId,
+          queueName: args.queueName,
+          jobId: args.jobId,
+          cursor: parseCursor(args.cursor),
+          pageSize: parsePageSize(args.pageSize),
+        })
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+          structuredContent: result,
+        }
+      }
+    )
+  }
+}

--- a/packages/mcp/src/transport/session-registry.ts
+++ b/packages/mcp/src/transport/session-registry.ts
@@ -4,7 +4,8 @@ import type { Context } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 
 import { MCP_JSON_RPC_VERSION } from '../constants'
-import { createMcpServer } from '../server/create-mcp-server'
+import { runWithMcpRequestContext, type McpRequestContext } from '../request-context'
+import { createMcpServer, type CreateMcpServerOptions } from '../server/create-mcp-server'
 
 const MAX_ACTIVE_SESSIONS = 256
 
@@ -17,6 +18,7 @@ interface McpSessionEntry {
 export interface McpSessionRegistryOptions {
   version: string
   allowedHosts: ReadonlySet<string>
+  serverOptions?: Omit<CreateMcpServerOptions, 'version'>
 }
 
 export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
@@ -36,7 +38,7 @@ export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
   }
 
   function createSessionEntry(): McpSessionEntry {
-    const server = createMcpServer({ version: options.version })
+    const server = createMcpServer({ version: options.version, ...options.serverOptions })
     let entry: McpSessionEntry
 
     const transport = new StreamableHTTPTransport({
@@ -84,7 +86,10 @@ export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
     }
   }
 
-  async function handleRequest(c: Context): Promise<Response | undefined> {
+  async function handleRequest(
+    c: Context,
+    requestContext?: McpRequestContext
+  ): Promise<Response | undefined> {
     const sessionId = c.req.header('mcp-session-id')
 
     try {
@@ -95,7 +100,7 @@ export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
         }
 
         await session.connected
-        return session.transport.handleRequest(c)
+        return runWithMcpRequestContext(requestContext, () => session.transport.handleRequest(c))
       }
 
       const isInitialize = await requestIsInitialize(c)
@@ -110,7 +115,7 @@ export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
       await evictOldestSessionIfNeeded()
       const session = createSessionEntry()
       await session.connected
-      return session.transport.handleRequest(c)
+      return runWithMcpRequestContext(requestContext, () => session.transport.handleRequest(c))
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error

--- a/packages/mcp/src/transport/session-registry.ts
+++ b/packages/mcp/src/transport/session-registry.ts
@@ -21,6 +21,14 @@ export interface McpSessionRegistryOptions {
   serverOptions?: Omit<CreateMcpServerOptions, 'version'>
 }
 
+function getCachedJsonBody(c: Context): unknown {
+  try {
+    return c.get('mcpRequestJsonBody' as never)
+  } catch {
+    return undefined
+  }
+}
+
 export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
   const sessions = new Map<string, McpSessionEntry>()
   const allowedHostList = [...options.allowedHosts]
@@ -65,6 +73,11 @@ export function createMcpSessionRegistry(options: McpSessionRegistryOptions) {
   async function requestIsInitialize(c: Context): Promise<boolean> {
     if (c.req.method !== 'POST') {
       return false
+    }
+
+    const cachedBody = getCachedJsonBody(c)
+    if (cachedBody && typeof cachedBody === 'object' && !Array.isArray(cachedBody)) {
+      return (cachedBody as { method?: string }).method === 'initialize'
     }
 
     try {

--- a/tasks/mcp-implementation-master-plan.md
+++ b/tasks/mcp-implementation-master-plan.md
@@ -81,6 +81,16 @@ Every incoming agent must complete this before writing code.
 
 ---
 
+## Implementation Status Snapshot (2026-05-26)
+
+- [x] Step 1 complete: MCP module + `/mcp` transport ingress on unified API app (PR-02 merged).
+- [x] Step 2 complete: OAuth discovery + token validation middleware (PR-03 merged).
+- [ ] Step 3 in progress: principal resolver + policy engine (PR-04 branch in progress).
+- [ ] Step 5 started: initial read tools (`list_connections`, `list_queues`, `get_queue`, `list_jobs`) wired with policy + principal context and pagination scaffolding.
+- [ ] Steps 4, 6-7 pending (shared domain adapters expansion, hardening, deployment, GA closure).
+
+---
+
 ## First 10 Steps (Deterministic Startup Runbook)
 
 1. Identify active PR ID from `tasks/mcp-pr-execution-playbook.md`.

--- a/tasks/mcp-implementation-master-plan.md
+++ b/tasks/mcp-implementation-master-plan.md
@@ -86,7 +86,7 @@ Every incoming agent must complete this before writing code.
 - [x] Step 1 complete: MCP module + `/mcp` transport ingress on unified API app (PR-02 merged).
 - [x] Step 2 complete: OAuth discovery + token validation middleware (PR-03 merged).
 - [ ] Step 3 in progress: principal resolver + policy engine (PR-04 branch in progress).
-- [ ] Step 5 started: initial read tools (`list_connections`, `list_queues`, `get_queue`, `list_jobs`) wired with policy + principal context and pagination scaffolding.
+- [ ] Step 5 started: initial read tools (`list_connections`, `list_queues`, `get_queue`, `list_jobs`, `get_job`, `get_job_logs`, `get_job_stacktraces`) wired with policy + principal context and pagination scaffolding.
 - [ ] Steps 4, 6-7 pending (shared domain adapters expansion, hardening, deployment, GA closure).
 
 ---

--- a/tasks/mcp-pr-execution-playbook.md
+++ b/tasks/mcp-pr-execution-playbook.md
@@ -620,18 +620,15 @@ Finalize production quality and confirm spec/safety compliance.
 - Branch: `feat/no-linear-mcp-pr01-security-baseline`
 - Linear issue: `NO-LINEAR (temporary; to be backfilled before merge if required)`
 - PR URL:
-- Status: `in progress`
+- Status: `folded into PR-04 (docs + runtime enforcement landed in later slices)`
 - Agent owner: `codex`
 - Start date: `2026-05-26`
 - Merge date:
 
 #### Scope Completed
 
-- [x] ADR for MCP architecture boundaries, threat model, and scope taxonomy.
-- [x] Decision record for phase-1 read-only GA and write-tool deferral.
-- [x] Operations security docs updated with MCP baseline guidance.
-- [ ] Permission matrix review signoff in PR thread.
-- [ ] Security design walkthrough evidence captured in PR description.
+- [ ] Standalone PR was not merged; baseline security decisions were carried forward into PR-02/03.
+- [ ] ADR + operations-doc finalization is intentionally folded into PR-04 before security closure.
 
 #### Verification Evidence
 
@@ -653,13 +650,14 @@ Finalize production quality and confirm spec/safety compliance.
 
 #### Handoff To Next PR
 
-- Next PR: `PR-02`
+- Next PR: `PR-04` (fold-in completion)
 - Known risks: runtime enforcement is not in this PR and must be implemented in PR-02/03/04.
 - Follow-up tasks:
   - backfill Linear issue link if merge policy requires it.
   - amend ADR-0001 deployable wording (dedicated `apps/mcp` → API `/mcp` ingress) when landing PR-02.
 - Notes for next agent:
   - treat ADR-0001 as source of truth for phase-1 **security** boundaries.
+  - complete remaining PR-01 docs guarantees while landing PR-04 principal/policy enforcement.
   - **do not** build standalone `apps/mcp`; mount MCP on `apps/api` at `/mcp` (see Hosting model section above).
 - PR-01 acceptance statement for PR body: `This PR defines security and scope contracts only; no MCP runtime behavior is introduced.`
 
@@ -711,10 +709,10 @@ Finalize production quality and confirm spec/safety compliance.
 - Branch: `cursor/mcp-pr03-oauth-discovery-token-validation`
 - Linear issue: `NO-LINEAR (temporary)`
 - PR URL: https://github.com/durabullhq/durabull/pull/89
-- Status: `in review`
+- Status: `merged`
 - Agent owner: `cursor`
 - Start date: `2026-05-26`
-- Merge date:
+- Merge date: `2026-05-27`
 
 #### Scope Completed
 
@@ -752,13 +750,124 @@ Finalize production quality and confirm spec/safety compliance.
 
 ---
 
+### PR Record: PR-04
+
+- PR ID: `PR-04`
+- Branch: `feat/no-linear-mcp-pr04-principals-policy-engine`
+- Linear issue: `NO-LINEAR (temporary)`
+- PR URL:
+- Status: `in progress`
+- Agent owner: `codex`
+- Start date: `2026-05-26`
+- Merge date:
+
+#### Scope Completed
+
+- [x] Principal resolver implemented for delegated users and OAuth-linked service accounts.
+- [x] Central policy decision point added in MCP ingress middleware for every `tools/call`.
+- [x] Org + connection boundary checks enforced in policy evaluation.
+- [x] Service account + policy + audit DAL schema/migration added (`mcp_service_account*`, `mcp_policy_binding`, `mcp_audit_event`).
+- [x] Repository support added for service-account lookup, policy bindings, and audit writes.
+- [x] Service-account credential hashing + rotation path added (`mcpPolicyRepository.issueServiceAccountSecret/rotateServiceAccountSecret`).
+- [x] Integration tests added for delegated and service-account policy enforcement through `/mcp`.
+- [x] Request-scoped principal context plumbed into MCP tool execution path.
+
+#### Verification Evidence
+
+- [x] Commands run:
+  - [x] `bun test packages/dal/src/repositories/mcp-policy.test.ts`
+  - [x] `bun run --filter @durabull/api test src/mcp/mount.test.ts`
+  - [x] `bun run --filter @durabull/dal typecheck`
+  - [x] `bun run --filter @durabull/dal lint`
+  - [ ] `bun run --filter @durabull/api typecheck` (blocked by pre-existing `alerts-global.test.ts` unknown-body typing errors)
+- [x] Tests added:
+  - [x] `packages/dal/src/repositories/mcp-policy.test.ts`
+  - [x] Expanded `apps/api/src/mcp/mount.test.ts` with service-account allow/deny and delegated cross-org boundary cases.
+- [x] Security checks:
+  - [x] No destructive MCP tools introduced.
+  - [x] Service-account policy bindings required for tool execution.
+  - [x] Policy audit records persisted for allow + deny decisions.
+
+#### Handoff To Next PR
+
+- Next PR: `PR-05`
+- Known risks:
+  - `PR-04` still runs with only `ping`; domain read tools + fine-grained scope mapping start in PR-05.
+  - RFC 8707 issuance binding follow-up from PR-03 still open.
+- Follow-up tasks:
+  - finalize PR-01 documentation fold-in artifacts before/with PR-04 PR description.
+  - attach Linear issue IDs retroactively if required by merge policy.
+- Notes for next agent:
+  - keep policy as the single authorization gate for MCP tool calls.
+  - register PR-05 read-only tools with explicit scope requirements and connection-bound checks.
+
+---
+
+### PR Record: PR-05
+
+- PR ID: `PR-05`
+- Branch: `feat/no-linear-mcp-pr04-principals-policy-engine` (temporary while PR-04 is unmerged)
+- Linear issue: `NO-LINEAR (temporary)`
+- PR URL:
+- Status: `in progress (scaffold + first tool)`
+- Agent owner: `codex`
+- Start date: `2026-05-26`
+- Merge date:
+
+#### Scope Completed
+
+- [x] Read-tool registration plumbing added to `@durabull/mcp` (`readTools` option in server/routes/registry).
+- [x] Async request-context bridge added so tool handlers can read resolved principal/correlation metadata.
+- [x] `list_connections` MCP tool implemented with pagination (`cursor`, `pageSize`) and structured output.
+- [x] `list_queues` MCP tool implemented (`connectionId`, cursor/pageSize) with queue status + counts.
+- [x] `get_queue` MCP tool implemented (`connectionId`, `queueName`) with workers/schedulers/counts snapshot.
+- [x] `list_jobs` MCP tool implemented (`connectionId`, `queueName`, filters, cursor/pageSize).
+- [x] `get_job` MCP tool implemented (`connectionId`, `queueName`, `jobId`) with safe job detail fields.
+- [x] `get_job_logs` MCP tool implemented (`connectionId`, `queueName`, `jobId`, cursor/pageSize).
+- [x] `get_job_stacktraces` MCP tool implemented (`connectionId`, `queueName`, `jobId`, cursor/pageSize).
+- [x] API-backed tool handler added (`apps/api/src/mcp/tools/list-connections-handler.ts`).
+- [x] API-backed queue/job handlers added (`list-queues-handler.ts`, `get-queue-handler.ts`, `list-jobs-handler.ts`).
+- [x] Job/queue scope gates mapped:
+  - [x] `list_connections`, `list_queues`, `get_queue`, `list_jobs`, `get_job` -> `mcp:jobs:read`
+  - [x] `get_job_logs`, `get_job_stacktraces` -> `mcp:logs:read`
+- [x] Integration tests for delegated pagination + service-account scoped access.
+
+#### Verification Evidence
+
+- [x] Commands run:
+  - [x] `bun run --filter @durabull/mcp typecheck`
+  - [x] `bun run --filter @durabull/mcp test`
+  - [x] `bun run --filter @durabull/mcp lint`
+  - [x] `bun run --filter @durabull/api test src/mcp/mount.test.ts`
+  - [x] `bun test packages/dal/src/repositories/mcp-policy.test.ts`
+  - [x] `bun run --filter @durabull/dal typecheck`
+  - [x] `bun run --filter @durabull/dal lint`
+  - [x] `bun run --filter @durabull/api test src/mcp/mount.test.ts` (updated: 14 pass)
+- [x] Tests added:
+  - [x] expanded `apps/api/src/mcp/mount.test.ts` with `list_connections` delegated + service-account scenarios.
+  - [x] expanded `apps/api/src/mcp/mount.test.ts` with `mcp:jobs:read` denial path and tool list assertions for new tools.
+
+#### Handoff To Next PR
+
+- Next PR: `PR-05` continuation (remaining tool catalog)
+- Known risks:
+  - only partial read catalog shipped; remaining diagnostic endpoints still pending (`get_job`, logs, stacktraces, failure events, metrics, workers, explain_job_failure).
+- Follow-up tasks:
+  - add per-tool schemas/contract tests for remaining read tools.
+  - validate pagination/limits on log and stacktrace-heavy tools.
+- Notes for next agent:
+  - keep all MCP tools read-only and route through existing policy middleware.
+  - preserve request-context bridge; do not bypass principal/policy/audit path when adding tools.
+
+---
+
 ## Live PR Tracker
 
-- [ ] PR-01 Security architecture baseline (in progress on `feat/no-linear-mcp-pr01-security-baseline`)
+- [ ] PR-01 Security architecture baseline (folded into PR-04 completion work)
 - [x] PR-02 API `/mcp` ingress + transport (`@durabull/mcp` package + thin API mount)
-- [ ] PR-03 OAuth discovery + token validation (in review — PR #89)
-- [ ] PR-04 Principals + policy engine
-- [ ] PR-05 Read-only diagnostic tools
+- [x] PR-03 OAuth discovery + token validation (merged — PR #89)
+- [ ] PR-04 Principals + policy engine (in progress on `feat/no-linear-mcp-pr04-principals-policy-engine`)
+- [ ] PR-05 Read-only diagnostic tools (in progress: scaffold + `list_connections`)
 - [ ] PR-06 Safety hardening
 - [ ] PR-07 Deployment + operations
 - [ ] PR-08 GA readiness + security closure

--- a/tasks/mcp-pr-execution-playbook.md
+++ b/tasks/mcp-pr-execution-playbook.md
@@ -851,7 +851,7 @@ Finalize production quality and confirm spec/safety compliance.
 
 - Next PR: `PR-05` continuation (remaining tool catalog)
 - Known risks:
-  - only partial read catalog shipped; remaining diagnostic endpoints still pending (`get_job`, logs, stacktraces, failure events, metrics, workers, explain_job_failure).
+  - partial read catalog shipped; remaining diagnostic endpoints still pending (`get_failure_events`, `get_queue_metrics`, `get_workers`, `explain_job_failure`).
 - Follow-up tasks:
   - add per-tool schemas/contract tests for remaining read tools.
   - validate pagination/limits on log and stacktrace-heavy tools.
@@ -867,7 +867,7 @@ Finalize production quality and confirm spec/safety compliance.
 - [x] PR-02 API `/mcp` ingress + transport (`@durabull/mcp` package + thin API mount)
 - [x] PR-03 OAuth discovery + token validation (merged — PR #89)
 - [ ] PR-04 Principals + policy engine (in progress on `feat/no-linear-mcp-pr04-principals-policy-engine`)
-- [ ] PR-05 Read-only diagnostic tools (in progress: scaffold + `list_connections`)
+- [ ] PR-05 Read-only diagnostic tools (in progress: first 7 tools + remaining catalog)
 - [ ] PR-06 Safety hardening
 - [ ] PR-07 Deployment + operations
 - [ ] PR-08 GA readiness + security closure

--- a/tasks/mcp-readiness-review.md
+++ b/tasks/mcp-readiness-review.md
@@ -2,9 +2,9 @@
 
 This document summarizes readiness after addressing live-test recommendations (expired-token handling, operator docs, automated e2e smoke) and re-running full MCP e2e checks.
 
-**Branch:** `cursor/mcp-pr03-oauth-discovery-token-validation`  
-**Draft PR:** https://github.com/durabullhq/durabull/pull/89  
-**Plan position:** End of **PR-03** in the sequential MCP stack (PR-04+ not started).
+**Branch at review time:** `cursor/mcp-pr03-oauth-discovery-token-validation`  
+**PR:** https://github.com/durabullhq/durabull/pull/89 (**merged**)  
+**Plan position:** Post-merge PR-03 baseline, with PR-04 principal/policy implementation now in progress.
 
 ---
 
@@ -12,8 +12,8 @@ This document summarizes readiness after addressing live-test recommendations (e
 
 | Dimension | Verdict |
 | --- | --- |
-| **PR-03 merge readiness** | **Ready for review/merge** as the OAuth + transport-auth slice, pending Linear issue linkage and your sign-off on deferred items below. |
-| **Production / customer diagnostics** | **Not ready** — only `ping` exists; no org-scoped tools, policy engine, redaction, rate limits, or deploy runbooks (PR-04–08). |
+| **PR-03 merge readiness** | **Merged** (PR #89); transport + OAuth discovery/auth slice is landed on `main`. |
+| **Production / customer diagnostics** | **Not ready** — only `ping` exists; policy + principals are now being added in PR-04, while diagnostic tools/redaction/deploy remain PR-05–08. |
 | **Full OAuth UX (browser PKCE)** | **Not manually verified** — registration + DB-seeded tokens exercised; authorize/consent UI flow not run in this pass. |
 
 ---
@@ -79,6 +79,26 @@ DURABULL_AUTHLESS=true APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
 
 ---
 
+## Current update (PR-04 in progress)
+
+- Added principal-resolution path for delegated users + OAuth-linked service accounts.
+- Added centralized policy middleware on MCP `tools/call` with audit-event writes.
+- Added org/connection boundary checks and service-account policy-binding enforcement.
+- Added DAL schema + migration for `mcp_service_account*`, `mcp_policy_binding`, and `mcp_audit_event`.
+- Added integration coverage in `apps/api/src/mcp/mount.test.ts` for service-account allow/deny and delegated cross-org denial.
+
+## Current update (PR-05 kickoff)
+
+- Added MCP read-tool registration plumbing in `@durabull/mcp` and request-context propagation for tool handlers.
+- Added first customer-facing read tool: `list_connections` with bounded `pageSize` and cursor pagination.
+- Added next diagnostic tools: `list_queues`, `get_queue`, and `list_jobs` behind the same policy/principal context path.
+- Added API handler implementation constrained by principal type:
+  - delegated users: only connections in org memberships
+  - service accounts: only connections in bound organization
+- Added integration coverage for delegated pagination and service-account scoped list access.
+
+---
+
 ## Known gaps and deferred work
 
 ### PR-03 follow-ups (non-blocking for merge if accepted)
@@ -116,15 +136,11 @@ DURABULL_AUTHLESS=true APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
 
 ---
 
-## Merge recommendation
+## Post-merge recommendation
 
-**Approve PR #89** when:
-
-1. Linear issue is attached (per playbook).
-2. Reviewers accept deferred browser OAuth UX test and RFC 8707 issuance wiring.
-3. Uncommitted follow-up commits on the branch include expiry fix + e2e script (push before merge).
-
-**Do not** treat PR-03 merge as MCP GA or production customer diagnostics — that requires PR-04–08.
+- Keep PR-03 treated as transport/auth foundation only.
+- Complete PR-04 policy/principal merge next, then proceed with PR-05 read-only diagnostic tools.
+- Do not treat merged PR-03 as MCP GA or production customer diagnostics — that still requires PR-04–08.
 
 ---
 

--- a/tasks/mcp-readiness-review.md
+++ b/tasks/mcp-readiness-review.md
@@ -91,11 +91,11 @@ DURABULL_AUTHLESS=true APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
 
 - Added MCP read-tool registration plumbing in `@durabull/mcp` and request-context propagation for tool handlers.
 - Added first customer-facing read tool: `list_connections` with bounded `pageSize` and cursor pagination.
-- Added next diagnostic tools: `list_queues`, `get_queue`, and `list_jobs` behind the same policy/principal context path.
+- Added next diagnostic tools: `list_queues`, `get_queue`, `list_jobs`, `get_job`, `get_job_logs`, and `get_job_stacktraces` behind the same policy/principal context path.
 - Added API handler implementation constrained by principal type:
   - delegated users: only connections in org memberships
   - service accounts: only connections in bound organization
-- Added integration coverage for delegated pagination and service-account scoped list access.
+- Added integration coverage for delegated pagination, service-account scoped list access, and `get_job*` authorization/error paths.
 
 ---
 
@@ -115,7 +115,7 @@ DURABULL_AUTHLESS=true APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
 | PR | Missing capability |
 | --- | --- |
 | PR-04 | Principal model, org/connection policy on tool calls |
-| PR-05 | `mcp:jobs:read`, failures, logs, diagnostics tools |
+| PR-05 | Remaining diagnostics tools (`get_failure_events`, `get_queue_metrics`, `get_workers`, `explain_job_failure`) |
 | PR-06 | Redaction, rate limits, audit logging |
 | PR-07 | Cloud/self-host deploy, runbooks |
 | PR-08 | Security review closure, GA docs |

--- a/tooling/scripts/mcp-live-final-proof.ts
+++ b/tooling/scripts/mcp-live-final-proof.ts
@@ -1,0 +1,579 @@
+#!/usr/bin/env bun
+import '@durabull/env'
+
+import {
+  getDb,
+  mcpPolicyBinding,
+  mcpServiceAccount,
+  member,
+  oauthAccessToken,
+  oauthApplication,
+  organization,
+  redisConnectionRepository,
+  redisDiscoveredQueueRepository,
+  user,
+} from '@durabull/dal'
+import { MCP_PROTOCOL_VERSION } from '@durabull/mcp'
+import { MCP_JSON_RPC_VERSION, parseSseJson } from '@durabull/mcp/testing'
+import { QueueEvents, Worker } from 'bullmq'
+
+import { toRedisConnectionOptions } from '../../apps/api/src/lib/connection-options'
+import { getQueue } from '../../apps/api/src/lib/redis'
+
+type Check = { name: string; ok: boolean; detail: string }
+const checks: Check[] = []
+
+function add(name: string, ok: boolean, detail: string) {
+  checks.push({ name, ok, detail })
+  console.log(`[${ok ? 'PASS' : 'FAIL'}] ${name} -> ${detail}`)
+}
+
+function parseJsonRpcText(text: string) {
+  try {
+    return parseSseJson(text) as Record<string, any>
+  } catch {
+    return {} as Record<string, any>
+  }
+}
+
+async function mcpPost(
+  baseUrl: string,
+  body: Record<string, unknown>,
+  options: { token: string; sessionId?: string }
+) {
+  const host = new URL(baseUrl).host
+  const headers: Record<string, string> = {
+    host,
+    accept: 'application/json, text/event-stream',
+    'content-type': 'application/json',
+    authorization: `Bearer ${options.token}`,
+  }
+  if (options.sessionId) headers['mcp-session-id'] = options.sessionId
+
+  return fetch(`${baseUrl}/mcp`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+async function initialize(baseUrl: string, token: string) {
+  const res = await mcpPost(
+    baseUrl,
+    {
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'final-live-proof', version: '1.0.0' },
+      },
+    },
+    { token }
+  )
+  const body = parseJsonRpcText(await res.text())
+  const sessionId = res.headers.get('mcp-session-id') ?? undefined
+  return { res, body, sessionId }
+}
+
+async function callTool(
+  baseUrl: string,
+  token: string,
+  sessionId: string,
+  name: string,
+  args: Record<string, unknown>
+) {
+  const res = await mcpPost(
+    baseUrl,
+    {
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 2,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    },
+    { token, sessionId }
+  )
+  const raw = await res.text()
+  return { res, body: parseJsonRpcText(raw), raw }
+}
+
+async function main() {
+  const baseUrl = process.env.APP_BASE_URL ?? 'http://localhost:3001'
+  console.log(`Running live MCP proof against ${baseUrl}`)
+
+  const db = await getDb()
+  const now = new Date()
+  const suffix = crypto.randomUUID().slice(0, 8)
+  const orgId = `mcp-live-org-${suffix}`
+  const userId = `mcp-live-user-${suffix}`
+  const delegatedClientId = `mcp-live-delegated-client-${suffix}`
+  const serviceClientId = `mcp-live-service-client-${suffix}`
+  const deniedServiceClientId = `mcp-live-service-denied-client-${suffix}`
+  const queueName = `mcp-live-queue-${suffix}`
+
+  await db.insert(organization).values({
+    id: orgId,
+    name: `MCP Live Org ${suffix}`,
+    slug: `mcp-live-org-${suffix}`,
+    createdAt: now,
+    updatedAt: now,
+  })
+  await db.insert(user).values({
+    id: userId,
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    name: 'MCP Live User',
+    image: null,
+    lastSignInAt: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+  await db.insert(member).values({
+    id: crypto.randomUUID(),
+    organizationId: orgId,
+    userId,
+    role: 'member',
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  await db.insert(oauthApplication).values([
+    {
+      id: crypto.randomUUID(),
+      name: 'mcp-live-delegated',
+      clientId: delegatedClientId,
+      redirectUrls: 'http://127.0.0.1:8765/callback',
+      type: 'public',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'mcp-live-service',
+      clientId: serviceClientId,
+      redirectUrls: 'http://127.0.0.1:8765/callback',
+      type: 'confidential',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'mcp-live-service-denied',
+      clientId: deniedServiceClientId,
+      redirectUrls: 'http://127.0.0.1:8765/callback',
+      type: 'confidential',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ])
+
+  const [serviceAccount] = await db
+    .insert(mcpServiceAccount)
+    .values({
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      name: `mcp-live-service-${suffix}`,
+      oauthClientId: serviceClientId,
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+
+  await db.insert(mcpServiceAccount).values({
+    id: crypto.randomUUID(),
+    organizationId: orgId,
+    name: `mcp-live-service-denied-${suffix}`,
+    oauthClientId: deniedServiceClientId,
+    disabled: false,
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  await db.insert(mcpPolicyBinding).values([
+    {
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: null,
+      scope: 'mcp:discover',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: null,
+      scope: 'mcp:jobs:read',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: null,
+      scope: 'mcp:logs:read',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ])
+
+  const accessExp = new Date(Date.now() + 60 * 60 * 1000)
+  const resource = `${new URL(baseUrl).origin}/mcp`
+  const delegatedFullToken = `mcp-live-delegated-full-${suffix}`
+  const delegatedLowScopeToken = `mcp-live-delegated-low-${suffix}`
+  const serviceToken = `mcp-live-service-${suffix}`
+  const deniedServiceToken = `mcp-live-service-denied-${suffix}`
+  await db.insert(oauthAccessToken).values([
+    {
+      id: crypto.randomUUID(),
+      accessToken: delegatedFullToken,
+      refreshToken: `refresh-${delegatedFullToken}`,
+      accessTokenExpiresAt: accessExp,
+      refreshTokenExpiresAt: accessExp,
+      clientId: delegatedClientId,
+      userId,
+      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read',
+      resource,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      accessToken: delegatedLowScopeToken,
+      refreshToken: `refresh-${delegatedLowScopeToken}`,
+      accessTokenExpiresAt: accessExp,
+      refreshTokenExpiresAt: accessExp,
+      clientId: delegatedClientId,
+      userId,
+      scopes: 'mcp:discover',
+      resource,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      accessToken: serviceToken,
+      refreshToken: `refresh-${serviceToken}`,
+      accessTokenExpiresAt: accessExp,
+      refreshTokenExpiresAt: accessExp,
+      clientId: serviceClientId,
+      userId: null,
+      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read',
+      resource,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      accessToken: deniedServiceToken,
+      refreshToken: `refresh-${deniedServiceToken}`,
+      accessTokenExpiresAt: accessExp,
+      refreshTokenExpiresAt: accessExp,
+      clientId: deniedServiceClientId,
+      userId: null,
+      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read',
+      resource,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ])
+
+  const connection = await redisConnectionRepository.create({
+    name: `mcp-live-conn-${suffix}`,
+    url: 'redis://127.0.0.1:56379/9',
+    isDefault: true,
+    environment: 'development',
+    prefix: 'bull',
+    allowSelfSignedCerts: false,
+    organizationId: orgId,
+  })
+  await redisDiscoveredQueueRepository.upsertConfirmedQueues(connection.id, [queueName], new Date())
+
+  const redisOptions = toRedisConnectionOptions(connection.allowSelfSignedCerts)
+  const queue = await getQueue(connection.id, connection.url, queueName, connection.prefix, redisOptions)
+  const queueEvents = new QueueEvents(queueName, {
+    connection: { url: connection.url },
+    prefix: connection.prefix,
+  })
+  await queueEvents.waitUntilReady()
+  const worker = new Worker(
+    queueName,
+    async (job) => {
+      await job.log(`live-log-${suffix}-1`)
+      await job.log(`live-log-${suffix}-2`)
+      throw new Error(`live-failure-${suffix}`)
+    },
+    {
+      connection: { url: connection.url },
+      prefix: connection.prefix,
+      concurrency: 1,
+    }
+  )
+  await worker.waitUntilReady()
+
+  const createdJob = await queue.add(
+    `live-job-${suffix}`,
+    { marker: `payload-${suffix}` },
+    { removeOnComplete: false, removeOnFail: false, attempts: 1 }
+  )
+  try {
+    await createdJob.waitUntilFinished(queueEvents, 15_000)
+  } catch {
+    // expected; worker throws to generate failed reason + stacktrace
+  }
+  const jobId = String(createdJob.id)
+  add('Live queue/job setup', !!jobId, `connection=${connection.id}, queue=${queueName}, job=${jobId}`)
+
+  const delegatedInit = await initialize(baseUrl, delegatedFullToken)
+  add(
+    'Delegated initialize',
+    delegatedInit.res.ok && !!delegatedInit.sessionId,
+    `status=${delegatedInit.res.status}, session=${delegatedInit.sessionId ?? 'none'}`
+  )
+  if (!delegatedInit.sessionId) throw new Error('Delegated init failed')
+
+  const serviceInit = await initialize(baseUrl, serviceToken)
+  add(
+    'Service initialize',
+    serviceInit.res.ok && !!serviceInit.sessionId,
+    `status=${serviceInit.res.status}, session=${serviceInit.sessionId ?? 'none'}`
+  )
+  if (!serviceInit.sessionId) throw new Error('Service init failed')
+
+  const deniedServiceInit = await initialize(baseUrl, deniedServiceToken)
+  add(
+    'Denied-service initialize',
+    deniedServiceInit.res.ok && !!deniedServiceInit.sessionId,
+    `status=${deniedServiceInit.res.status}, session=${deniedServiceInit.sessionId ?? 'none'}`
+  )
+  if (!deniedServiceInit.sessionId) throw new Error('Denied service init failed')
+
+  const lowScopeInit = await initialize(baseUrl, delegatedLowScopeToken)
+  add(
+    'Low-scope initialize',
+    lowScopeInit.res.ok && !!lowScopeInit.sessionId,
+    `status=${lowScopeInit.res.status}, session=${lowScopeInit.sessionId ?? 'none'}`
+  )
+  if (!lowScopeInit.sessionId) throw new Error('Low-scope init failed')
+
+  const toolsList = await mcpPost(
+    baseUrl,
+    { jsonrpc: MCP_JSON_RPC_VERSION, id: 11, method: 'tools/list', params: {} },
+    { token: delegatedFullToken, sessionId: delegatedInit.sessionId }
+  )
+  const toolsListBody = parseJsonRpcText(await toolsList.text())
+  const toolNames: string[] = toolsListBody?.result?.tools?.map((t: any) => t.name) ?? []
+  const expectedTools = [
+    'ping',
+    'list_connections',
+    'list_queues',
+    'get_queue',
+    'list_jobs',
+    'get_job',
+    'get_job_logs',
+    'get_job_stacktraces',
+  ]
+  add(
+    'tools/list exposes all MCP tools',
+    toolsList.ok && expectedTools.every((name) => toolNames.includes(name)),
+    `tools=${toolNames.join(',')}`
+  )
+
+  const ping = await callTool(baseUrl, delegatedFullToken, delegatedInit.sessionId, 'ping', {})
+  add('ping', ping.res.ok && ping.body?.result?.content?.[0]?.text === 'pong', `status=${ping.res.status}`)
+
+  const listConnections = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'list_connections',
+    { pageSize: 10 }
+  )
+  const listConnectionsJson = JSON.parse(
+    listConnections.body?.result?.content?.[0]?.text ?? '{"connections":[]}'
+  ) as { connections: Array<{ id: string }> }
+  add(
+    'list_connections',
+    listConnections.res.ok &&
+      listConnectionsJson.connections.some((connectionRow) => connectionRow.id === connection.id),
+    `status=${listConnections.res.status}, total=${listConnectionsJson.connections.length}`
+  )
+
+  const listQueues = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'list_queues',
+    {
+      connectionId: connection.id,
+      pageSize: 10,
+    }
+  )
+  const listQueuesJson = JSON.parse(
+    listQueues.body?.result?.content?.[0]?.text ?? '{"queues":[]}'
+  ) as { queues: Array<{ name: string }> }
+  add(
+    'list_queues',
+    listQueues.res.ok && listQueuesJson.queues.some((row) => row.name === queueName),
+    `status=${listQueues.res.status}, queues=${listQueuesJson.queues.map((q) => q.name).join(',')}`
+  )
+
+  const getQueueTool = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'get_queue',
+    { connectionId: connection.id, queueName }
+  )
+  const getQueueJson = JSON.parse(
+    getQueueTool.body?.result?.content?.[0]?.text ?? '{"name":""}'
+  ) as { name?: string }
+  add('get_queue', getQueueTool.res.ok && getQueueJson.name === queueName, `status=${getQueueTool.res.status}`)
+
+  const listJobs = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'list_jobs',
+    { connectionId: connection.id, queueName, pageSize: 20 }
+  )
+  const listJobsJson = JSON.parse(
+    listJobs.body?.result?.content?.[0]?.text ?? '{"jobs":[]}'
+  ) as { jobs: Array<{ id: string }> }
+  add(
+    'list_jobs',
+    listJobs.res.ok && listJobsJson.jobs.some((row) => row.id === jobId),
+    `status=${listJobs.res.status}, jobs=${listJobsJson.jobs.length}`
+  )
+
+  const getJob = await callTool(baseUrl, delegatedFullToken, delegatedInit.sessionId, 'get_job', {
+    connectionId: connection.id,
+    queueName,
+    jobId,
+  })
+  const getJobJson = JSON.parse(getJob.body?.result?.content?.[0]?.text ?? '{"job":{}}') as {
+    job?: { id?: string; status?: string; stacktraceCount?: number }
+  }
+  add(
+    'get_job',
+    getJob.res.ok && getJobJson.job?.id === jobId && (getJobJson.job?.stacktraceCount ?? 0) > 0,
+    `status=${getJob.res.status}, state=${getJobJson.job?.status ?? 'unknown'}`
+  )
+
+  const getJobLogs = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'get_job_logs',
+    {
+      connectionId: connection.id,
+      queueName,
+      jobId,
+      pageSize: 10,
+    }
+  )
+  const getJobLogsJson = JSON.parse(
+    getJobLogs.body?.result?.content?.[0]?.text ?? '{"logs":[]}'
+  ) as { logs: string[] }
+  add(
+    'get_job_logs',
+    getJobLogs.res.ok && getJobLogsJson.logs.some((line) => line.includes(`live-log-${suffix}`)),
+    `status=${getJobLogs.res.status}, logs=${getJobLogsJson.logs.length}`
+  )
+
+  const getStacktraces = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'get_job_stacktraces',
+    {
+      connectionId: connection.id,
+      queueName,
+      jobId,
+      pageSize: 10,
+    }
+  )
+  const getStacktracesJson = JSON.parse(
+    getStacktraces.body?.result?.content?.[0]?.text ?? '{"stacktraces":[]}'
+  ) as { stacktraces: Array<{ stacktrace: string }> }
+  add(
+    'get_job_stacktraces',
+    getStacktraces.res.ok &&
+      getStacktracesJson.stacktraces.some((row) => row.stacktrace.includes(`live-failure-${suffix}`)),
+    `status=${getStacktraces.res.status}, traces=${getStacktracesJson.stacktraces.length}`
+  )
+
+  const serviceListConnections = await callTool(
+    baseUrl,
+    serviceToken,
+    serviceInit.sessionId,
+    'list_connections',
+    { pageSize: 10 }
+  )
+  const serviceListConnectionsJson = JSON.parse(
+    serviceListConnections.body?.result?.content?.[0]?.text ?? '{"connections":[]}'
+  ) as { connections: Array<{ id: string }> }
+  add(
+    'service_account list_connections (allowed)',
+    serviceListConnections.res.ok &&
+      serviceListConnectionsJson.connections.some((connectionRow) => connectionRow.id === connection.id),
+    `status=${serviceListConnections.res.status}`
+  )
+
+  const deniedServicePing = await callTool(
+    baseUrl,
+    deniedServiceToken,
+    deniedServiceInit.sessionId,
+    'ping',
+    {}
+  )
+  add(
+    'service_account without bindings denied',
+    deniedServicePing.res.status === 403 &&
+      (deniedServicePing.raw.includes('service_account_policy_denied') ||
+        deniedServicePing.raw.includes('Forbidden')),
+    `status=${deniedServicePing.res.status}`
+  )
+
+  const lowScopeListConnections = await callTool(
+    baseUrl,
+    delegatedLowScopeToken,
+    lowScopeInit.sessionId,
+    'list_connections',
+    { pageSize: 10 }
+  )
+  add(
+    'missing scope denied',
+    lowScopeListConnections.res.status === 403 &&
+      lowScopeListConnections.raw.includes('missing_scopes'),
+    `status=${lowScopeListConnections.res.status}`
+  )
+
+  await worker.close()
+  await queueEvents.close()
+  await queue.close()
+
+  const passCount = checks.filter((check) => check.ok).length
+  console.log(`\nSummary: ${passCount}/${checks.length} checks passed`)
+  if (passCount !== checks.length) {
+    process.exit(1)
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- implement MCP principal resolution and policy enforcement for delegated-user and service-account callers, including service-account policy bindings and audit events
- add read-only diagnostics tools for connections, queues, and jobs (`list_connections`, `list_queues`, `get_queue`, `list_jobs`, `get_job`, `get_job_logs`, `get_job_stacktraces`) with request-context-aware handlers
- harden tool behavior by failing closed for unmapped policy scopes, returning typed `isError` envelopes for not-found paths, and sanitizing unknown internal errors

## Test plan
- [x] `bun test packages/mcp apps/api/src/mcp`
- [x] `bun test apps/api/src/mcp/mount.test.ts`
- [x] `bun test apps/api/src/mcp/tools/job-read-handlers.test.ts apps/api/src/mcp/policy/policy-engine.test.ts`
- [x] local MCP initialize/tools/list/tools/call verification completed in prior session

## Notes
- Linear linkage intentionally marked as `NO-LINEAR` per current instruction.
- Excluded unrelated untracked docs artifacts from commit (`apps/docs/public/llms-full.txt`, `apps/docs/public/llms.txt`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented MCP authorization system with OAuth scope-based access control
  * Added tools for managing connections, queues, and jobs with pagination support
  * Enabled job logs and stacktrace retrieval
  * Implemented delegated user and service account support with organization boundary enforcement

* **Tests**
  * Added comprehensive authorization and policy validation test coverage
  * Extended MCP tool handler test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->