### PR TITLE
feat(mcp): PR-05 remaining read tools

### DIFF
--- a/apps/api/src/lib/bullmq-metrics.ts
+++ b/apps/api/src/lib/bullmq-metrics.ts
@@ -2,6 +2,8 @@ import type { Metrics, Queue, QueueMeta } from 'bullmq'
 
 export const DEFAULT_METRICS_WINDOW_MINUTES = 360
 export const MAX_METRICS_WINDOW_MINUTES = 80640
+/** Bounded window for MCP `get_queue_metrics` (24 hours). */
+export const MCP_MAX_METRICS_WINDOW_MINUTES = 1440
 export const DEFAULT_PRIORITY_BUCKETS = [1, 2, 5, 10, 20, 50] as const
 
 interface CollectNativeMetricsOptions {
@@ -376,5 +378,103 @@ export async function collectQueueNativeMetrics(
       metrics: prometheusMetrics,
     },
     warnings,
+  }
+}
+
+export async function collectQueueMcpMetricsSummary(
+  queue: Queue,
+  {
+    queueName,
+    windowMinutes,
+  }: {
+    queueName: string
+    windowMinutes: number
+  }
+) {
+  const requestedWindowMinutes = Math.min(
+    Math.max(Math.floor(windowMinutes), 1),
+    MCP_MAX_METRICS_WINDOW_MINUTES
+  )
+  const start = 0
+  const end = Math.max(requestedWindowMinutes - 1, 0)
+
+  const mcpWarnings: string[] = []
+  const [
+    completedMetrics,
+    failedMetrics,
+    jobCountsRaw,
+    waitingToProcess,
+    isPaused,
+    isMaxed,
+    workersCount,
+    schedulersCount,
+  ] = await Promise.all([
+    queue.getMetrics('completed', start, end),
+    queue.getMetrics('failed', start, end),
+    queue.getJobCounts(),
+    queue.count(),
+    queue.isPaused(),
+    safeCall(() => queue.isMaxed(), false, 'isMaxed unavailable', mcpWarnings),
+    queue.getWorkersCount(),
+    queue.getJobSchedulersCount(),
+  ])
+
+  const series = buildSeriesPoints(completedMetrics, failedMetrics, start)
+  const completedInWindow = series.reduce((sum, point) => sum + point.completed, 0)
+  const failedInWindow = series.reduce((sum, point) => sum + point.failed, 0)
+  const finishedInWindow = completedInWindow + failedInWindow
+  const minutesInWindow = series.length
+  const avgFinishedPerMinuteInWindow = minutesInWindow > 0 ? finishedInWindow / minutesInWindow : 0
+  const longestFailureStreakMinutesInWindow = longestStreak(series, (point) => point.failed > 0)
+  const longestCompletionStreakMinutesInWindow = longestStreak(
+    series,
+    (point) => point.completed > 0
+  )
+  const lifetimeCompleted = completedMetrics.meta.count
+  const lifetimeFailed = failedMetrics.meta.count
+  const lifetimeFinished = lifetimeCompleted + lifetimeFailed
+
+  return {
+    queueName,
+    range: {
+      requestedWindowMinutes,
+      returnedPoints: series.length,
+      oldestPointTimestamp: series.length > 0 ? series[0].timestamp : null,
+      newestPointTimestamp: series.length > 0 ? series[series.length - 1].timestamp : null,
+      latestPointAgeMs:
+        series.length > 0
+          ? Math.max(Date.now() - series[series.length - 1].timestamp, 0)
+          : null,
+      requestedWindowCoverage:
+        requestedWindowMinutes > 0
+          ? Math.min(series.length / requestedWindowMinutes, 1)
+          : null,
+    },
+    totals: {
+      completedInWindow,
+      failedInWindow,
+      finishedInWindow,
+      successRateInWindow: finishedInWindow > 0 ? completedInWindow / finishedInWindow : 1,
+      failureRateInWindow: finishedInWindow > 0 ? failedInWindow / finishedInWindow : 0,
+      avgCompletedPerMinuteInWindow:
+        minutesInWindow > 0 ? completedInWindow / minutesInWindow : 0,
+      avgFailedPerMinuteInWindow: minutesInWindow > 0 ? failedInWindow / minutesInWindow : 0,
+      longestFailureStreakMinutesInWindow,
+      longestCompletionStreakMinutesInWindow,
+      completedLifetime: lifetimeCompleted,
+      failedLifetime: lifetimeFailed,
+      failureRateLifetime: lifetimeFinished > 0 ? lifetimeFailed / lifetimeFinished : 0,
+      estimatedDrainMinutes:
+        avgFinishedPerMinuteInWindow > 0 ? waitingToProcess / avgFinishedPerMinuteInWindow : null,
+    },
+    counts: parseCounts(jobCountsRaw),
+    queue: {
+      isPaused,
+      isMaxed,
+      waitingToProcess,
+      workersCount,
+      schedulersCount,
+    },
+    warnings: mcpWarnings.map(() => 'One or more queue metrics were unavailable.'),
   }
 }

--- a/apps/api/src/mcp/mount.test.ts
+++ b/apps/api/src/mcp/mount.test.ts
@@ -202,6 +202,10 @@ describe('api MCP ingress', () => {
     expect(toolNames).toContain('get_job')
     expect(toolNames).toContain('get_job_logs')
     expect(toolNames).toContain('get_job_stacktraces')
+    expect(toolNames).toContain('get_failure_events')
+    expect(toolNames).toContain('get_queue_metrics')
+    expect(toolNames).toContain('get_workers')
+    expect(toolNames).toContain('explain_job_failure')
 
     const callResponse = await postMcp(
       {
@@ -528,6 +532,239 @@ describe('api MCP ingress', () => {
     expect(denialBody).toContain('mcp:logs:read')
   })
 
+  it('returns 403 for failure tools when token lacks mcp:failures:read scope', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const userId = `failures-user-${crypto.randomUUID().slice(0, 8)}`
+    const orgId = `failures-org-${crypto.randomUUID().slice(0, 8)}`
+
+    await db.insert(user).values({
+      id: userId,
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      name: 'Failures Scope User',
+      createdAt: now,
+      updatedAt: now,
+      image: null,
+      lastSignInAt: null,
+    })
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Failures Scope Org',
+      slug: `failures-scope-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [connection] = await db
+      .insert(redisConnection)
+      .values({
+        id: crypto.randomUUID(),
+        name: 'Failures Scope Connection',
+        url: 'redis://localhost:6379/4',
+        isDefault: true,
+        environment: 'development',
+        prefix: 'bull',
+        allowSelfSignedCerts: false,
+        organizationId: orgId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    await db.insert(member).values({
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      userId,
+      role: 'member',
+      createdAt: now,
+      updatedAt: now,
+    })
+    const clientId = `failures-scope-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'failures-scope-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'public',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const token = `failures-scope-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId,
+      scopes: 'mcp:discover mcp:jobs:read',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'failures-scope-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const response = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'get_failure_events',
+          arguments: {
+            connectionId: connection.id,
+            pageSize: 10,
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+
+    expect(response.status).toBe(403)
+    const denialBody = await response.text()
+    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('mcp:failures:read')
+  })
+
+  it('returns 403 for explain_job_failure when token lacks composite diagnostic scopes', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const userId = `diagnostics-user-${crypto.randomUUID().slice(0, 8)}`
+    const orgId = `diagnostics-org-${crypto.randomUUID().slice(0, 8)}`
+
+    await db.insert(user).values({
+      id: userId,
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      name: 'Diagnostics Scope User',
+      createdAt: now,
+      updatedAt: now,
+      image: null,
+      lastSignInAt: null,
+    })
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Diagnostics Scope Org',
+      slug: `diagnostics-scope-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [connection] = await db
+      .insert(redisConnection)
+      .values({
+        id: crypto.randomUUID(),
+        name: 'Diagnostics Scope Connection',
+        url: 'redis://localhost:6379/5',
+        isDefault: true,
+        environment: 'development',
+        prefix: 'bull',
+        allowSelfSignedCerts: false,
+        organizationId: orgId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    await db.insert(member).values({
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      userId,
+      role: 'member',
+      createdAt: now,
+      updatedAt: now,
+    })
+    const clientId = `diagnostics-scope-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'diagnostics-scope-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'public',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const token = `diagnostics-scope-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId,
+      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read mcp:failures:read',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'diagnostics-scope-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const response = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'explain_job_failure',
+          arguments: {
+            connectionId: connection.id,
+            queueName: 'emails',
+            jobId: 'abc',
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+
+    expect(response.status).toBe(403)
+    const denialBody = await response.text()
+    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('mcp:diagnostics:read')
+  })
+
   it('denies service-account tool calls without policy bindings', async () => {
     mutableEnv.DURABULL_AUTHLESS = false
     await closeDb()
@@ -819,6 +1056,113 @@ describe('api MCP ingress', () => {
       result?: { content?: Array<{ text?: string }> }
     }
     expect(callPayload.result?.content?.[0]?.text).toBe('pong')
+  })
+
+  it('denies explain_job_failure for service accounts missing a composite scope binding', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const db = await getDb()
+    const now = new Date()
+    const orgId = `org-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(organization).values({
+      id: orgId,
+      name: 'Composite Scope Org',
+      slug: `composite-scope-org-${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const clientId = `svc-client-${crypto.randomUUID().slice(0, 8)}`
+    await db.insert(oauthApplication).values({
+      id: crypto.randomUUID(),
+      name: 'composite-scope-client',
+      clientId,
+      redirectUrls: 'http://127.0.0.1/callback',
+      type: 'confidential',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [serviceAccount] = await db
+      .insert(mcpServiceAccount)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: orgId,
+        name: 'composite-scope-account',
+        oauthClientId: clientId,
+        disabled: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    await db.insert(mcpPolicyBinding).values({
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: 'explain_job_failure',
+      scope: 'mcp:diagnostics:read',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const token = `svc-token-${crypto.randomUUID().slice(0, 8)}`
+    const future = new Date(Date.now() + 3600_000)
+    await db.insert(oauthAccessToken).values({
+      id: crypto.randomUUID(),
+      accessToken: token,
+      refreshToken: `refresh-${token}`,
+      accessTokenExpiresAt: future,
+      refreshTokenExpiresAt: future,
+      clientId,
+      userId: null,
+      scopes:
+        'mcp:discover mcp:diagnostics:read mcp:jobs:read mcp:logs:read mcp:failures:read',
+      resource: mcpResource,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const initResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'composite-scope-test', version: '1.0.0' },
+        },
+      },
+      { authorization: `Bearer ${token}` }
+    )
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const callResponse = await postMcp(
+      {
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'explain_job_failure',
+          arguments: {
+            connectionId: crypto.randomUUID(),
+            queueName: 'emails',
+            jobId: 'job-1',
+          },
+        },
+      },
+      { authorization: `Bearer ${token}`, sessionId: sessionId ?? undefined }
+    )
+
+    expect(callResponse.status).toBe(403)
+    const denialBody = await callResponse.text()
+    expect(denialBody).toContain('service_account_policy_denied')
   })
 
   it('denies delegated-user tool calls when connection is outside membership boundary', async () => {

--- a/apps/api/src/mcp/mount.ts
+++ b/apps/api/src/mcp/mount.ts
@@ -5,10 +5,14 @@ import { APP_VERSION } from '../lib/build-info'
 import { assertMcpAuthConfiguration } from './auth/mcp-auth-config'
 import { createMcpSessionMiddleware } from './auth/mcp-session-middleware'
 import { createMcpPolicyMiddleware } from './policy/mcp-policy-middleware'
+import { explainJobFailureHandler } from './tools/explain-job-failure-handler'
+import { getFailureEventsHandler } from './tools/get-failure-events-handler'
 import { getJobHandler } from './tools/get-job-handler'
 import { getJobLogsHandler } from './tools/get-job-logs-handler'
 import { getJobStacktracesHandler } from './tools/get-job-stacktraces-handler'
+import { getQueueMetricsHandler } from './tools/get-queue-metrics-handler'
 import { getQueueHandler } from './tools/get-queue-handler'
+import { getWorkersHandler } from './tools/get-workers-handler'
 import { listConnectionsHandler } from './tools/list-connections-handler'
 import { listJobsHandler } from './tools/list-jobs-handler'
 import { listQueuesHandler } from './tools/list-queues-handler'
@@ -40,6 +44,10 @@ export async function mountMcpIngress() {
       getJob: getJobHandler,
       getJobLogs: getJobLogsHandler,
       getJobStacktraces: getJobStacktracesHandler,
+      getFailureEvents: getFailureEventsHandler,
+      getQueueMetrics: getQueueMetricsHandler,
+      getWorkers: getWorkersHandler,
+      explainJobFailure: explainJobFailureHandler,
     },
     requestContextResolver: (c) => {
       const principal = c.get('mcpPrincipal')
@@ -61,6 +69,8 @@ export async function mountMcpIngress() {
                 organizationId: principal.organizationId,
               },
         correlationId: decision?.correlationId,
+        grantedScopes: c.get('mcpGrantedScopes'),
+        resolvedConnection: c.get('mcpResolvedConnection'),
       }
     },
     middleware: [authMiddleware, policyMiddleware],

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -3,6 +3,7 @@ import type { Context } from 'hono'
 import { createMiddleware } from 'hono/factory'
 
 import type { McpSession } from '../auth/mcp-session-middleware'
+import { resolveConnectionForPrincipal } from '../tools/shared'
 import { evaluateMcpToolPolicy } from './policy-engine'
 import { resolveMcpPrincipal } from './principal-resolver'
 import type { McpPolicyDecision, McpToolCallRequest, McpPrincipal } from './types'
@@ -225,8 +226,37 @@ export function createMcpPolicyMiddleware() {
       )
     }
 
+    if (toolCall.connectionId) {
+      const principalForConnection =
+        principal.type === 'delegated_user'
+          ? {
+              type: 'delegated_user' as const,
+              principalId: principal.principalId,
+              userId: principal.userId,
+            }
+          : {
+              type: 'service_account' as const,
+              principalId: principal.principalId,
+              organizationId: principal.organizationId,
+            }
+      const resolvedConnection = await resolveConnectionForPrincipal(
+        principalForConnection,
+        toolCall.connectionId
+      )
+      if (resolvedConnection) {
+        c.set('mcpResolvedConnection', resolvedConnection)
+      }
+    }
+
     c.set('mcpPrincipal', principal)
     c.set('mcpPolicyDecision', decision)
+    c.set(
+      'mcpGrantedScopes',
+      session.scopes
+        .split(/\s+/)
+        .map((scope) => scope.trim())
+        .filter(Boolean)
+    )
     return next()
   })
 }
@@ -237,5 +267,7 @@ declare module 'hono' {
     mcpPrincipal: McpPrincipal
     mcpPolicyDecision: McpPolicyDecision
     mcpSession: McpSession
+    mcpResolvedConnection?: import('@durabull/mcp').McpResolvedConnection
+    mcpGrantedScopes?: string[]
   }
 }

--- a/apps/api/src/mcp/policy/policy-engine.test.ts
+++ b/apps/api/src/mcp/policy/policy-engine.test.ts
@@ -11,7 +11,14 @@ const baseSession: McpSession = {
   refreshTokenExpiresAt: new Date(),
   clientId: 'client-id',
   userId: 'user-1',
-  scopes: 'mcp:discover mcp:jobs:read mcp:logs:read',
+  scopes:
+    'mcp:discover mcp:jobs:read mcp:logs:read mcp:failures:read mcp:diagnostics:read',
+}
+
+const diagnosticsSession: McpSession = {
+  ...baseSession,
+  scopes:
+    'mcp:discover mcp:diagnostics:read mcp:jobs:read mcp:logs:read mcp:failures:read',
 }
 
 const delegatedPrincipal: McpPrincipal = {
@@ -37,5 +44,40 @@ describe('evaluateMcpToolPolicy', () => {
     expect(decision.granted).toBe(false)
     expect(decision.denialReason).toBe('policy_configuration_missing')
     expect(decision.requiredScopes).toEqual([])
+  })
+
+  it('maps diagnostic tools to failures and diagnostics scopes', async () => {
+    const failuresDecision = await evaluateMcpToolPolicy({
+      correlationId: 'corr-2',
+      principal: delegatedPrincipal,
+      session: baseSession,
+      call: {
+        toolName: 'get_failure_events',
+        arguments: {},
+        connectionId: null,
+      },
+    })
+
+    expect(failuresDecision.requiredScopes).toEqual(['mcp:failures:read'])
+    expect(failuresDecision.granted).toBe(true)
+
+    const diagnosticsDecision = await evaluateMcpToolPolicy({
+      correlationId: 'corr-3',
+      principal: delegatedPrincipal,
+      session: diagnosticsSession,
+      call: {
+        toolName: 'explain_job_failure',
+        arguments: {},
+        connectionId: null,
+      },
+    })
+
+    expect(diagnosticsDecision.requiredScopes).toEqual([
+      'mcp:diagnostics:read',
+      'mcp:jobs:read',
+      'mcp:logs:read',
+      'mcp:failures:read',
+    ])
+    expect(diagnosticsDecision.granted).toBe(true)
   })
 })

--- a/apps/api/src/mcp/policy/policy-engine.ts
+++ b/apps/api/src/mcp/policy/policy-engine.ts
@@ -12,6 +12,15 @@ const TOOL_REQUIRED_SCOPES: Record<string, string[]> = {
   get_job: ['mcp:jobs:read'],
   get_job_logs: ['mcp:logs:read'],
   get_job_stacktraces: ['mcp:logs:read'],
+  get_failure_events: ['mcp:failures:read'],
+  get_queue_metrics: ['mcp:diagnostics:read'],
+  get_workers: ['mcp:jobs:read'],
+  explain_job_failure: [
+    'mcp:diagnostics:read',
+    'mcp:jobs:read',
+    'mcp:logs:read',
+    'mcp:failures:read',
+  ],
 }
 
 function parseScopes(scopeString: string): string[] {
@@ -90,11 +99,13 @@ export async function evaluateMcpToolPolicy(input: {
 
   if (input.principal.type === 'service_account') {
     const policyBindings = await mcpPolicyRepository.listPolicyBindings('service_account', input.principal.serviceAccountId)
-    const hasPolicyBinding = policyBindings.some(
-      (binding) =>
-        requiredScopes.includes(binding.scope) &&
-        (binding.toolName === null || binding.toolName === input.call.toolName) &&
-        (binding.organizationId === null || binding.organizationId === input.principal.organizationId)
+    const hasPolicyBinding = requiredScopes.every((scope) =>
+      policyBindings.some(
+        (binding) =>
+          binding.scope === scope &&
+          (binding.toolName === null || binding.toolName === input.call.toolName) &&
+          (binding.organizationId === null || binding.organizationId === input.principal.organizationId)
+      )
     )
 
     if (!hasPolicyBinding) {

--- a/apps/api/src/mcp/tools/explain-job-failure-handler.test.ts
+++ b/apps/api/src/mcp/tools/explain-job-failure-handler.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createExplainJobFailureHandler } from './explain-job-failure-handler'
+import { McpToolError } from './shared'
+
+const principal = {
+  type: 'service_account' as const,
+  principalId: 'principal-1',
+  organizationId: 'org-1',
+}
+
+const connection = {
+  id: 'conn-1',
+  organizationId: 'org-1',
+  url: 'redis://localhost:6379',
+  prefix: 'bull',
+  allowSelfSignedCerts: false,
+}
+
+describe('explain_job_failure handler', () => {
+  it('composes a high-confidence summary for failed jobs', async () => {
+    const explainJobFailureHandler = createExplainJobFailureHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return {
+              id: 'job-1',
+              failedReason: 'SMTP connection refused',
+              stacktrace: ['Error: SMTP connection refused\n    at send()'],
+              attemptsMade: 2,
+              opts: { attempts: 3 },
+              processedOn: 100,
+              finishedOn: 200,
+              timestamp: 50,
+              async getState() {
+                return 'failed'
+              },
+            }
+          },
+          async getJobLogs() {
+            return { logs: ['connecting to smtp'], count: 1 }
+          },
+        } as never
+      },
+      async findAlertEvents() {
+        return [
+          {
+            id: 'event-1',
+            alertRuleId: 'rule-1',
+            queueName: 'email',
+            type: 'job_failed',
+            status: 'firing',
+            summary: 'Job failed in email queue',
+            firedAt: new Date('2026-05-27T00:00:00.000Z'),
+            resolvedAt: null,
+            context: { jobId: 'job-1', secret: 'hidden' },
+          },
+        ] as never
+      },
+      async countAlertEvents() {
+        return 1
+      },
+    })
+
+    const result = await explainJobFailureHandler({
+      principal,
+      connectionId: 'conn-1',
+      queueName: 'email',
+      jobId: 'job-1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.confidence).toBe('high')
+    expect(result.topSignal.source).toBe('failed_reason')
+    expect(result.relatedAlertEvents).toHaveLength(1)
+    expect(result.relatedAlertEvents[0]?.context).toEqual({ jobId: 'job-1' })
+    expect(result.summary).toContain('SMTP connection refused')
+  })
+
+  it('returns low confidence when the job is not failed', async () => {
+    const explainJobFailureHandler = createExplainJobFailureHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return {
+              id: 'job-1',
+              failedReason: null,
+              stacktrace: [],
+              attemptsMade: 0,
+              opts: { attempts: 1 },
+              processedOn: null,
+              finishedOn: null,
+              timestamp: 1,
+              async getState() {
+                return 'completed'
+              },
+            }
+          },
+          async getJobLogs() {
+            return { logs: [], count: 0 }
+          },
+        } as never
+      },
+      async findAlertEvents() {
+        return []
+      },
+      async countAlertEvents() {
+        return 0
+      },
+    })
+
+    const result = await explainJobFailureHandler({
+      principal,
+      connectionId: 'conn-1',
+      queueName: 'email',
+      jobId: 'job-1',
+    })
+
+    expect(result.confidence).toBe('low')
+    expect(result.summary).toContain('not failed')
+    expect(result.failedReason).toBeNull()
+    expect(result.relatedAlertEvents).toHaveLength(0)
+    expect(result.topSignal.source).toBe('none')
+  })
+
+  it('reads the tail of job logs when choosing a log-based failure signal', async () => {
+    const logCalls: Array<{ start: number; end: number }> = []
+    const explainJobFailureHandler = createExplainJobFailureHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return {
+              id: 'job-1',
+              failedReason: null,
+              stacktrace: [],
+              attemptsMade: 1,
+              opts: { attempts: 1 },
+              processedOn: 100,
+              finishedOn: 200,
+              timestamp: 50,
+              async getState() {
+                return 'failed'
+              },
+            }
+          },
+          async getJobLogs(_jobId: string, start: number, end: number) {
+            logCalls.push({ start, end })
+            if (start === 0 && end === 0) {
+              return { logs: [], count: 10 }
+            }
+            return {
+              logs: ['line-6', 'line-7', 'line-8', 'line-9', 'line-10'],
+              count: 10,
+            }
+          },
+        } as never
+      },
+      async findAlertEvents() {
+        return []
+      },
+      async countAlertEvents() {
+        return 0
+      },
+    })
+
+    const result = await explainJobFailureHandler({
+      principal,
+      connectionId: 'conn-1',
+      queueName: 'email',
+      jobId: 'job-1',
+    })
+
+    expect(logCalls).toEqual([
+      { start: 0, end: 0 },
+      { start: 5, end: 9 },
+    ])
+    expect(result.topSignal.source).toBe('logs')
+    expect(result.topSignal.excerpt).toBe('line-10')
+    expect(result.recentLogLines).toEqual([
+      'line-6',
+      'line-7',
+      'line-8',
+      'line-9',
+      'line-10',
+    ])
+  })
+
+  it('throws not_found when the job is missing', async () => {
+    const explainJobFailureHandler = createExplainJobFailureHandler({
+      async requireConnectionForPrincipal() {
+        return connection as never
+      },
+      async getQueue() {
+        return {
+          async getJob() {
+            return null
+          },
+        } as never
+      },
+      async findAlertEvents() {
+        return []
+      },
+      async countAlertEvents() {
+        return 0
+      },
+    })
+
+    await expect(
+      explainJobFailureHandler({
+        principal,
+        connectionId: 'conn-1',
+        queueName: 'email',
+        jobId: 'missing',
+      })
+    ).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/apps/api/src/mcp/tools/explain-job-failure-handler.ts
+++ b/apps/api/src/mcp/tools/explain-job-failure-handler.ts
@@ -1,0 +1,205 @@
+import { alertEventRepository } from '@durabull/dal'
+import type {
+  ExplainJobFailureHandlerInput,
+  ExplainJobFailureHandlerOutput,
+} from '@durabull/mcp'
+
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import { McpToolError, requireConnectionForPrincipal } from './shared'
+import { sanitizeMcpText, toMcpAlertEventSummary } from './mcp-sanitize'
+
+interface ExplainJobFailureHandlerDeps {
+  getQueue: typeof getQueue
+  requireConnectionForPrincipal: typeof requireConnectionForPrincipal
+  findAlertEvents: typeof alertEventRepository.findByConnection
+  countAlertEvents: typeof alertEventRepository.countByConnection
+}
+
+const EXPLAIN_LOG_LINE_COUNT = 5
+
+function pickTopSignal(input: {
+  failedReason: string | null
+  stacktrace: string | null
+  logLines: string[]
+}): ExplainJobFailureHandlerOutput['topSignal'] {
+  const failedReason = sanitizeMcpText(input.failedReason)
+  if (failedReason) {
+    return {
+      source: 'failed_reason',
+      excerpt: failedReason,
+    }
+  }
+
+  const stacktrace = sanitizeMcpText(input.stacktrace)
+  if (stacktrace) {
+    return {
+      source: 'stacktrace',
+      excerpt: stacktrace,
+    }
+  }
+
+  const lastLog = [...input.logLines]
+    .reverse()
+    .map((line) => sanitizeMcpText(line))
+    .find((line): line is string => !!line)
+  if (lastLog) {
+    return {
+      source: 'logs',
+      excerpt: lastLog,
+    }
+  }
+
+  return {
+    source: 'none',
+    excerpt: 'No failure reason, stacktrace, or logs were available for this job.',
+  }
+}
+
+function buildSummary(input: {
+  queueName: string
+  jobId: string
+  status: string
+  failedReason: string | null
+  topSignal: ExplainJobFailureHandlerOutput['topSignal']
+  alertCount: number
+}): string {
+  if (input.status !== 'failed') {
+    return `Job ${input.jobId} in queue ${input.queueName} is currently "${input.status}", not failed.`
+  }
+
+  const signalLine =
+    input.topSignal.source === 'none'
+      ? 'No dominant failure signal was found in job metadata.'
+      : `Top signal (${input.topSignal.source}): ${input.topSignal.excerpt}`
+
+  const alertLine =
+    input.alertCount > 0
+      ? `${input.alertCount} related alert event(s) were found.`
+      : 'No related alert events were found.'
+
+  const reasonLine = input.failedReason
+    ? `BullMQ failedReason: ${input.failedReason}`
+    : 'BullMQ did not provide a failedReason.'
+
+  return sanitizeMcpText([reasonLine, signalLine, alertLine].join(' ')) ?? ''
+}
+
+export function createExplainJobFailureHandler(
+  deps: ExplainJobFailureHandlerDeps = {
+    getQueue,
+    requireConnectionForPrincipal,
+    findAlertEvents: alertEventRepository.findByConnection,
+    countAlertEvents: alertEventRepository.countByConnection,
+  }
+) {
+  return async function explainJobFailureHandler(
+    input: ExplainJobFailureHandlerInput
+  ): Promise<ExplainJobFailureHandlerOutput> {
+    const connection = await deps.requireConnectionForPrincipal(
+      input.principal,
+      input.connectionId
+    )
+
+    const queue = await deps.getQueue(
+      connection.id,
+      connection.url,
+      input.queueName,
+      connection.prefix,
+      toRedisConnectionOptions(connection.allowSelfSignedCerts)
+    )
+    const job = await queue.getJob(input.jobId)
+    if (!job) {
+      throw new McpToolError('not_found', `Job ${input.jobId} not found in queue ${input.queueName}.`)
+    }
+
+    const alertFilters = {
+      queueName: input.queueName,
+      jobId: input.jobId,
+    }
+
+    const [status, logProbe, alertEvents, relatedAlertCount] = await Promise.all([
+      job.getState(),
+      queue.getJobLogs(input.jobId, 0, 0),
+      deps.findAlertEvents(connection.id, connection.organizationId, {
+        offset: 0,
+        limit: 5,
+        ...alertFilters,
+      }),
+      deps.countAlertEvents(connection.id, connection.organizationId, alertFilters),
+    ])
+
+    const logCount = logProbe.count ?? logProbe.logs?.length ?? 0
+    const logStart = Math.max(0, logCount - EXPLAIN_LOG_LINE_COUNT)
+    const logEnd = Math.max(0, logCount - 1)
+    const logs =
+      logCount === 0
+        ? logProbe
+        : await queue.getJobLogs(input.jobId, logStart, logEnd)
+
+    const logLines = (logs.logs ?? [])
+      .map((line) => sanitizeMcpText(line))
+      .filter((line): line is string => !!line)
+
+    const isFailed = status === 'failed'
+    const failedReason = isFailed ? sanitizeMcpText(job.failedReason ?? null) : null
+    const stacktraces = isFailed ? (job.stacktrace ?? []) : []
+    const latestStacktrace =
+      stacktraces.length > 0 ? sanitizeMcpText(stacktraces[stacktraces.length - 1] ?? null) : null
+
+    const topSignal = isFailed
+      ? pickTopSignal({
+          failedReason,
+          stacktrace: latestStacktrace,
+          logLines,
+        })
+      : {
+          source: 'none' as const,
+          excerpt: 'Job is not in failed state.',
+        }
+
+    const confidence: ExplainJobFailureHandlerOutput['confidence'] = !isFailed
+      ? 'low'
+      : topSignal.source === 'failed_reason' || topSignal.source === 'stacktrace'
+        ? 'high'
+        : topSignal.source === 'logs'
+          ? 'medium'
+          : 'low'
+
+    const relatedAlertEvents = isFailed
+      ? alertEvents.map((event) => toMcpAlertEventSummary(event))
+      : []
+
+    return {
+      connectionId: connection.id,
+      queueName: input.queueName,
+      jobId: input.jobId,
+      status,
+      summary: buildSummary({
+        queueName: input.queueName,
+        jobId: input.jobId,
+        status,
+        failedReason,
+        topSignal,
+        alertCount: relatedAlertCount,
+      }),
+      failedReason,
+      attemptTimeline: {
+        attemptsMade: job.attemptsMade,
+        maxAttempts: job.opts.attempts ?? 1,
+        processedOn: job.processedOn ?? null,
+        finishedOn: job.finishedOn ?? null,
+        timestamp: job.timestamp ?? null,
+      },
+      topSignal,
+      relatedAlertEvents,
+      recentLogLines: isFailed ? logLines.slice(-EXPLAIN_LOG_LINE_COUNT) : [],
+      confidence,
+      sources: isFailed
+        ? ['job.failedReason', 'job.stacktrace', 'queue.getJobLogs', 'alert_event']
+        : ['job.state'],
+    }
+  }
+}
+
+export const explainJobFailureHandler = createExplainJobFailureHandler()

--- a/apps/api/src/mcp/tools/get-failure-events-handler.ts
+++ b/apps/api/src/mcp/tools/get-failure-events-handler.ts
@@ -1,0 +1,40 @@
+import { alertEventRepository } from '@durabull/dal'
+import type {
+  GetFailureEventsHandlerInput,
+  GetFailureEventsHandlerOutput,
+} from '@durabull/mcp'
+
+import { parseOffsetPageSize, requireConnectionForPrincipal } from './shared'
+import { toMcpAlertEventSummary } from './mcp-sanitize'
+
+export async function getFailureEventsHandler(
+  input: GetFailureEventsHandlerInput
+): Promise<GetFailureEventsHandlerOutput> {
+  const connection = await requireConnectionForPrincipal(input.principal, input.connectionId)
+  const { offset, limit } = parseOffsetPageSize(input.cursor, input.pageSize)
+
+  const filters = {
+    status: input.status,
+    queueName: input.queueName,
+    jobId: input.jobId,
+  }
+
+  const [total, events] = await Promise.all([
+    alertEventRepository.countByConnection(connection.id, connection.organizationId, filters),
+    alertEventRepository.findByConnection(connection.id, connection.organizationId, {
+      ...filters,
+      offset,
+      limit,
+    }),
+  ])
+
+  const nextOffset = offset + events.length
+  const nextCursor = nextOffset < total ? String(nextOffset) : null
+
+  return {
+    connectionId: connection.id,
+    total,
+    events: events.map((event) => toMcpAlertEventSummary(event)),
+    nextCursor,
+  }
+}

--- a/apps/api/src/mcp/tools/get-queue-metrics-handler.ts
+++ b/apps/api/src/mcp/tools/get-queue-metrics-handler.ts
@@ -1,0 +1,51 @@
+import { redisDiscoveredQueueRepository } from '@durabull/dal'
+import type { GetQueueMetricsHandlerInput, GetQueueMetricsHandlerOutput } from '@durabull/mcp'
+
+import {
+  collectQueueMcpMetricsSummary,
+  DEFAULT_METRICS_WINDOW_MINUTES,
+  MCP_MAX_METRICS_WINDOW_MINUTES,
+} from '../../lib/bullmq-metrics'
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import { McpToolError, requireConnectionForPrincipal } from './shared'
+
+export async function getQueueMetricsHandler(
+  input: GetQueueMetricsHandlerInput
+): Promise<GetQueueMetricsHandlerOutput> {
+  const connection = await requireConnectionForPrincipal(input.principal, input.connectionId)
+
+  const indexedQueue = await redisDiscoveredQueueRepository.findByConnectionAndName(
+    connection.id,
+    input.queueName
+  )
+  if (!indexedQueue) {
+    throw new McpToolError('not_found', `Queue ${input.queueName} not found.`)
+  }
+
+  const requestedWindowMinutes =
+    typeof input.windowMinutes === 'number' && Number.isFinite(input.windowMinutes)
+      ? Math.min(
+          Math.max(Math.floor(input.windowMinutes), 1),
+          MCP_MAX_METRICS_WINDOW_MINUTES
+        )
+      : DEFAULT_METRICS_WINDOW_MINUTES
+
+  const queue = await getQueue(
+    connection.id,
+    connection.url,
+    input.queueName,
+    connection.prefix,
+    toRedisConnectionOptions(connection.allowSelfSignedCerts)
+  )
+
+  const metrics = await collectQueueMcpMetricsSummary(queue, {
+    queueName: input.queueName,
+    windowMinutes: requestedWindowMinutes,
+  })
+
+  return {
+    connectionId: connection.id,
+    ...metrics,
+  }
+}

--- a/apps/api/src/mcp/tools/get-workers-handler.ts
+++ b/apps/api/src/mcp/tools/get-workers-handler.ts
@@ -1,0 +1,133 @@
+import { redisDiscoveredQueueRepository } from '@durabull/dal'
+import type { GetWorkersHandlerInput, GetWorkersHandlerOutput } from '@durabull/mcp'
+
+import { getQueue } from '../../lib/redis'
+import { toRedisConnectionOptions } from '../../lib/connection-options'
+import {
+  encodeWorkersCursor,
+  McpToolError,
+  parseWorkersCursor,
+  requireConnectionForPrincipal,
+} from './shared'
+
+/** Max queues scanned in one get_workers call when queueName is omitted. */
+const MAX_QUEUES_SCANNED_PER_REQUEST = 50
+
+export async function getWorkersHandler(
+  input: GetWorkersHandlerInput
+): Promise<GetWorkersHandlerOutput> {
+  const connection = await requireConnectionForPrincipal(input.principal, input.connectionId)
+  const pageSize = Math.min(100, Math.max(1, input.pageSize))
+  let { queueIndex, workerOffset } = parseWorkersCursor(input.cursor)
+
+  const redisOptions = toRedisConnectionOptions(connection.allowSelfSignedCerts)
+
+  const totalQueues = input.queueName
+    ? 1
+    : await redisDiscoveredQueueRepository.countByConnection(connection.id)
+
+  const workers: GetWorkersHandlerOutput['workers'] = []
+  const queues: GetWorkersHandlerOutput['queues'] = []
+  let hasMore = false
+  let queuesScanned = 0
+
+  while (workers.length < pageSize && queueIndex < totalQueues) {
+    if (!input.queueName && workerOffset === 0) {
+      if (queuesScanned >= MAX_QUEUES_SCANNED_PER_REQUEST) {
+        hasMore = true
+        break
+      }
+      queuesScanned += 1
+    }
+    let queueName: string
+    if (input.queueName) {
+      if (queueIndex > 0) {
+        break
+      }
+      const indexedQueue = await redisDiscoveredQueueRepository.findByConnectionAndName(
+        connection.id,
+        input.queueName
+      )
+      if (!indexedQueue) {
+        throw new McpToolError('not_found', `Queue ${input.queueName} not found.`)
+      }
+      queueName = indexedQueue.name
+    } else {
+      const indexedQueues = await redisDiscoveredQueueRepository.listByConnection(connection.id, {
+        offset: queueIndex,
+        limit: 1,
+      })
+      if (indexedQueues.length === 0) {
+        break
+      }
+      queueName = indexedQueues[0].name
+    }
+
+    const queue = await getQueue(
+      connection.id,
+      connection.url,
+      queueName,
+      connection.prefix,
+      redisOptions
+    )
+    let queueWorkers: Array<Record<string, string>>
+    try {
+      queueWorkers = await queue.getWorkers()
+    } catch {
+      throw new McpToolError('internal_error', `Could not fetch workers for queue ${queueName}.`)
+    }
+
+    const [isPaused, counts] = await Promise.all([queue.isPaused(), queue.getJobCounts()])
+
+    const sortedWorkers = [...queueWorkers].sort((left, right) =>
+      String(left.id ?? '').localeCompare(String(right.id ?? ''))
+    )
+
+    for (let index = workerOffset; index < sortedWorkers.length; index += 1) {
+      if (workers.length >= pageSize) {
+        hasMore = true
+        workerOffset = index
+        break
+      }
+
+      const worker = sortedWorkers[index]
+      workers.push({
+        id: worker.id ?? '',
+        name: worker.name ?? '',
+        address: worker.addr ?? '',
+        ageMs: Number(worker.age ?? 0) || 0,
+        idleMs: Number(worker.idle ?? 0) || 0,
+        queueName,
+      })
+    }
+
+    if (!hasMore) {
+      queues.push({
+        name: queueName,
+        workerCount: sortedWorkers.length,
+        status: isPaused ? 'paused' : 'active',
+        jobCounts: {
+          active: counts.active ?? 0,
+          waiting: counts.waiting ?? 0,
+        },
+      })
+      queueIndex += 1
+      workerOffset = 0
+    }
+  }
+
+  if (queueIndex < totalQueues || hasMore) {
+    hasMore = true
+  }
+
+  const nextCursor = hasMore ? encodeWorkersCursor(queueIndex, workerOffset) : null
+
+  return {
+    connectionId: connection.id,
+    totalQueues,
+    totalWorkersInPage: workers.length,
+    workers,
+    queues,
+    nextCursor,
+  }
+}

--- a/apps/api/src/mcp/tools/mcp-sanitize.ts
+++ b/apps/api/src/mcp/tools/mcp-sanitize.ts
@@ -1,0 +1,96 @@
+const SENSITIVE_KEY = /(secret|password|token|authorization|api[_-]?key|credential|redis|url)/i
+const REDIS_URL_PATTERN = /redis(s)?:\/\/[^\s]+/gi
+const MAX_MCP_TEXT_LENGTH = 500
+const MAX_CONTEXT_DEPTH = 4
+const MAX_CONTEXT_ARRAY_ITEMS = 50
+const MAX_CONTEXT_STRING_LENGTH = 512
+
+export function truncateMcpText(value: string, maxLength = MAX_MCP_TEXT_LENGTH): string {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, maxLength)}…`
+}
+
+export function sanitizeMcpText(value: string | null | undefined): string | null {
+  if (value == null) return null
+  const redacted = value.replace(REDIS_URL_PATTERN, '[redacted]').trim()
+  if (!redacted) return null
+  return truncateMcpText(redacted)
+}
+
+export function sanitizeAlertEventContext(
+  context: unknown,
+  depth = 0
+): Record<string, unknown> | null {
+  if (context == null || depth > MAX_CONTEXT_DEPTH) {
+    return null
+  }
+
+  if (Array.isArray(context)) {
+    const items = context
+      .slice(0, MAX_CONTEXT_ARRAY_ITEMS)
+      .map((item) => sanitizeAlertContextValue(item, depth + 1))
+      .filter((item) => item !== undefined)
+    return items.length > 0 ? { items } : null
+  }
+
+  if (typeof context !== 'object') {
+    return null
+  }
+
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(context as Record<string, unknown>)) {
+    if (SENSITIVE_KEY.test(key)) {
+      continue
+    }
+    const next = sanitizeAlertContextValue(value, depth + 1)
+    if (next !== undefined) {
+      sanitized[key] = next
+    }
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : null
+}
+
+function sanitizeAlertContextValue(value: unknown, depth: number): unknown | undefined {
+  if (value == null) return value
+  if (typeof value === 'string') {
+    const redacted = value.replace(REDIS_URL_PATTERN, '[redacted]')
+    return truncateMcpText(redacted, MAX_CONTEXT_STRING_LENGTH)
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value
+  }
+  if (Array.isArray(value)) {
+    const nested = sanitizeAlertEventContext(value, depth)
+    return nested ?? undefined
+  }
+  if (typeof value === 'object') {
+    const nested = sanitizeAlertEventContext(value, depth)
+    return nested ?? undefined
+  }
+  return undefined
+}
+
+export function toMcpAlertEventSummary(event: {
+  id: string
+  alertRuleId: string
+  queueName: string
+  type: string
+  status: string
+  summary: string
+  firedAt: Date
+  resolvedAt: Date | null
+  context: unknown
+}) {
+  return {
+    id: event.id,
+    alertRuleId: event.alertRuleId,
+    queueName: event.queueName,
+    type: event.type,
+    status: event.status,
+    summary: sanitizeMcpText(event.summary) ?? '',
+    firedAt: event.firedAt.toISOString(),
+    resolvedAt: event.resolvedAt?.toISOString() ?? null,
+    context: sanitizeAlertEventContext(event.context),
+  }
+}

--- a/apps/api/src/mcp/tools/shared.ts
+++ b/apps/api/src/mcp/tools/shared.ts
@@ -1,5 +1,6 @@
 import { mcpPolicyRepository, redisConnectionRepository } from '@durabull/dal'
-import type { ListConnectionsHandlerInput } from '@durabull/mcp'
+import type { ListConnectionsHandlerInput, McpResolvedConnection } from '@durabull/mcp'
+import { getMcpRequestContext } from '@durabull/mcp'
 
 export type ToolPrincipal = ListConnectionsHandlerInput['principal']
 
@@ -13,9 +14,34 @@ export class McpToolError extends Error {
   }
 }
 
+function toResolvedConnection(connection: {
+  id: string
+  organizationId: string
+  url: string
+  prefix: string
+  allowSelfSignedCerts: boolean
+}): McpResolvedConnection {
+  return {
+    id: connection.id,
+    organizationId: connection.organizationId,
+    url: connection.url,
+    prefix: connection.prefix,
+    allowSelfSignedCerts: connection.allowSelfSignedCerts,
+  }
+}
+
 export async function resolveConnectionForPrincipal(principal: ToolPrincipal, connectionId: string) {
+  const cached = getMcpRequestContext()?.resolvedConnection
+  if (cached?.id === connectionId) {
+    return cached
+  }
+
   if (principal.type === 'service_account') {
-    return redisConnectionRepository.findById(connectionId, principal.organizationId)
+    const connection = await redisConnectionRepository.findById(
+      connectionId,
+      principal.organizationId
+    )
+    return connection ? toResolvedConnection(connection) : null
   }
 
   const hasAccess = await mcpPolicyRepository.canDelegatedUserAccessConnection(
@@ -25,7 +51,8 @@ export async function resolveConnectionForPrincipal(principal: ToolPrincipal, co
   if (!hasAccess) {
     return null
   }
-  return redisConnectionRepository.findByIdUnsafe(connectionId)
+  const connection = await redisConnectionRepository.findByIdUnsafe(connectionId)
+  return connection ? toResolvedConnection(connection) : null
 }
 
 export async function requireConnectionForPrincipal(
@@ -42,9 +69,72 @@ export async function requireConnectionForPrincipal(
 export function decodeCursor(cursor: string | undefined): number {
   if (!cursor) return 0
   const parsed = Number.parseInt(cursor, 10)
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new McpToolError('validation_error', 'Invalid cursor.')
+  }
+  return parsed
 }
 
 export function encodeCursor(offset: number): string {
   return String(offset)
+}
+
+export function parseOffsetPageSize(cursor: string | undefined, pageSize: number): {
+  offset: number
+  limit: number
+} {
+  return {
+    offset: decodeCursor(cursor),
+    limit: Math.min(100, Math.max(1, pageSize)),
+  }
+}
+
+export function parseWorkersCursor(cursor: string | undefined): {
+  queueIndex: number
+  workerOffset: number
+} {
+  if (!cursor) {
+    return { queueIndex: 0, workerOffset: 0 }
+  }
+
+  const [queuePart, workerPart] = cursor.split(':')
+  const queueIndex = Number.parseInt(queuePart ?? '', 10)
+  const workerOffset = Number.parseInt(workerPart ?? '', 10)
+  if (
+    !Number.isFinite(queueIndex) ||
+    queueIndex < 0 ||
+    !Number.isFinite(workerOffset) ||
+    workerOffset < 0
+  ) {
+    throw new McpToolError('validation_error', 'Invalid cursor.')
+  }
+
+  return { queueIndex, workerOffset }
+}
+
+export function encodeWorkersCursor(queueIndex: number, workerOffset: number): string {
+  return `${queueIndex}:${workerOffset}`
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  if (items.length === 0) return []
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  const workerCount = Math.min(Math.max(1, concurrency), items.length)
+
+  async function runWorker() {
+    while (true) {
+      const index = nextIndex
+      nextIndex += 1
+      if (index >= items.length) return
+      results[index] = await fn(items[index], index)
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()))
+  return results
 }

--- a/packages/dal/src/repositories/alert-event.ts
+++ b/packages/dal/src/repositories/alert-event.ts
@@ -9,6 +9,24 @@ function toNumber(value: number | string | bigint | null | undefined): number {
   return Number(value)
 }
 
+function buildAlertEventConnectionFilter(
+  connectionId: string,
+  organizationId: string,
+  options: {
+    status?: AlertEventStatus
+    queueName?: string
+    jobId?: string
+  }
+) {
+  return and(
+    eq(alertEvent.connectionId, connectionId),
+    eq(alertEvent.organizationId, organizationId),
+    ...(options.status ? [eq(alertEvent.status, options.status)] : []),
+    ...(options.queueName ? [eq(alertEvent.queueName, options.queueName)] : []),
+    ...(options.jobId ? [sql`${alertEvent.context}->>'jobId' = ${options.jobId}`] : [])
+  )
+}
+
 export const alertEventRepository = {
   async create(data: Omit<NewAlertEvent, 'id' | 'createdAt' | 'updatedAt'>): Promise<AlertEvent> {
     const db = await getDb()
@@ -91,6 +109,26 @@ export const alertEventRepository = {
     return rows[0] ?? null
   },
 
+  async countByConnection(
+    connectionId: string,
+    organizationId: string,
+    options: {
+      status?: AlertEventStatus
+      queueName?: string
+      jobId?: string
+    }
+  ): Promise<number> {
+    const db = await getDb()
+    const [row] = await db
+      .select({
+        total: sql<number>`count(*)`,
+      })
+      .from(alertEvent)
+      .where(buildAlertEventConnectionFilter(connectionId, organizationId, options))
+
+    return toNumber(row?.total)
+  },
+
   async findByConnection(
     connectionId: string,
     organizationId: string,
@@ -106,15 +144,7 @@ export const alertEventRepository = {
     return db
       .select()
       .from(alertEvent)
-      .where(
-        and(
-          eq(alertEvent.connectionId, connectionId),
-          eq(alertEvent.organizationId, organizationId),
-          ...(options.status ? [eq(alertEvent.status, options.status)] : []),
-          ...(options.queueName ? [eq(alertEvent.queueName, options.queueName)] : []),
-          ...(options.jobId ? [sql`${alertEvent.context}->>'jobId' = ${options.jobId}`] : [])
-        )
-      )
+      .where(buildAlertEventConnectionFilter(connectionId, organizationId, options))
       .orderBy(desc(alertEvent.firedAt))
       .offset(options.offset)
       .limit(options.limit)

--- a/packages/dal/src/repositories/redis-discovered-queue.ts
+++ b/packages/dal/src/repositories/redis-discovered-queue.ts
@@ -40,6 +40,22 @@ export const redisDiscoveredQueueRepository = {
       .offset(options.offset)
   },
 
+  async findByConnectionAndName(
+    connectionId: string,
+    name: string
+  ): Promise<RedisDiscoveredQueue | null> {
+    const db = await getDb()
+    const rows = await db
+      .select()
+      .from(redisDiscoveredQueue)
+      .where(
+        and(eq(redisDiscoveredQueue.connectionId, connectionId), eq(redisDiscoveredQueue.name, name))
+      )
+      .limit(1)
+
+    return rows[0] ?? null
+  },
+
   async countByConnection(connectionId: string): Promise<number> {
     const db = await getDb()
     const [row] = await db

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,13 +12,25 @@ export {
   MCP_SERVER_NAME,
 } from './constants'
 export { createMcpRoutes, type CreateMcpRoutesOptions } from './routes'
-export type { McpRequestContext, McpRequestPrincipal } from './request-context'
+export {
+  getMcpRequestContext,
+  runWithMcpRequestContext,
+} from './request-context'
+export type {
+  McpRequestContext,
+  McpRequestPrincipal,
+  McpResolvedConnection,
+} from './request-context'
 export {
   getCanonicalMcpResourceUri,
   getMcpProtectedResourceMetadataUrl,
   MCP_TRANSPORT_REQUIRED_SCOPES,
 } from './auth'
 export type {
+  ExplainJobFailureHandlerInput,
+  ExplainJobFailureHandlerOutput,
+  GetFailureEventsHandlerInput,
+  GetFailureEventsHandlerOutput,
   GetJobHandlerInput,
   GetJobHandlerOutput,
   GetJobLogsHandlerInput,
@@ -27,6 +39,10 @@ export type {
   GetJobStacktracesHandlerOutput,
   GetQueueHandlerInput,
   GetQueueHandlerOutput,
+  GetQueueMetricsHandlerInput,
+  GetQueueMetricsHandlerOutput,
+  GetWorkersHandlerInput,
+  GetWorkersHandlerOutput,
   ListConnectionsHandlerInput,
   ListConnectionsHandlerOutput,
   ListJobsHandlerInput,

--- a/packages/mcp/src/request-context.ts
+++ b/packages/mcp/src/request-context.ts
@@ -7,9 +7,19 @@ export interface McpRequestPrincipal {
   organizationId?: string
 }
 
+export interface McpResolvedConnection {
+  id: string
+  organizationId: string
+  url: string
+  prefix: string
+  allowSelfSignedCerts: boolean
+}
+
 export interface McpRequestContext {
   principal?: McpRequestPrincipal
   correlationId?: string
+  grantedScopes?: string[]
+  resolvedConnection?: McpResolvedConnection
 }
 
 const store = new AsyncLocalStorage<McpRequestContext>()

--- a/packages/mcp/src/routes.test.ts
+++ b/packages/mcp/src/routes.test.ts
@@ -281,16 +281,14 @@ describe('createMcpRoutes', () => {
     const payload = (await readMcpJsonResponse(callResponse)) as {
       result?: {
         isError?: boolean
-        structuredContent?: {
-          error?: {
-            code?: string
-            message?: string
-          }
-        }
+        content?: Array<{ type: string; text?: string }>
       }
     }
     expect(payload.result?.isError).toBe(true)
-    expect(payload.result?.structuredContent?.error?.code).toBe('not_found')
-    expect(payload.result?.structuredContent?.error?.message).toContain('Connection missing for test')
+    const errorPayload = JSON.parse(payload.result?.content?.[0]?.text ?? '{}') as {
+      error?: { code?: string; message?: string }
+    }
+    expect(errorPayload.error?.code).toBe('not_found')
+    expect(errorPayload.error?.message).toContain('Connection missing for test')
   })
 })

--- a/packages/mcp/src/tools/register-read-tools.ts
+++ b/packages/mcp/src/tools/register-read-tools.ts
@@ -197,6 +197,160 @@ export interface GetJobStacktracesHandlerOutput {
   nextCursor: string | null
 }
 
+export interface GetFailureEventsHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName?: string
+  jobId?: string
+  status?: 'firing' | 'resolved' | 'suppressed'
+  cursor?: string
+  pageSize: number
+}
+
+export interface GetFailureEventsHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  total: number
+  events: Array<{
+    id: string
+    alertRuleId: string
+    queueName: string
+    type: string
+    status: string
+    summary: string
+    context: Record<string, unknown> | null
+    firedAt: string
+    resolvedAt: string | null
+  }>
+  nextCursor: string | null
+}
+
+export interface GetQueueMetricsHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName: string
+  windowMinutes?: number
+}
+
+export interface GetQueueMetricsHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  queueName: string
+  range: {
+    requestedWindowMinutes: number | null
+    returnedPoints: number
+    oldestPointTimestamp: number | null
+    newestPointTimestamp: number | null
+    latestPointAgeMs: number | null
+    requestedWindowCoverage: number | null
+  }
+  totals: {
+    completedInWindow: number
+    failedInWindow: number
+    finishedInWindow: number
+    successRateInWindow: number
+    failureRateInWindow: number
+    avgCompletedPerMinuteInWindow: number
+    avgFailedPerMinuteInWindow: number
+    longestFailureStreakMinutesInWindow: number
+    longestCompletionStreakMinutesInWindow: number
+    completedLifetime: number
+    failedLifetime: number
+    failureRateLifetime: number
+    estimatedDrainMinutes: number | null
+  }
+  counts: {
+    waiting: number
+    active: number
+    delayed: number
+    completed: number
+    failed: number
+    paused: number
+    prioritized: number
+    waitingChildren: number
+  }
+  queue: {
+    isPaused: boolean
+    isMaxed: boolean
+    waitingToProcess: number
+    workersCount: number
+    schedulersCount: number
+  }
+  warnings: string[]
+}
+
+export interface GetWorkersHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName?: string
+  cursor?: string
+  pageSize: number
+}
+
+export interface GetWorkersHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  totalQueues: number
+  totalWorkersInPage: number
+  workers: Array<{
+    id: string
+    name: string
+    address: string
+    ageMs: number
+    idleMs: number
+    queueName: string
+  }>
+  queues: Array<{
+    name: string
+    workerCount: number
+    status: 'paused' | 'active'
+    jobCounts: {
+      active: number
+      waiting: number
+    }
+  }>
+  nextCursor: string | null
+}
+
+export interface ExplainJobFailureHandlerInput {
+  principal: ListConnectionsHandlerInput['principal']
+  connectionId: string
+  queueName: string
+  jobId: string
+}
+
+export interface ExplainJobFailureHandlerOutput {
+  [key: string]: unknown
+  connectionId: string
+  queueName: string
+  jobId: string
+  status: string
+  summary: string
+  failedReason: string | null
+  attemptTimeline: {
+    attemptsMade: number
+    maxAttempts: number
+    processedOn: number | null
+    finishedOn: number | null
+    timestamp: number | null
+  }
+  topSignal: {
+    source: 'failed_reason' | 'stacktrace' | 'logs' | 'none'
+    excerpt: string
+  }
+  relatedAlertEvents: Array<{
+    id: string
+    type: string
+    status: string
+    summary: string
+    firedAt: string
+    context: Record<string, unknown> | null
+  }>
+  recentLogLines: string[]
+  confidence: 'high' | 'medium' | 'low'
+  sources: string[]
+}
+
 export interface RegisterReadToolsOptions {
   listConnections?: (input: ListConnectionsHandlerInput) => Promise<ListConnectionsHandlerOutput>
   listQueues?: (input: ListQueuesHandlerInput) => Promise<ListQueuesHandlerOutput>
@@ -207,6 +361,12 @@ export interface RegisterReadToolsOptions {
   getJobStacktraces?: (
     input: GetJobStacktracesHandlerInput
   ) => Promise<GetJobStacktracesHandlerOutput>
+  getFailureEvents?: (input: GetFailureEventsHandlerInput) => Promise<GetFailureEventsHandlerOutput>
+  getQueueMetrics?: (input: GetQueueMetricsHandlerInput) => Promise<GetQueueMetricsHandlerOutput>
+  getWorkers?: (input: GetWorkersHandlerInput) => Promise<GetWorkersHandlerOutput>
+  explainJobFailure?: (
+    input: ExplainJobFailureHandlerInput
+  ) => Promise<ExplainJobFailureHandlerOutput>
 }
 
 function parsePageSize(raw: unknown): number {
@@ -256,16 +416,34 @@ function toToolError(error: unknown): { code: string; message: string } {
     typeof (error as { code: unknown }).code === 'string'
   ) {
     const code = (error as { code: string }).code
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : KNOWN_CODES.has(code)
+          ? code
+          : INTERNAL_ERROR_MESSAGE
     return {
       code: KNOWN_CODES.has(code) ? code : 'internal_error',
-      message:
-        KNOWN_CODES.has(code) && error instanceof Error ? error.message : INTERNAL_ERROR_MESSAGE,
+      message: KNOWN_CODES.has(code) ? message : INTERNAL_ERROR_MESSAGE,
     }
   }
 
   return {
     code: 'internal_error',
     message: INTERNAL_ERROR_MESSAGE,
+  }
+}
+
+function mcpToolSuccess(result: Record<string, unknown>) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+  }
+}
+
+function mcpToolFailure(toolError: { code: string; message: string }) {
+  return {
+    isError: true,
+    content: [{ type: 'text' as const, text: JSON.stringify({ error: toolError }) }],
   }
 }
 
@@ -287,17 +465,10 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          }
+          return mcpToolSuccess(result)
         } catch (error) {
           const toolError = toToolError(error)
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
-            structuredContent: { error: toolError },
-          }
+          return mcpToolFailure(toolError)
         }
       }
     )
@@ -320,17 +491,10 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          }
+          return mcpToolSuccess(result)
         } catch (error) {
           const toolError = toToolError(error)
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
-            structuredContent: { error: toolError },
-          }
+          return mcpToolFailure(toolError)
         }
       }
     )
@@ -351,17 +515,10 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             connectionId: args.connectionId,
             queueName: args.queueName,
           })
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          }
+          return mcpToolSuccess(result)
         } catch (error) {
           const toolError = toToolError(error)
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
-            structuredContent: { error: toolError },
-          }
+          return mcpToolFailure(toolError)
         }
       }
     )
@@ -392,17 +549,10 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          }
+          return mcpToolSuccess(result)
         } catch (error) {
           const toolError = toToolError(error)
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
-            structuredContent: { error: toolError },
-          }
+          return mcpToolFailure(toolError)
         }
       }
     )
@@ -425,17 +575,10 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             queueName: args.queueName,
             jobId: args.jobId,
           })
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          }
+          return mcpToolSuccess(result)
         } catch (error) {
           const toolError = toToolError(error)
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
-            structuredContent: { error: toolError },
-          }
+          return mcpToolFailure(toolError)
         }
       }
     )
@@ -462,17 +605,10 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          }
+          return mcpToolSuccess(result)
         } catch (error) {
           const toolError = toToolError(error)
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
-            structuredContent: { error: toolError },
-          }
+          return mcpToolFailure(toolError)
         }
       }
     )
@@ -499,17 +635,122 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          }
+          return mcpToolSuccess(result)
         } catch (error) {
           const toolError = toToolError(error)
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: toolError }) }],
-            structuredContent: { error: toolError },
-          }
+          return mcpToolFailure(toolError)
+        }
+      }
+    )
+  }
+
+  const getFailureEvents = options.getFailureEvents
+  if (getFailureEvents) {
+    server.tool(
+      'get_failure_events',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1).optional(),
+        jobId: z.string().min(1).optional(),
+        status: z.enum(['firing', 'resolved', 'suppressed']).optional(),
+        cursor: z.string().optional(),
+        pageSize: z.number().int().min(1).max(100).optional(),
+      },
+      async (args) => {
+        try {
+          const result = await getFailureEvents({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            jobId: args.jobId,
+            status: args.status,
+            cursor: parseCursor(args.cursor),
+            pageSize: parsePageSize(args.pageSize),
+          })
+          return mcpToolSuccess(result)
+        } catch (error) {
+          const toolError = toToolError(error)
+          return mcpToolFailure(toolError)
+        }
+      }
+    )
+  }
+
+  const getQueueMetrics = options.getQueueMetrics
+  if (getQueueMetrics) {
+    server.tool(
+      'get_queue_metrics',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1),
+        windowMinutes: z.number().int().min(1).max(1440).optional(),
+      },
+      async (args) => {
+        try {
+          const result = await getQueueMetrics({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            windowMinutes: args.windowMinutes,
+          })
+          return mcpToolSuccess(result)
+        } catch (error) {
+          const toolError = toToolError(error)
+          return mcpToolFailure(toolError)
+        }
+      }
+    )
+  }
+
+  const getWorkers = options.getWorkers
+  if (getWorkers) {
+    server.tool(
+      'get_workers',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1).optional(),
+        cursor: z.string().optional(),
+        pageSize: z.number().int().min(1).max(100).optional(),
+      },
+      async (args) => {
+        try {
+          const result = await getWorkers({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            cursor: parseCursor(args.cursor),
+            pageSize: parsePageSize(args.pageSize),
+          })
+          return mcpToolSuccess(result)
+        } catch (error) {
+          const toolError = toToolError(error)
+          return mcpToolFailure(toolError)
+        }
+      }
+    )
+  }
+
+  const explainJobFailure = options.explainJobFailure
+  if (explainJobFailure) {
+    server.tool(
+      'explain_job_failure',
+      {
+        connectionId: z.string().min(1),
+        queueName: z.string().min(1),
+        jobId: z.string().min(1),
+      },
+      async (args) => {
+        try {
+          const result = await explainJobFailure({
+            principal: getPrincipalFromContext(),
+            connectionId: args.connectionId,
+            queueName: args.queueName,
+            jobId: args.jobId,
+          })
+          return mcpToolSuccess(result)
+        } catch (error) {
+          const toolError = toToolError(error)
+          return mcpToolFailure(toolError)
         }
       }
     )

--- a/tasks/mcp-pr-execution-playbook.md
+++ b/tasks/mcp-pr-execution-playbook.md
@@ -849,15 +849,23 @@ Finalize production quality and confirm spec/safety compliance.
 
 #### Handoff To Next PR
 
-- Next PR: `PR-05` continuation (remaining tool catalog)
+- Next PR: `PR-06` (safety hardening)
 - Known risks:
-  - partial read catalog shipped; remaining diagnostic endpoints still pending (`get_failure_events`, `get_queue_metrics`, `get_workers`, `explain_job_failure`).
+  - MCP output redaction is minimal (alert context key filtering only); full sanitizer lands in PR-06.
 - Follow-up tasks:
-  - add per-tool schemas/contract tests for remaining read tools.
-  - validate pagination/limits on log and stacktrace-heavy tools.
+  - land remaining tools on `feat/mcp-pr05-remaining-read-tools` (`get_failure_events`, `get_queue_metrics`, `get_workers`, `explain_job_failure`).
 - Notes for next agent:
   - keep all MCP tools read-only and route through existing policy middleware.
   - preserve request-context bridge; do not bypass principal/policy/audit path when adding tools.
+
+#### PR-05 continuation (`feat/mcp-pr05-remaining-read-tools`)
+
+- [x] `get_failure_events` (`mcp:failures:read`) with paginated alert events + sanitized context.
+- [x] `get_queue_metrics` (`mcp:diagnostics:read`) with bounded summary (no Prometheus/raw series export).
+- [x] `get_workers` (`mcp:jobs:read`) with queue-scoped worker snapshots.
+- [x] `explain_job_failure` (`mcp:diagnostics:read`) deterministic composed summary.
+- [x] Policy scope mappings + `tools/list` integration tests updated.
+- [x] Unit tests: `explain-job-failure-handler.test.ts`, policy scope mapping test.
 
 ---
 
@@ -866,8 +874,8 @@ Finalize production quality and confirm spec/safety compliance.
 - [ ] PR-01 Security architecture baseline (folded into PR-04 completion work)
 - [x] PR-02 API `/mcp` ingress + transport (`@durabull/mcp` package + thin API mount)
 - [x] PR-03 OAuth discovery + token validation (merged — PR #89)
-- [ ] PR-04 Principals + policy engine (in progress on `feat/no-linear-mcp-pr04-principals-policy-engine`)
-- [ ] PR-05 Read-only diagnostic tools (in progress: first 7 tools + remaining catalog)
+- [x] PR-04 Principals + policy engine (merged — PR #94)
+- [ ] PR-05 Read-only diagnostic tools (complete on branch `feat/mcp-pr05-remaining-read-tools`; pending merge)
 - [ ] PR-06 Safety hardening
 - [ ] PR-07 Deployment + operations
 - [ ] PR-08 GA readiness + security closure

--- a/tooling/scripts/mcp-live-final-proof.ts
+++ b/tooling/scripts/mcp-live-final-proof.ts
@@ -2,6 +2,8 @@
 import '@durabull/env'
 
 import {
+  alertEventRepository,
+  alertRuleRepository,
   getDb,
   mcpPolicyBinding,
   mcpServiceAccount,
@@ -228,6 +230,28 @@ async function main() {
       createdAt: now,
       updatedAt: now,
     },
+    {
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: null,
+      scope: 'mcp:failures:read',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      principalType: 'service_account',
+      principalId: serviceAccount.id,
+      organizationId: orgId,
+      toolName: null,
+      scope: 'mcp:diagnostics:read',
+      disabled: false,
+      createdAt: now,
+      updatedAt: now,
+    },
   ])
 
   const accessExp = new Date(Date.now() + 60 * 60 * 1000)
@@ -245,7 +269,7 @@ async function main() {
       refreshTokenExpiresAt: accessExp,
       clientId: delegatedClientId,
       userId,
-      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read',
+      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read mcp:failures:read mcp:diagnostics:read',
       resource,
       createdAt: now,
       updatedAt: now,
@@ -271,7 +295,7 @@ async function main() {
       refreshTokenExpiresAt: accessExp,
       clientId: serviceClientId,
       userId: null,
-      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read',
+      scopes: 'mcp:discover mcp:jobs:read mcp:logs:read mcp:failures:read mcp:diagnostics:read',
       resource,
       createdAt: now,
       updatedAt: now,
@@ -337,6 +361,37 @@ async function main() {
   const jobId = String(createdJob.id)
   add('Live queue/job setup', !!jobId, `connection=${connection.id}, queue=${queueName}, job=${jobId}`)
 
+  const alertRule = await alertRuleRepository.create({
+    organizationId: orgId,
+    connectionId: connection.id,
+    name: `mcp-live-rule-${suffix}`,
+    type: 'job_failed',
+    config: { notifyOnEveryFailure: true },
+    enabled: true,
+    notificationChannels: [],
+    cooldownMinutes: 30,
+    queueName,
+    queueFilterMode: null,
+    filterQueueNames: [],
+  })
+  const alertEvent = await alertEventRepository.create({
+    alertRuleId: alertRule.id,
+    organizationId: orgId,
+    connectionId: connection.id,
+    queueName,
+    type: 'job_failed',
+    status: 'firing',
+    summary: `Live MCP failure for job ${jobId}`,
+    context: { jobId, marker: `payload-${suffix}` },
+    dedupeKey: `mcp-live-dedupe-${suffix}`,
+    firedAt: now,
+  })
+  add(
+    'Alert fixture seeded',
+    alertEvent.id.length > 0,
+    `rule=${alertRule.id}, event=${alertEvent.id}`
+  )
+
   const delegatedInit = await initialize(baseUrl, delegatedFullToken)
   add(
     'Delegated initialize',
@@ -385,6 +440,10 @@ async function main() {
     'get_job',
     'get_job_logs',
     'get_job_stacktraces',
+    'get_failure_events',
+    'get_queue_metrics',
+    'get_workers',
+    'explain_job_failure',
   ]
   add(
     'tools/list exposes all MCP tools',
@@ -514,6 +573,109 @@ async function main() {
     getStacktraces.res.ok &&
       getStacktracesJson.stacktraces.some((row) => row.stacktrace.includes(`live-failure-${suffix}`)),
     `status=${getStacktraces.res.status}, traces=${getStacktracesJson.stacktraces.length}`
+  )
+
+  const getFailureEvents = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'get_failure_events',
+    {
+      connectionId: connection.id,
+      queueName,
+      jobId,
+      pageSize: 10,
+    }
+  )
+  const getFailureEventsJson = JSON.parse(
+    getFailureEvents.body?.result?.content?.[0]?.text ?? '{"events":[]}'
+  ) as { events: Array<{ id: string; summary: string; context: Record<string, unknown> | null }> }
+  add(
+    'get_failure_events',
+    getFailureEvents.res.ok &&
+      getFailureEventsJson.events.some((row) => row.id === alertEvent.id) &&
+      getFailureEventsJson.events.some((row) => row.context?.jobId === jobId),
+    `status=${getFailureEvents.res.status}, events=${getFailureEventsJson.events.length}`
+  )
+
+  const getQueueMetrics = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'get_queue_metrics',
+    {
+      connectionId: connection.id,
+      queueName,
+      windowMinutes: 60,
+    }
+  )
+  const getQueueMetricsJson = JSON.parse(
+    getQueueMetrics.body?.result?.content?.[0]?.text ?? '{"queueName":""}'
+  ) as {
+    queueName?: string
+    totals?: { failedInWindow?: number }
+    counts?: { failed?: number }
+    queue?: { workersCount?: number }
+  }
+  add(
+    'get_queue_metrics',
+    getQueueMetrics.res.ok &&
+      getQueueMetricsJson.queueName === queueName &&
+      typeof getQueueMetricsJson.totals?.failedInWindow === 'number' &&
+      typeof getQueueMetricsJson.counts?.failed === 'number',
+    `status=${getQueueMetrics.res.status}, failedInWindow=${getQueueMetricsJson.totals?.failedInWindow}, queueFailed=${getQueueMetricsJson.counts?.failed}`
+  )
+
+  const getWorkers = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'get_workers',
+    {
+      connectionId: connection.id,
+      queueName,
+      pageSize: 10,
+    }
+  )
+  const getWorkersJson = JSON.parse(
+    getWorkers.body?.result?.content?.[0]?.text ?? '{"workers":[]}'
+  ) as { workers: Array<{ queueName: string; id: string }>; queues: Array<{ name: string }> }
+  add(
+    'get_workers',
+    getWorkers.res.ok &&
+      getWorkersJson.workers.some((row) => row.queueName === queueName) &&
+      getWorkersJson.queues.some((row) => row.name === queueName) &&
+      (getWorkersJson.totalWorkersInPage ?? getWorkersJson.totalWorkers ?? 0) > 0,
+    `status=${getWorkers.res.status}, workers=${getWorkersJson.workers.length}`
+  )
+
+  const explainJobFailure = await callTool(
+    baseUrl,
+    delegatedFullToken,
+    delegatedInit.sessionId,
+    'explain_job_failure',
+    {
+      connectionId: connection.id,
+      queueName,
+      jobId,
+    }
+  )
+  const explainJobFailureJson = JSON.parse(
+    explainJobFailure.body?.result?.content?.[0]?.text ?? '{"status":"unknown"}'
+  ) as {
+    status?: string
+    confidence?: string
+    summary?: string
+    topSignal?: { excerpt?: string }
+    relatedAlertEvents?: Array<{ id: string }>
+  }
+  add(
+    'explain_job_failure',
+    explainJobFailure.res.ok &&
+      explainJobFailureJson.status === 'failed' &&
+      (explainJobFailureJson.topSignal?.excerpt?.includes(`live-failure-${suffix}`) ?? false) &&
+      (explainJobFailureJson.relatedAlertEvents?.some((row) => row.id === alertEvent.id) ?? false),
+    `status=${explainJobFailure.res.status}, confidence=${explainJobFailureJson.confidence}, summaryLen=${explainJobFailureJson.summary?.length ?? 0}`
   )
 
   const serviceListConnections = await callTool(


### PR DESCRIPTION
## Summary

- Adds the four remaining MCP read tools: `get_failure_events`, `get_queue_metrics`, `get_workers`, and `explain_job_failure`.
- Hardens authorization and output contracts: composite service-account scope bindings, request-scoped connection resolution, partial sanitization, and bounded pagination (metrics window, queue scan cap, log tail reads).
- Extends live proof script and mount/policy tests for the new tools.

## Test plan

- [x] `bun run --filter @durabull/api test src/mcp/` (29 tests)
- [x] `bun run --filter @durabull/mcp test` (35 tests)
- [ ] `bun tooling/scripts/mcp-live-final-proof.ts` against a running API with Redis/Postgres

## Follow-ups (PR-06)

- Central output redaction for `get_job` / logs / stacktraces
- Rate limits and read-only tool metadata annotations


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new diagnostic tools: retrieve failure events with pagination, view queue metrics and performance analytics, discover workers, and analyze job failures with related alert context.
  * Enhanced authorization with new scope requirements for failure and diagnostic data access.

* **Tests**
  * Added coverage for new diagnostic tools and authorization scenarios.

* **Documentation**
  * Updated execution playbook with PR completion status and follow-up tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->