### PR TITLE
MCP PR-06 safety hardening

### DIFF
--- a/apps/api/src/mcp/audit/mcp-audit.test.ts
+++ b/apps/api/src/mcp/audit/mcp-audit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+
+import { hashMcpToolInput } from '../audit/mcp-audit'
+
+describe('hashMcpToolInput', () => {
+  it('hashes stable argument ordering', () => {
+    const first = hashMcpToolInput({ connectionId: 'abc', queueName: 'mail' })
+    const second = hashMcpToolInput({ queueName: 'mail', connectionId: 'abc' })
+    expect(first).toBe(second)
+    expect(first).toHaveLength(64)
+  })
+
+  it('includes nested argument keys in the hash', () => {
+    const first = hashMcpToolInput({
+      connectionId: 'abc',
+      nested: { queueName: 'mail', jobId: '1' },
+    })
+    const second = hashMcpToolInput({
+      nested: { jobId: '1', queueName: 'mail' },
+      connectionId: 'abc',
+    })
+    const shallowOnly = hashMcpToolInput({
+      connectionId: 'abc',
+      nested: {},
+    })
+
+    expect(first).toBe(second)
+    expect(first).not.toBe(shallowOnly)
+  })
+})

--- a/apps/api/src/mcp/audit/mcp-audit.ts
+++ b/apps/api/src/mcp/audit/mcp-audit.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'node:crypto'
+
+import { mcpPolicyRepository } from '@durabull/dal'
+
+import { recordMcpTelemetry } from '../observability/mcp-telemetry'
+
+export type McpAuditResponseClass =
+  | 'policy_denied'
+  | 'rate_limited'
+  | 'success'
+  | 'tool_error'
+
+export interface McpAuditEventInput {
+  correlationId: string
+  principalType: 'delegated_user' | 'service_account'
+  principalId: string
+  organizationId?: string | null
+  connectionId?: string | null
+  toolName: string
+  requiredScopes: string[]
+  granted: boolean
+  denialReason?: string | null
+  inputHash?: string | null
+  responseClass?: McpAuditResponseClass | null
+}
+
+const MAX_AUDIT_IN_FLIGHT = 16
+const MAX_AUDIT_QUEUE_DEPTH = 1024
+const AUDIT_DROP_LOG_INTERVAL = 100
+let auditInFlight = 0
+let droppedAuditEvents = 0
+const pendingAuditEvents: McpAuditEventInput[] = []
+
+function dispatchAuditEvent(input: McpAuditEventInput): void {
+  auditInFlight += 1
+  void mcpPolicyRepository
+    .createAuditEvent(input)
+    .catch((error) => {
+      console.error('[mcp-audit] failed to write audit event', error)
+      recordMcpTelemetry({
+        signal: 'audit_write_failed',
+        toolName: input.toolName,
+        principalId: input.principalId,
+        correlationId: input.correlationId,
+      })
+    })
+    .finally(() => {
+      auditInFlight -= 1
+      flushPendingAuditEvents()
+    })
+}
+
+function flushPendingAuditEvents(): void {
+  while (auditInFlight < MAX_AUDIT_IN_FLIGHT && pendingAuditEvents.length > 0) {
+    const next = pendingAuditEvents.shift()
+    if (!next) break
+    dispatchAuditEvent(next)
+  }
+}
+
+export function writeMcpAuditEventNonBlocking(input: McpAuditEventInput): void {
+  if (input.responseClass === 'policy_denied') {
+    recordMcpTelemetry({
+      signal: 'policy_denied',
+      toolName: input.toolName,
+      principalId: input.principalId,
+      correlationId: input.correlationId,
+    })
+  } else if (input.responseClass === 'rate_limited') {
+    recordMcpTelemetry({
+      signal: 'rate_limited_tool',
+      toolName: input.toolName,
+      principalId: input.principalId,
+      correlationId: input.correlationId,
+    })
+  }
+
+  if (auditInFlight < MAX_AUDIT_IN_FLIGHT && pendingAuditEvents.length === 0) {
+    dispatchAuditEvent(input)
+    return
+  }
+
+  if (pendingAuditEvents.length >= MAX_AUDIT_QUEUE_DEPTH) {
+    droppedAuditEvents += 1
+    recordMcpTelemetry({
+      signal: 'audit_dropped',
+      toolName: input.toolName,
+      principalId: input.principalId,
+      correlationId: input.correlationId,
+    })
+    if (droppedAuditEvents === 1 || droppedAuditEvents % AUDIT_DROP_LOG_INTERVAL === 0) {
+      console.warn(
+        `[mcp-audit] dropping audit events due to backpressure (dropped=${droppedAuditEvents}, inFlight=${auditInFlight}, queued=${pendingAuditEvents.length})`
+      )
+    }
+    return
+  }
+
+  pendingAuditEvents.push(input)
+  flushPendingAuditEvents()
+}
+
+function stableStringify(value: unknown, depth = 0): string {
+  if (depth > 32) {
+    return '"[truncated]"'
+  }
+
+  if (value == null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item, depth + 1)).join(',')}]`
+  }
+
+  const record = value as Record<string, unknown>
+  const keys = Object.keys(record).sort()
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key], depth + 1)}`)
+    .join(',')}}`
+}
+
+export function hashMcpToolInput(args: Record<string, unknown>): string {
+  return createHash('sha256').update(stableStringify(args)).digest('hex')
+}

--- a/apps/api/src/mcp/json-rpc-tool-call.ts
+++ b/apps/api/src/mcp/json-rpc-tool-call.ts
@@ -1,0 +1,58 @@
+export interface ParsedMcpToolCall {
+  toolName: string
+  arguments: Record<string, unknown>
+  connectionId: string | null
+  payloadId: string | number | null
+}
+
+interface JsonRpcToolCallBody {
+  id?: string | number | null
+  method?: string
+  params?: {
+    name?: string
+    arguments?: Record<string, unknown>
+  }
+}
+
+export function parseMcpJsonRpcPayloadId(body: unknown): string | number | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  if (!('id' in body)) return null
+  const candidate = (body as { id?: unknown }).id
+  return typeof candidate === 'string' ||
+    typeof candidate === 'number' ||
+    candidate === null ||
+    candidate === undefined
+    ? (candidate ?? null)
+    : null
+}
+
+export function parseMcpToolCallBody(body: unknown): ParsedMcpToolCall | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  const payload = body as JsonRpcToolCallBody
+  if (payload.method !== 'tools/call') return null
+  const toolName = payload.params?.name
+  if (!toolName || typeof toolName !== 'string') return null
+  const args = payload.params?.arguments
+  const safeArgs: Record<string, unknown> =
+    args && typeof args === 'object' && !Array.isArray(args) ? args : {}
+  const connectionId =
+    typeof safeArgs.connectionId === 'string' && safeArgs.connectionId.trim().length > 0
+      ? safeArgs.connectionId.trim()
+      : null
+
+  return {
+    toolName,
+    arguments: safeArgs,
+    connectionId,
+    payloadId: parseMcpJsonRpcPayloadId(body),
+  }
+}
+
+export function isMcpToolsCallMethod(body: unknown): boolean {
+  return (
+    body != null &&
+    typeof body === 'object' &&
+    !Array.isArray(body) &&
+    (body as { method?: string }).method === 'tools/call'
+  )
+}

--- a/apps/api/src/mcp/middleware/mcp-tool-rate-limit.test.ts
+++ b/apps/api/src/mcp/middleware/mcp-tool-rate-limit.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Hono } from 'hono'
+
+import {
+  createMcpToolRateLimitMiddleware,
+  resetMcpToolRateLimitStoreForTests,
+  setMcpToolRateLimitBypassForTests,
+} from './mcp-tool-rate-limit'
+
+describe('createMcpToolRateLimitMiddleware', () => {
+  beforeEach(() => {
+    resetMcpToolRateLimitStoreForTests()
+    setMcpToolRateLimitBypassForTests(true)
+  })
+
+  afterEach(() => {
+    resetMcpToolRateLimitStoreForTests()
+    setMcpToolRateLimitBypassForTests(false)
+  })
+
+  it('returns JSON-RPC 429 when per-tool limit is exceeded', async () => {
+    const app = new Hono()
+    app.use('*', createMcpToolRateLimitMiddleware())
+    app.post('/', (c) => c.json({ ok: true }))
+
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'get_job_logs',
+        arguments: { connectionId: 'conn-1' },
+      },
+    }
+
+    const headers = {
+      Authorization: 'Bearer test-token',
+      'x-forwarded-for': '203.0.113.44',
+    }
+
+    let lastStatus = 200
+    for (let i = 0; i < 31; i += 1) {
+      const response = await app.request('/', {
+        method: 'POST',
+        headers: {
+          ...headers,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+      lastStatus = response.status
+    }
+
+    expect(lastStatus).toBe(429)
+  })
+})

--- a/apps/api/src/mcp/middleware/mcp-tool-rate-limit.ts
+++ b/apps/api/src/mcp/middleware/mcp-tool-rate-limit.ts
@@ -1,0 +1,205 @@
+import { createHash } from 'node:crypto'
+
+import { extractBearerToken } from '@durabull/mcp/auth'
+import { env } from '@durabull/env'
+import type { Context } from 'hono'
+import { createMiddleware } from 'hono/factory'
+
+import { hashMcpToolInput, writeMcpAuditEventNonBlocking } from '../audit/mcp-audit'
+import { isMcpToolsCallMethod, parseMcpJsonRpcPayloadId, parseMcpToolCallBody } from '../json-rpc-tool-call'
+
+interface RateLimitEntry {
+  count: number
+  resetAt: number
+}
+
+const rateLimitStore = new Map<string, RateLimitEntry>()
+
+const DEFAULT_TOOL_WINDOW_MS = 60 * 1000
+const DEFAULT_TOOL_LIMIT = 60
+const HEAVY_TOOL_LIMIT = 30
+const MAX_RATE_LIMIT_ENTRIES = 4096
+
+const HEAVY_TOOLS = new Set([
+  'get_job_logs',
+  'get_job_stacktraces',
+  'explain_job_failure',
+  'get_failure_events',
+  'get_queue_metrics',
+])
+
+let forceToolRateLimitInTests = false
+
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of rateLimitStore.entries()) {
+    if (entry.resetAt < now) {
+      rateLimitStore.delete(key)
+    }
+  }
+}, 60 * 1000)
+
+function shouldSkipToolRateLimiting(): boolean {
+  if (forceToolRateLimitInTests) return false
+  if (env.DISABLE_RATE_LIMIT === true) return true
+  if (env.NODE_ENV === 'test') return true
+  if (env.NODE_ENV === 'development' || env.NODE_ENV === undefined) return true
+  return false
+}
+
+function evictRateLimitEntriesIfNeeded(nextKey: string): void {
+  if (rateLimitStore.size < MAX_RATE_LIMIT_ENTRIES || rateLimitStore.has(nextKey)) {
+    return
+  }
+
+  const overflow = rateLimitStore.size - MAX_RATE_LIMIT_ENTRIES + 1
+  const keysToDelete = [...rateLimitStore.keys()].slice(0, overflow)
+  for (const key of keysToDelete) {
+    rateLimitStore.delete(key)
+  }
+}
+
+function resolveRateLimitAuditPrincipal(c: Context, principalKey: string) {
+  const session = c.get('mcpSession')
+  if (session?.userId) {
+    return {
+      principalType: 'delegated_user' as const,
+      principalId: session.userId,
+    }
+  }
+  if (session?.clientId) {
+    return {
+      principalType: 'service_account' as const,
+      principalId: session.clientId,
+    }
+  }
+  return {
+    principalType: 'service_account' as const,
+    principalId: principalKey,
+  }
+}
+
+function principalRateLimitKey(c: Context): string {
+  const bearerToken = extractBearerToken(c.req.header('Authorization'))
+  if (bearerToken) {
+    return createHash('sha256').update(bearerToken).digest('hex').slice(0, 24)
+  }
+  return 'anonymous'
+}
+
+function toolLimitForName(toolName: string): number {
+  return HEAVY_TOOLS.has(toolName) ? HEAVY_TOOL_LIMIT : DEFAULT_TOOL_LIMIT
+}
+
+function jsonRpcRateLimitResponse(
+  c: Context,
+  payloadId: string | number | null,
+  retryAfterSeconds: number
+) {
+  return c.json(
+    {
+      jsonrpc: '2.0',
+      error: {
+        code: -32_029,
+        message: 'Rate limit exceeded for this MCP tool. Please slow down.',
+        data: {
+          retryAfter: retryAfterSeconds,
+        },
+      },
+      id: payloadId,
+    },
+    429
+  )
+}
+
+async function readMcpRequestBody(c: Context): Promise<unknown> {
+  const cached = c.get('mcpRequestJsonBody')
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const body = await c.req.raw.clone().json().catch(() => null)
+  c.set('mcpRequestJsonBody', body)
+  return body
+}
+
+export function createMcpToolRateLimitMiddleware() {
+  return createMiddleware(async (c, next) => {
+    if (c.req.method !== 'POST') {
+      return next()
+    }
+
+    const body = await readMcpRequestBody(c)
+    if (!isMcpToolsCallMethod(body)) {
+      return next()
+    }
+
+    const toolCall = parseMcpToolCallBody(body) ?? {
+      toolName: '__invalid_tools_call__',
+      arguments: {},
+      connectionId: null,
+      payloadId: parseMcpJsonRpcPayloadId(body),
+    }
+
+    if (shouldSkipToolRateLimiting()) {
+      return next()
+    }
+
+    const principalKey = principalRateLimitKey(c)
+    const limit = toolLimitForName(toolCall.toolName)
+    const key = `mcp-tool:${principalKey}:${toolCall.toolName}`
+    const now = Date.now()
+
+    if (rateLimitStore.size >= MAX_RATE_LIMIT_ENTRIES && !rateLimitStore.has(key)) {
+      evictRateLimitEntriesIfNeeded(key)
+    }
+
+    let entry = rateLimitStore.get(key)
+    if (!entry || entry.resetAt < now) {
+      entry = { count: 0, resetAt: now + DEFAULT_TOOL_WINDOW_MS }
+    }
+
+    entry.count += 1
+    rateLimitStore.set(key, entry)
+
+    const remaining = Math.max(0, limit - entry.count)
+    const retryAfterSeconds = Math.ceil((entry.resetAt - now) / 1000)
+    c.header('X-RateLimit-Limit', limit.toString())
+    c.header('X-RateLimit-Remaining', remaining.toString())
+    c.header('X-RateLimit-Reset', retryAfterSeconds.toString())
+
+    if (entry.count > limit) {
+      c.header('Retry-After', retryAfterSeconds.toString())
+
+      const auditPrincipal = resolveRateLimitAuditPrincipal(c, principalKey)
+      const correlationId = c.req.header('x-request-id') ?? crypto.randomUUID()
+      writeMcpAuditEventNonBlocking({
+        correlationId,
+        principalType: auditPrincipal.principalType,
+        principalId: auditPrincipal.principalId,
+        organizationId: null,
+        connectionId: toolCall.connectionId,
+        toolName: toolCall.toolName,
+        requiredScopes: [],
+        granted: false,
+        denialReason: 'tool_rate_limited',
+        inputHash: hashMcpToolInput(toolCall.arguments),
+        responseClass: 'rate_limited',
+      })
+
+      return jsonRpcRateLimitResponse(c, toolCall.payloadId, retryAfterSeconds)
+    }
+
+    return next()
+  })
+}
+
+/** Test-only helper to reset in-memory counters. */
+export function resetMcpToolRateLimitStoreForTests(): void {
+  rateLimitStore.clear()
+}
+
+/** Test-only helper to force rate limiting during tests. */
+export function setMcpToolRateLimitBypassForTests(enabled: boolean): void {
+  forceToolRateLimitInTests = enabled
+}

--- a/apps/api/src/mcp/mount.test.ts
+++ b/apps/api/src/mcp/mount.test.ts
@@ -410,7 +410,7 @@ describe('api MCP ingress', () => {
 
     expect(response.status).toBe(403)
     const denialBody = await response.text()
-    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('insufficient_scope')
     expect(denialBody).toContain('mcp:jobs:read')
   })
 
@@ -528,7 +528,7 @@ describe('api MCP ingress', () => {
 
     expect(response.status).toBe(403)
     const denialBody = await response.text()
-    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('insufficient_scope')
     expect(denialBody).toContain('mcp:logs:read')
   })
 
@@ -644,7 +644,7 @@ describe('api MCP ingress', () => {
 
     expect(response.status).toBe(403)
     const denialBody = await response.text()
-    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('insufficient_scope')
     expect(denialBody).toContain('mcp:failures:read')
   })
 
@@ -761,7 +761,7 @@ describe('api MCP ingress', () => {
 
     expect(response.status).toBe(403)
     const denialBody = await response.text()
-    expect(denialBody).toContain('missing_scopes')
+    expect(denialBody).toContain('insufficient_scope')
     expect(denialBody).toContain('mcp:diagnostics:read')
   })
 
@@ -1162,7 +1162,7 @@ describe('api MCP ingress', () => {
 
     expect(callResponse.status).toBe(403)
     const denialBody = await callResponse.text()
-    expect(denialBody).toContain('service_account_policy_denied')
+    expect(denialBody).toContain('policy_denied')
   })
 
   it('denies delegated-user tool calls when connection is outside membership boundary', async () => {

--- a/apps/api/src/mcp/mount.ts
+++ b/apps/api/src/mcp/mount.ts
@@ -1,9 +1,13 @@
 import { createMcpRoutes, getDefaultAllowedHosts, getProductionAllowedHosts } from '@durabull/mcp'
+import type { McpToolInvocationAuditInput } from '@durabull/mcp'
 import { env } from '@durabull/env'
 
 import { APP_VERSION } from '../lib/build-info'
+import { hashMcpToolInput, writeMcpAuditEventNonBlocking } from './audit/mcp-audit'
 import { assertMcpAuthConfiguration } from './auth/mcp-auth-config'
 import { createMcpSessionMiddleware } from './auth/mcp-session-middleware'
+import { createMcpToolRateLimitMiddleware } from './middleware/mcp-tool-rate-limit'
+import { recordMcpTelemetry } from './observability/mcp-telemetry'
 import { createMcpPolicyMiddleware } from './policy/mcp-policy-middleware'
 import { explainJobFailureHandler } from './tools/explain-job-failure-handler'
 import { getFailureEventsHandler } from './tools/get-failure-events-handler'
@@ -28,6 +32,7 @@ export async function mountMcpIngress() {
   const isProduction = env.NODE_ENV === 'production'
   const authMiddleware = await createMcpSessionMiddleware(appBaseUrl)
   const policyMiddleware = createMcpPolicyMiddleware()
+  const toolRateLimitMiddleware = createMcpToolRateLimitMiddleware()
 
   return createMcpRoutes({
     version: APP_VERSION,
@@ -55,6 +60,31 @@ export async function mountMcpIngress() {
       if (!principal) {
         return undefined
       }
+
+      const recordToolInvocation = (input: McpToolInvocationAuditInput) => {
+        if (!decision) return
+
+        recordMcpTelemetry({
+          signal: input.responseClass === 'success' ? 'tool_success' : 'tool_error',
+          toolName: input.toolName,
+          principalId: decision.principalId,
+          correlationId: decision.correlationId,
+        })
+
+        writeMcpAuditEventNonBlocking({
+          correlationId: decision.correlationId,
+          principalType: decision.principalType,
+          principalId: decision.principalId,
+          organizationId: decision.organizationId,
+          connectionId: input.connectionId ?? decision.connectionId,
+          toolName: input.toolName,
+          requiredScopes: decision.requiredScopes,
+          granted: true,
+          inputHash: c.get('mcpToolInputHash') ?? hashMcpToolInput(input.arguments),
+          responseClass: input.responseClass,
+        })
+      }
+
       return {
         principal:
           principal.type === 'delegated_user'
@@ -71,8 +101,16 @@ export async function mountMcpIngress() {
         correlationId: decision?.correlationId,
         grantedScopes: c.get('mcpGrantedScopes'),
         resolvedConnection: c.get('mcpResolvedConnection'),
+        onToolInvocationComplete: recordToolInvocation,
+        onRedactionApplied: (redactionCount) => {
+          recordMcpTelemetry({
+            signal: 'redaction_applied',
+            count: redactionCount,
+            correlationId: decision?.correlationId,
+          })
+        },
       }
     },
-    middleware: [authMiddleware, policyMiddleware],
+    middleware: [authMiddleware, toolRateLimitMiddleware, policyMiddleware],
   })
 }

--- a/apps/api/src/mcp/observability/mcp-telemetry.ts
+++ b/apps/api/src/mcp/observability/mcp-telemetry.ts
@@ -1,0 +1,54 @@
+export type McpTelemetrySignal =
+  | 'auth_unauthorized'
+  | 'auth_forbidden'
+  | 'policy_denied'
+  | 'rate_limited_ingress'
+  | 'rate_limited_tool'
+  | 'tool_success'
+  | 'tool_error'
+  | 'redaction_applied'
+  | 'audit_dropped'
+  | 'audit_write_failed'
+
+export interface McpTelemetryEvent {
+  signal: McpTelemetrySignal
+  toolName?: string
+  principalId?: string
+  correlationId?: string
+  count?: number
+}
+
+const signalTotals = new Map<McpTelemetrySignal, number>()
+let telemetryLoggingEnabled = process.env.MCP_TELEMETRY_LOG !== 'false'
+
+export function recordMcpTelemetry(event: McpTelemetryEvent): void {
+  const increment = Math.max(1, event.count ?? 1)
+  signalTotals.set(event.signal, (signalTotals.get(event.signal) ?? 0) + increment)
+
+  if (!telemetryLoggingEnabled) return
+
+  console.info(
+    JSON.stringify({
+      type: 'mcp_telemetry',
+      signal: event.signal,
+      toolName: event.toolName ?? null,
+      correlationId: event.correlationId ?? null,
+      count: increment,
+    })
+  )
+}
+
+/** Test-only helper for asserting telemetry counters. */
+export function getMcpTelemetryTotalsForTests(): ReadonlyMap<McpTelemetrySignal, number> {
+  return signalTotals
+}
+
+/** Test-only helper to reset counters between tests. */
+export function resetMcpTelemetryForTests(): void {
+  signalTotals.clear()
+}
+
+/** Test-only helper to disable stdout telemetry noise in tests. */
+export function setMcpTelemetryLoggingForTests(enabled: boolean): void {
+  telemetryLoggingEnabled = enabled
+}

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -1,100 +1,16 @@
-import { mcpPolicyRepository } from '@durabull/dal'
 import type { Context } from 'hono'
 import { createMiddleware } from 'hono/factory'
 
 import type { McpSession } from '../auth/mcp-session-middleware'
+import { hashMcpToolInput, writeMcpAuditEventNonBlocking } from '../audit/mcp-audit'
+import { parseMcpJsonRpcPayloadId, parseMcpToolCallBody, isMcpToolsCallMethod } from '../json-rpc-tool-call'
 import { resolveConnectionForPrincipal } from '../tools/shared'
 import { evaluateMcpToolPolicy } from './policy-engine'
 import { resolveMcpPrincipal } from './principal-resolver'
-import type { McpPolicyDecision, McpToolCallRequest, McpPrincipal } from './types'
-
-interface JsonRpcToolCallBody {
-  id?: string | number | null
-  method?: string
-  params?: {
-    name?: string
-    arguments?: Record<string, unknown>
-  }
-}
-
-interface McpAuditEventInput {
-  correlationId: string
-  principalType: 'delegated_user' | 'service_account'
-  principalId: string
-  organizationId?: string | null
-  connectionId?: string | null
-  toolName: string
-  requiredScopes: string[]
-  granted: boolean
-  denialReason?: string | null
-}
-
-const MAX_AUDIT_IN_FLIGHT = 16
-const MAX_AUDIT_QUEUE_DEPTH = 1024
-const AUDIT_DROP_LOG_INTERVAL = 100
-let auditInFlight = 0
-let droppedAuditEvents = 0
-const pendingAuditEvents: McpAuditEventInput[] = []
-
-function parseToolCallBody(body: unknown): McpToolCallRequest | null {
-  if (!body || typeof body !== 'object') return null
-  const payload = body as JsonRpcToolCallBody
-  if (payload.method !== 'tools/call') return null
-  const toolName = payload.params?.name
-  if (!toolName || typeof toolName !== 'string') return null
-  const args = payload.params?.arguments
-  const safeArgs: Record<string, unknown> = args && typeof args === 'object' ? args : {}
-  const connectionId =
-    typeof safeArgs.connectionId === 'string' && safeArgs.connectionId.trim().length > 0
-      ? safeArgs.connectionId.trim()
-      : null
-
-  return { toolName, arguments: safeArgs, connectionId }
-}
+import type { McpPolicyDecision, McpPrincipal } from './types'
 
 function buildCorrelationId(): string {
   return crypto.randomUUID()
-}
-
-function dispatchAuditEvent(input: McpAuditEventInput): void {
-  auditInFlight += 1
-  void mcpPolicyRepository
-    .createAuditEvent(input)
-    .catch((error) => {
-      console.error('[mcp-policy] failed to write audit event', error)
-    })
-    .finally(() => {
-      auditInFlight -= 1
-      flushPendingAuditEvents()
-    })
-}
-
-function flushPendingAuditEvents(): void {
-  while (auditInFlight < MAX_AUDIT_IN_FLIGHT && pendingAuditEvents.length > 0) {
-    const next = pendingAuditEvents.shift()
-    if (!next) break
-    dispatchAuditEvent(next)
-  }
-}
-
-function writeAuditEventNonBlocking(input: McpAuditEventInput): void {
-  if (auditInFlight < MAX_AUDIT_IN_FLIGHT && pendingAuditEvents.length === 0) {
-    dispatchAuditEvent(input)
-    return
-  }
-
-  if (pendingAuditEvents.length >= MAX_AUDIT_QUEUE_DEPTH) {
-    droppedAuditEvents += 1
-    if (droppedAuditEvents === 1 || droppedAuditEvents % AUDIT_DROP_LOG_INTERVAL === 0) {
-      console.warn(
-        `[mcp-policy] dropping audit events due to backpressure (dropped=${droppedAuditEvents}, inFlight=${auditInFlight}, queued=${pendingAuditEvents.length})`
-      )
-    }
-    return
-  }
-
-  pendingAuditEvents.push(input)
-  flushPendingAuditEvents()
 }
 
 function jsonRpcErrorResponse(
@@ -119,19 +35,34 @@ function jsonRpcErrorResponse(
   )
 }
 
+async function readMcpRequestBody(c: Context): Promise<unknown> {
+  const cached = c.get('mcpRequestJsonBody')
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const body = await c.req.raw.clone().json().catch(() => null)
+  c.set('mcpRequestJsonBody', body)
+  return body
+}
+
+function policyDenialErrorData(decision: McpPolicyDecision): Record<string, unknown> {
+  if (decision.denialReason?.startsWith('missing_scopes')) {
+    return {
+      code: 'insufficient_scope',
+      requiredScopes: decision.requiredScopes,
+    }
+  }
+  return { code: 'policy_denied' }
+}
+
 export function createMcpPolicyMiddleware() {
   return createMiddleware(async (c, next) => {
     if (c.req.method !== 'POST') {
       return next()
     }
 
-    const body = await c.req.raw
-      .clone()
-      .json()
-      .catch(() => null)
-    if (body !== null) {
-      c.set('mcpRequestJsonBody', body)
-    }
+    const body = await readMcpRequestBody(c)
     if (Array.isArray(body)) {
       return jsonRpcErrorResponse(
         c,
@@ -141,24 +72,10 @@ export function createMcpPolicyMiddleware() {
         null
       )
     }
-    const payloadId =
-      body && typeof body === 'object' && 'id' in body
-        ? (() => {
-            const candidate = (body as { id?: unknown }).id
-            return typeof candidate === 'string' ||
-              typeof candidate === 'number' ||
-              candidate === null ||
-              candidate === undefined
-              ? (candidate ?? null)
-              : null
-          })()
-        : null
-    const isToolsCallMethod =
-      body && typeof body === 'object' && !Array.isArray(body)
-        ? (body as JsonRpcToolCallBody).method === 'tools/call'
-        : false
-    const toolCall = parseToolCallBody(body)
-    if (isToolsCallMethod && !toolCall) {
+
+    const payloadId = parseMcpJsonRpcPayloadId(body)
+    const toolCall = parseMcpToolCallBody(body)
+    if (isMcpToolsCallMethod(body) && !toolCall) {
       return jsonRpcErrorResponse(
         c,
         400,
@@ -174,9 +91,10 @@ export function createMcpPolicyMiddleware() {
     const session = c.get('mcpSession')
     const principal = await resolveMcpPrincipal(session)
     const correlationId = c.req.header('x-request-id') ?? buildCorrelationId()
+    const inputHash = hashMcpToolInput(toolCall.arguments)
 
     if (!principal) {
-      writeAuditEventNonBlocking({
+      writeMcpAuditEventNonBlocking({
         correlationId,
         principalType: 'service_account',
         principalId: session.clientId,
@@ -186,6 +104,8 @@ export function createMcpPolicyMiddleware() {
         requiredScopes: [],
         granted: false,
         denialReason: 'principal_resolution_failed',
+        inputHash,
+        responseClass: 'policy_denied',
       })
 
       return jsonRpcErrorResponse(
@@ -204,25 +124,28 @@ export function createMcpPolicyMiddleware() {
       call: toolCall,
     })
 
-    writeAuditEventNonBlocking({
-      correlationId: decision.correlationId,
-      principalType: decision.principalType,
-      principalId: decision.principalId,
-      organizationId: decision.organizationId,
-      connectionId: decision.connectionId,
-      toolName: decision.toolName,
-      requiredScopes: decision.requiredScopes,
-      granted: decision.granted,
-      denialReason: decision.denialReason,
-    })
-
     if (!decision.granted) {
+      writeMcpAuditEventNonBlocking({
+        correlationId: decision.correlationId,
+        principalType: decision.principalType,
+        principalId: decision.principalId,
+        organizationId: decision.organizationId,
+        connectionId: decision.connectionId,
+        toolName: decision.toolName,
+        requiredScopes: decision.requiredScopes,
+        granted: false,
+        denialReason: decision.denialReason,
+        inputHash,
+        responseClass: 'policy_denied',
+      })
+
       return jsonRpcErrorResponse(
         c,
         403,
         -32_003,
-        decision.denialReason ?? 'Forbidden: MCP policy denied this tool call.',
-        payloadId
+        'Forbidden: MCP policy denied this tool call.',
+        payloadId,
+        policyDenialErrorData(decision)
       )
     }
 
@@ -250,6 +173,7 @@ export function createMcpPolicyMiddleware() {
 
     c.set('mcpPrincipal', principal)
     c.set('mcpPolicyDecision', decision)
+    c.set('mcpToolInputHash', inputHash)
     c.set(
       'mcpGrantedScopes',
       session.scopes
@@ -269,5 +193,6 @@ declare module 'hono' {
     mcpSession: McpSession
     mcpResolvedConnection?: import('@durabull/mcp').McpResolvedConnection
     mcpGrantedScopes?: string[]
+    mcpToolInputHash?: string
   }
 }

--- a/apps/api/src/mcp/tools/mcp-sanitize.test.ts
+++ b/apps/api/src/mcp/tools/mcp-sanitize.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test'
+
+import { sanitizeMcpOutput } from './mcp-sanitize'
+
+describe('mcp-sanitize api helpers', () => {
+  it('sanitizes alert event summaries without leaking redis URLs', () => {
+    const { value, redactionCount } = sanitizeMcpOutput({
+      summary: 'Worker failed connecting to redis://:secret@host:6379/0',
+    })
+
+    expect(JSON.stringify(value)).not.toContain('redis://')
+    expect(redactionCount).toBeGreaterThan(0)
+  })
+})

--- a/apps/api/src/mcp/tools/mcp-sanitize.ts
+++ b/apps/api/src/mcp/tools/mcp-sanitize.ts
@@ -1,21 +1,17 @@
-const SENSITIVE_KEY = /(secret|password|token|authorization|api[_-]?key|credential|redis|url)/i
-const REDIS_URL_PATTERN = /redis(s)?:\/\/[^\s]+/gi
-const MAX_MCP_TEXT_LENGTH = 500
+import {
+  sanitizeMcpText as sanitizeMcpTextImpl,
+  truncateMcpText as truncateMcpTextImpl,
+} from '@durabull/mcp/safety/sanitize-output'
+
+export { sanitizeMcpOutput } from '@durabull/mcp/safety/sanitize-output'
+
+const SENSITIVE_KEY =
+  /(^|_)(secret|password|authorization|api[_-]?key|credential|private[_-]?key|redis[_-]?url|connection[_-]?url|access[_-]?token)(_|$)/i
 const MAX_CONTEXT_DEPTH = 4
 const MAX_CONTEXT_ARRAY_ITEMS = 50
-const MAX_CONTEXT_STRING_LENGTH = 512
 
-export function truncateMcpText(value: string, maxLength = MAX_MCP_TEXT_LENGTH): string {
-  if (value.length <= maxLength) return value
-  return `${value.slice(0, maxLength)}…`
-}
-
-export function sanitizeMcpText(value: string | null | undefined): string | null {
-  if (value == null) return null
-  const redacted = value.replace(REDIS_URL_PATTERN, '[redacted]').trim()
-  if (!redacted) return null
-  return truncateMcpText(redacted)
-}
+export const truncateMcpText = truncateMcpTextImpl
+export const sanitizeMcpText = sanitizeMcpTextImpl
 
 export function sanitizeAlertEventContext(
   context: unknown,
@@ -54,8 +50,7 @@ export function sanitizeAlertEventContext(
 function sanitizeAlertContextValue(value: unknown, depth: number): unknown | undefined {
   if (value == null) return value
   if (typeof value === 'string') {
-    const redacted = value.replace(REDIS_URL_PATTERN, '[redacted]')
-    return truncateMcpText(redacted, MAX_CONTEXT_STRING_LENGTH)
+    return sanitizeMcpText(value) ?? undefined
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return value

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -4,6 +4,8 @@ import { extractBearerToken } from '@durabull/mcp/auth'
 import { env } from '@durabull/env'
 import { createMiddleware } from 'hono/factory'
 
+import { recordMcpTelemetry } from '../mcp/observability/mcp-telemetry'
+
 /**
  * Simple in-memory rate limiter.
  * For production with multiple instances, consider using Redis-backed rate limiting.
@@ -286,8 +288,9 @@ export const mcpRateLimiter = rateLimiter({
   limit: 120,
   keyPrefix: 'rl:mcp',
   keyGenerator: mcpIngressRateLimitKey,
-  onRateLimit: (c) =>
-    c.json(
+  onRateLimit: (c) => {
+    recordMcpTelemetry({ signal: 'rate_limited_ingress' })
+    return c.json(
       {
         error: 'Too Many Requests',
         code: 'RATE_LIMITED',
@@ -295,5 +298,6 @@ export const mcpRateLimiter = rateLimiter({
         retryAfter: 60,
       },
       429
-    ),
+    )
+  },
 })

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -97,9 +97,22 @@ forwards sanitized telemetry to Durabull's existing cloud API.
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `DISABLE_RATE_LIMIT` | No | Disable in-memory rate limiting |
+| `DISABLE_RATE_LIMIT` | No | Disable in-memory rate limiting (API + MCP ingress + MCP per-tool limits) |
+| `MCP_AUTHLESS_BEARER_TOKEN` | When authless + production | Bearer token for local/private MCP authless mode |
 | `ASSET_PRELOAD_MAX_SIZE` | No | Asset preload tuning |
 | `ASSET_PRELOAD_VERBOSE_LOGGING` | No | Extra preload diagnostics |
+
+## MCP
+
+MCP is served at `{APP_BASE_URL}/mcp` on the unified API deployment. No separate MCP port is required.
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `APP_BASE_URL` | Recommended | Canonical OAuth resource URI (`{APP_BASE_URL}/mcp`) and MCP host allowlist |
+| `DURABULL_AUTHLESS` | No | Must remain `false` on internet-facing deployments |
+| `DISABLE_RATE_LIMIT` | No | When `true`, disables MCP ingress and per-tool rate limits |
+
+See [MCP Server](/documentation/integrations/mcp-server) for scopes, tools, and client setup.
 
 ## Recommended Production Baseline
 

--- a/apps/docs/content/documentation/index.mdx
+++ b/apps/docs/content/documentation/index.mdx
@@ -68,6 +68,8 @@ If you are new, follow this order:
 - Alert routing:
   [Linear Integration](/documentation/integrations/linear),
   [Webhook Notifications](/documentation/integrations/webhooks)
+- AI assistant diagnostics:
+  [MCP Server](/documentation/integrations/mcp-server)
 
 ### Operations and Reference
 

--- a/apps/docs/content/documentation/integrations/mcp-server.mdx
+++ b/apps/docs/content/documentation/integrations/mcp-server.mdx
@@ -1,0 +1,124 @@
+---
+title: MCP Server
+description: Connect AI assistants to Durabull read-only queue diagnostics through the hosted MCP endpoint.
+---
+
+Durabull exposes a **read-only** [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server on the same origin as the web app and API.
+
+```txt
+{APP_BASE_URL}/mcp
+```
+
+Example: `https://app.durabull.io/mcp`
+
+MCP runs inside the unified Durabull API process. There is no separate MCP port or container in phase 1.
+
+## What MCP provides
+
+Phase 1 ships diagnostic tools only — no queue mutations, retries, pauses, or purges.
+
+| Tool | Scope | Purpose |
+| --- | --- | --- |
+| `ping` | `mcp:discover` | Transport smoke check |
+| `list_connections` | `mcp:jobs:read` | Connections visible to the principal |
+| `list_queues` | `mcp:jobs:read` | Queue inventory for a connection |
+| `get_queue` | `mcp:jobs:read` | Queue detail and counts |
+| `list_jobs` | `mcp:jobs:read` | Paginated job summaries |
+| `get_job` | `mcp:jobs:read` | Safe job detail |
+| `get_job_logs` | `mcp:logs:read` | Paginated job logs |
+| `get_job_stacktraces` | `mcp:logs:read` | Attempt-indexed stacktraces |
+| `get_failure_events` | `mcp:failures:read` | Alert/failure events |
+| `get_queue_metrics` | `mcp:diagnostics:read` | Queue metrics window |
+| `get_workers` | `mcp:jobs:read` | Worker snapshots |
+| `explain_job_failure` | `mcp:failures:read` + `mcp:logs:read` + `mcp:diagnostics:read` | Deterministic failure summary |
+
+## Authentication
+
+Remote MCP clients authenticate with **OAuth 2.1 bearer tokens** issued by Durabull (Better Auth MCP plugin).
+
+1. Discover protected resource metadata at `GET /.well-known/oauth-protected-resource`.
+2. Register an OAuth client (`POST /api/auth/mcp/register`) or use an existing client.
+3. Complete authorization code + PKCE.
+4. Request tokens with `resource={APP_BASE_URL}/mcp`.
+5. Call MCP with `Authorization: Bearer <access_token>`.
+
+Canonical resource URI:
+
+```txt
+{APP_BASE_URL}/mcp
+```
+
+`APP_BASE_URL` must match the public origin clients use to reach `/mcp` (including port in local dev).
+
+See the operator guide in the repo at `docs/mcp-oauth-operator.md` for HTTP status semantics and discovery endpoints.
+
+## Scopes
+
+| Scope | Grants |
+| --- | --- |
+| `mcp:discover` | Transport + `ping` |
+| `mcp:jobs:read` | Connection/queue/job/worker reads |
+| `mcp:logs:read` | Logs and stacktraces |
+| `mcp:failures:read` | Failure/alert events |
+| `mcp:diagnostics:read` | Metrics and composed diagnostics |
+
+Delegated users receive scopes from OAuth consent. Service accounts require explicit policy bindings per tool/scope.
+
+## Safety controls (PR-06)
+
+Durabull hardens MCP reads even for authenticated callers:
+
+### Output redaction
+
+All read-tool responses pass through a central sanitizer that:
+
+- strips sensitive object keys (for example `apiKey`, `redisUrl`, `password`)
+- redacts inline Redis URLs and bearer tokens in text fields
+- truncates oversized strings
+- adds `_mcpSafety.redactionCount` when redactions occur
+
+### Rate limits
+
+| Layer | Default limit | Key |
+| --- | --- | --- |
+| `/mcp` ingress | 120 requests/minute | Bearer token hash (or client IP) |
+| Per tool | 60 calls/minute (30 for log/stacktrace/metrics-heavy tools) | Bearer token hash + tool name |
+
+Responses include `X-RateLimit-*` headers. Exceeded limits return HTTP `429`.
+
+Set `DISABLE_RATE_LIMIT=true` to bypass all rate limiting (not recommended in production).
+
+### Audit trail
+
+Every `tools/call` writes an `mcp_audit_event` row with:
+
+- principal id/type and org context
+- tool name and required scopes
+- SHA-256 hash of tool arguments (not raw args)
+- allow/deny decision and `response_class` (`success`, `tool_error`, `policy_denied`, `rate_limited`)
+
+Audit writes are non-blocking with bounded in-memory backpressure.
+
+### Observability
+
+Structured JSON logs emit `mcp_telemetry` signals for auth denials, policy denies, ingress/tool rate limits, tool success/error, and redaction events. Wire these into your log aggregator or metrics pipeline.
+
+## Local development
+
+Authless mode (`DURABULL_AUTHLESS=true`) accepts the dev bearer token for `/mcp` only on private/local setups. Never enable authless mode on Durabull Cloud.
+
+Smoke scripts:
+
+```bash
+bun run --filter @durabull/mcp test
+bun run --filter @durabull/api test src/mcp/
+
+cd tooling/scripts
+APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
+```
+
+## Related docs
+
+- [Security and Hardening](/documentation/operations/security-and-hardening)
+- [Environment Variables](/documentation/getting-started/environment-variables)
+- [HTTP API Reference](/documentation/reference/http-api)

--- a/apps/docs/content/documentation/meta.json
+++ b/apps/docs/content/documentation/meta.json
@@ -30,6 +30,7 @@
     "workflows/naming-best-practices",
     "workflows/log-formatting-and-highlighting",
     "---Integrations---",
+    "integrations/mcp-server",
     "integrations/linear",
     "---Reference---",
     "reference/http-api",

--- a/apps/docs/content/documentation/operations/security-and-hardening.mdx
+++ b/apps/docs/content/documentation/operations/security-and-hardening.mdx
@@ -41,6 +41,18 @@ Built-in controls include:
 - request body size limit (`1MB`)
 - in-memory rate limiting in production
 
+### MCP (`/mcp`)
+
+Durabull's hosted MCP endpoint adds layered read protections:
+
+- **Ingress rate limit:** 120 requests/minute per bearer token (or client IP fallback)
+- **Per-tool rate limit:** 60 calls/minute by default; 30/minute for log, stacktrace, metrics, and failure-heavy tools
+- **Output redaction:** central sanitizer removes Redis URLs, credential-like keys, and bearer tokens from tool payloads
+- **Audit events:** every MCP tool call records principal, tool, input hash, and outcome in `mcp_audit_event`
+- **Structured telemetry:** JSON `mcp_telemetry` logs for auth/policy/rate-limit/tool outcomes
+
+See [MCP Server](/documentation/integrations/mcp-server) for scopes, tools, and client setup.
+
 If running multiple API replicas, consider moving rate limits to a shared backend.
 
 ## Secrets Handling

--- a/packages/dal/src/db/migrations/20260528020000_mcp_pr06_audit_hardening/migration.sql
+++ b/packages/dal/src/db/migrations/20260528020000_mcp_pr06_audit_hardening/migration.sql
@@ -1,3 +1,3 @@
 ALTER TABLE "mcp_audit_event" ADD COLUMN IF NOT EXISTS "input_hash" text;
-
+--> statement-breakpoint
 ALTER TABLE "mcp_audit_event" ADD COLUMN IF NOT EXISTS "response_class" text;

--- a/packages/dal/src/db/migrations/20260528020000_mcp_pr06_audit_hardening/migration.sql
+++ b/packages/dal/src/db/migrations/20260528020000_mcp_pr06_audit_hardening/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "mcp_audit_event" ADD COLUMN IF NOT EXISTS "input_hash" text;
+
+ALTER TABLE "mcp_audit_event" ADD COLUMN IF NOT EXISTS "response_class" text;

--- a/packages/dal/src/db/schemas/mcp-policy/schema.ts
+++ b/packages/dal/src/db/schemas/mcp-policy/schema.ts
@@ -92,6 +92,8 @@ export const mcpAuditEvent = pgTable(
     requiredScopes: text('required_scopes').notNull(),
     granted: boolean('granted').notNull(),
     denialReason: text('denial_reason'),
+    inputHash: text('input_hash'),
+    responseClass: text('response_class'),
   },
   (table) => [
     index('mcp_audit_event_correlation_idx').on(table.correlationId),

--- a/packages/dal/src/repositories/mcp-policy.ts
+++ b/packages/dal/src/repositories/mcp-policy.ts
@@ -295,6 +295,8 @@ export const mcpPolicyRepository = {
     requiredScopes: string[]
     granted: boolean
     denialReason?: string | null
+    inputHash?: string | null
+    responseClass?: string | null
   }) {
     const db = await getDb()
     const now = new Date()
@@ -313,6 +315,8 @@ export const mcpPolicyRepository = {
         requiredScopes: input.requiredScopes.join(' '),
         granted: input.granted,
         denialReason: input.denialReason ?? null,
+        inputHash: input.inputHash ?? null,
+        responseClass: input.responseClass ?? null,
       })
       .returning()
     return record

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,6 +15,10 @@
     "./testing": {
       "types": "./src/testing/mcp-test-client.ts",
       "import": "./src/testing/mcp-test-client.ts"
+    },
+    "./safety/sanitize-output": {
+      "types": "./src/safety/sanitize-output.ts",
+      "import": "./src/safety/sanitize-output.ts"
     }
   },
   "scripts": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -20,6 +20,7 @@ export type {
   McpRequestContext,
   McpRequestPrincipal,
   McpResolvedConnection,
+  McpToolInvocationAuditInput,
 } from './request-context'
 export {
   getCanonicalMcpResourceUri,

--- a/packages/mcp/src/request-context.ts
+++ b/packages/mcp/src/request-context.ts
@@ -15,11 +15,20 @@ export interface McpResolvedConnection {
   allowSelfSignedCerts: boolean
 }
 
+export interface McpToolInvocationAuditInput {
+  toolName: string
+  arguments: Record<string, unknown>
+  connectionId?: string | null
+  responseClass: 'success' | 'tool_error'
+}
+
 export interface McpRequestContext {
   principal?: McpRequestPrincipal
   correlationId?: string
   grantedScopes?: string[]
   resolvedConnection?: McpResolvedConnection
+  onToolInvocationComplete?: (input: McpToolInvocationAuditInput) => void
+  onRedactionApplied?: (redactionCount: number) => void
 }
 
 const store = new AsyncLocalStorage<McpRequestContext>()

--- a/packages/mcp/src/routes.test.ts
+++ b/packages/mcp/src/routes.test.ts
@@ -289,6 +289,6 @@ describe('createMcpRoutes', () => {
       error?: { code?: string; message?: string }
     }
     expect(errorPayload.error?.code).toBe('not_found')
-    expect(errorPayload.error?.message).toContain('Connection missing for test')
+    expect(errorPayload.error?.message).toBe('Resource not found.')
   })
 })

--- a/packages/mcp/src/safety/sanitize-output.test.ts
+++ b/packages/mcp/src/safety/sanitize-output.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test'
+
+import { sanitizeMcpOutput, sanitizeMcpText } from './sanitize-output'
+
+describe('sanitizeMcpOutput', () => {
+  it('redacts redis URLs in nested job payloads', () => {
+    const { value, redactionCount } = sanitizeMcpOutput({
+      job: {
+        data: {
+          callback: 'redis://:secret@host:6379/0',
+        },
+      },
+    })
+
+    expect(JSON.stringify(value)).not.toContain('redis://')
+    expect(JSON.stringify(value)).toContain('[redacted]')
+    expect(redactionCount).toBeGreaterThan(0)
+  })
+
+  it('drops sensitive object keys', () => {
+    const { value, redactionCount } = sanitizeMcpOutput({
+      apiKey: 'abc123',
+      name: 'worker-1',
+    })
+
+    expect(value).toEqual({ name: 'worker-1' })
+    expect(redactionCount).toBe(1)
+  })
+
+  it('redacts bearer tokens in log lines', () => {
+    const { value, redactionCount } = sanitizeMcpOutput({
+      logs: ['Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.token'],
+    })
+
+    expect(JSON.stringify(value)).toContain('[redacted]')
+    expect(redactionCount).toBeGreaterThan(0)
+  })
+
+  it('preserves benign url field names while redacting secret values', () => {
+    const { value, redactionCount } = sanitizeMcpOutput({
+      callbackUrl: 'https://example.com/hooks',
+      apiKey: 'should-drop-key',
+    })
+
+    expect(value).toEqual({ callbackUrl: 'https://example.com/hooks' })
+    expect(redactionCount).toBe(1)
+  })
+
+  it('redacts jwt-like strings in generic payload fields', () => {
+    const { value, redactionCount } = sanitizeMcpOutput({
+      message: 'token eyJabc.def.ghi failed',
+    })
+
+    expect(JSON.stringify(value)).toContain('[redacted]')
+    expect(redactionCount).toBeGreaterThan(0)
+  })
+})
+
+describe('sanitizeMcpText', () => {
+  it('returns null for empty strings after redaction', () => {
+    expect(sanitizeMcpText('   ')).toBeNull()
+  })
+})

--- a/packages/mcp/src/safety/sanitize-output.ts
+++ b/packages/mcp/src/safety/sanitize-output.ts
@@ -1,0 +1,106 @@
+const SENSITIVE_KEY =
+  /(^|_)(secret|password|authorization|api[_-]?key|credential|private[_-]?key|redis[_-]?url|connection[_-]?url|access[_-]?token)(_|$)/i
+const REDIS_URL_PATTERN = /redis(s)?:\/\/[^\s]+/gi
+const DATABASE_URL_PATTERN = /(postgres|mysql|mongodb)(\+srv)?:\/\/[^\s]+/gi
+const BEARER_TOKEN_PATTERN = /bearer\s+[a-z0-9._~+/=-]+/gi
+const JWT_PATTERN = /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g
+const API_KEY_PATTERN = /\b(sk|pk)_[a-zA-Z0-9]{8,}\b/g
+export const DEFAULT_MCP_TEXT_MAX_LENGTH = 500
+const MAX_DEPTH = 8
+const MAX_ARRAY_ITEMS = 100
+const MAX_OBJECT_KEYS = 200
+
+export interface SanitizeMcpOutputResult {
+  value: unknown
+  redactionCount: number
+}
+
+function redactString(value: string, maxLength: number): { text: string; redactions: number } {
+  let redactions = 0
+  let text = value
+
+  const patterns = [
+    REDIS_URL_PATTERN,
+    DATABASE_URL_PATTERN,
+    BEARER_TOKEN_PATTERN,
+    JWT_PATTERN,
+    API_KEY_PATTERN,
+  ]
+
+  for (const pattern of patterns) {
+    if (pattern.test(text)) {
+      redactions += 1
+      text = text.replace(pattern, '[redacted]')
+    }
+    pattern.lastIndex = 0
+  }
+
+  if (text.length > maxLength) {
+    text = `${text.slice(0, maxLength)}…`
+  }
+
+  return { text, redactions }
+}
+
+function sanitizeValue(value: unknown, depth: number, maxTextLength: number): SanitizeMcpOutputResult {
+  if (value == null || depth > MAX_DEPTH) {
+    return { value, redactionCount: 0 }
+  }
+
+  if (typeof value === 'string') {
+    const { text, redactions } = redactString(value, maxTextLength)
+    return { value: text, redactionCount: redactions }
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return { value, redactionCount: 0 }
+  }
+
+  if (Array.isArray(value)) {
+    let redactionCount = 0
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((item) => {
+      const next = sanitizeValue(item, depth + 1, maxTextLength)
+      redactionCount += next.redactionCount
+      return next.value
+    })
+    return { value: items, redactionCount }
+  }
+
+  if (typeof value === 'object') {
+    let redactionCount = 0
+    const sanitized: Record<string, unknown> = {}
+    const entries = Object.entries(value as Record<string, unknown>).slice(0, MAX_OBJECT_KEYS)
+    for (const [key, nested] of entries) {
+      if (SENSITIVE_KEY.test(key)) {
+        redactionCount += 1
+        continue
+      }
+      const next = sanitizeValue(nested, depth + 1, maxTextLength)
+      redactionCount += next.redactionCount
+      sanitized[key] = next.value
+    }
+    return { value: sanitized, redactionCount }
+  }
+
+  return { value: undefined, redactionCount: 0 }
+}
+
+export function sanitizeMcpOutput(
+  value: unknown,
+  options?: { maxTextLength?: number }
+): SanitizeMcpOutputResult {
+  const maxTextLength = options?.maxTextLength ?? DEFAULT_MCP_TEXT_MAX_LENGTH
+  return sanitizeValue(value, 0, maxTextLength)
+}
+
+export function truncateMcpText(value: string, maxLength = DEFAULT_MCP_TEXT_MAX_LENGTH): string {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, maxLength)}…`
+}
+
+export function sanitizeMcpText(value: string | null | undefined): string | null {
+  if (value == null) return null
+  const { text, redactions } = redactString(value, DEFAULT_MCP_TEXT_MAX_LENGTH)
+  if (!text.trim()) return null
+  return redactions > 0 ? text : truncateMcpText(text)
+}

--- a/packages/mcp/src/tools/register-read-tools.ts
+++ b/packages/mcp/src/tools/register-read-tools.ts
@@ -2,6 +2,8 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 
 import { getMcpRequestContext } from '../request-context'
+import type { McpToolInvocationAuditInput } from '../request-context'
+import { sanitizeMcpOutput } from '../safety/sanitize-output'
 
 export interface ListConnectionsHandlerInput {
   principal:
@@ -367,6 +369,7 @@ export interface RegisterReadToolsOptions {
   explainJobFailure?: (
     input: ExplainJobFailureHandlerInput
   ) => Promise<ExplainJobFailureHandlerOutput>
+  onToolInvocationComplete?: (input: McpToolInvocationAuditInput) => void
 }
 
 function parsePageSize(raw: unknown): number {
@@ -407,7 +410,11 @@ function getPrincipalFromContext(): ToolPrincipal {
 
 function toToolError(error: unknown): { code: string; message: string } {
   const INTERNAL_ERROR_MESSAGE = 'Tool invocation failed.'
-  const KNOWN_CODES = new Set(['not_found', 'validation_error', 'forbidden'])
+  const KNOWN_MESSAGES: Record<string, string> = {
+    not_found: 'Resource not found.',
+    validation_error: 'Invalid input.',
+    forbidden: 'Forbidden.',
+  }
 
   if (
     typeof error === 'object' &&
@@ -416,15 +423,12 @@ function toToolError(error: unknown): { code: string; message: string } {
     typeof (error as { code: unknown }).code === 'string'
   ) {
     const code = (error as { code: string }).code
-    const message =
-      error instanceof Error && error.message
-        ? error.message
-        : KNOWN_CODES.has(code)
-          ? code
-          : INTERNAL_ERROR_MESSAGE
+    if (code in KNOWN_MESSAGES) {
+      return { code, message: KNOWN_MESSAGES[code]! }
+    }
     return {
-      code: KNOWN_CODES.has(code) ? code : 'internal_error',
-      message: KNOWN_CODES.has(code) ? message : INTERNAL_ERROR_MESSAGE,
+      code: 'internal_error',
+      message: INTERNAL_ERROR_MESSAGE,
     }
   }
 
@@ -434,16 +438,70 @@ function toToolError(error: unknown): { code: string; message: string } {
   }
 }
 
-function mcpToolSuccess(result: Record<string, unknown>) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  }
-}
-
 function mcpToolFailure(toolError: { code: string; message: string }) {
   return {
     isError: true,
     content: [{ type: 'text' as const, text: JSON.stringify({ error: toolError }) }],
+  }
+}
+
+function finalizeReadToolSuccess(
+  options: RegisterReadToolsOptions,
+  toolName: string,
+  args: Record<string, unknown>,
+  result: Record<string, unknown>
+) {
+  const { value, redactionCount } = sanitizeMcpOutput(result)
+  const sanitizedResult =
+    typeof value === 'object' && value != null && !Array.isArray(value)
+      ? ({ ...(value as Record<string, unknown>) } as Record<string, unknown>)
+      : ({ value } as Record<string, unknown>)
+
+  if (redactionCount > 0) {
+    sanitizedResult._mcpSafety = { redactionCount }
+    getMcpRequestContext()?.onRedactionApplied?.(redactionCount)
+  }
+
+  const auditInput = {
+    toolName,
+    arguments: args,
+    connectionId: typeof args.connectionId === 'string' ? args.connectionId : null,
+    responseClass: 'success' as const,
+  }
+  getMcpRequestContext()?.onToolInvocationComplete?.(auditInput)
+
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(sanitizedResult) }],
+  }
+}
+
+function finalizeReadToolFailure(
+  options: RegisterReadToolsOptions,
+  toolName: string,
+  args: Record<string, unknown>,
+  error: unknown
+) {
+  const auditInput = {
+    toolName,
+    arguments: args,
+    connectionId: typeof args.connectionId === 'string' ? args.connectionId : null,
+    responseClass: 'tool_error' as const,
+  }
+  getMcpRequestContext()?.onToolInvocationComplete?.(auditInput)
+  return mcpToolFailure(toToolError(error))
+}
+
+async function runReadTool(
+  options: RegisterReadToolsOptions,
+  toolName: string,
+  args: Record<string, unknown>,
+  invoke: () => Promise<Record<string, unknown>>
+) {
+  try {
+    const result = await invoke()
+    return finalizeReadToolSuccess(options, toolName, args, result)
+  } catch (error) {
+    return finalizeReadToolFailure(options, toolName, args, error)
   }
 }
 
@@ -458,19 +516,14 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
     server.tool(
       'list_connections',
       listConnectionsSchema,
-      async (args) => {
-        try {
-          const result = await listConnections({
+      async (args) =>
+        runReadTool(options, 'list_connections', args, () =>
+          listConnections({
             principal: getPrincipalFromContext(),
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -483,20 +536,15 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         cursor: z.string().optional(),
         pageSize: z.number().int().min(1).max(100).optional(),
       },
-      async (args) => {
-        try {
-          const result = await listQueues({
+      async (args) =>
+        runReadTool(options, 'list_queues', args, () =>
+          listQueues({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -508,19 +556,14 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         connectionId: z.string().min(1),
         queueName: z.string().min(1),
       },
-      async (args) => {
-        try {
-          const result = await getQueue({
+      async (args) =>
+        runReadTool(options, 'get_queue', args, () =>
+          getQueue({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -537,9 +580,9 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         cursor: z.string().optional(),
         pageSize: z.number().int().min(1).max(100).optional(),
       },
-      async (args) => {
-        try {
-          const result = await listJobs({
+      async (args) =>
+        runReadTool(options, 'list_jobs', args, () =>
+          listJobs({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
@@ -549,12 +592,7 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -567,20 +605,15 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         queueName: z.string().min(1),
         jobId: z.string().min(1),
       },
-      async (args) => {
-        try {
-          const result = await getJob({
+      async (args) =>
+        runReadTool(options, 'get_job', args, () =>
+          getJob({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
             jobId: args.jobId,
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -595,9 +628,9 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         cursor: z.string().optional(),
         pageSize: z.number().int().min(1).max(100).optional(),
       },
-      async (args) => {
-        try {
-          const result = await getJobLogs({
+      async (args) =>
+        runReadTool(options, 'get_job_logs', args, () =>
+          getJobLogs({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
@@ -605,12 +638,7 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -625,9 +653,9 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         cursor: z.string().optional(),
         pageSize: z.number().int().min(1).max(100).optional(),
       },
-      async (args) => {
-        try {
-          const result = await getJobStacktraces({
+      async (args) =>
+        runReadTool(options, 'get_job_stacktraces', args, () =>
+          getJobStacktraces({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
@@ -635,12 +663,7 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -656,9 +679,9 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         cursor: z.string().optional(),
         pageSize: z.number().int().min(1).max(100).optional(),
       },
-      async (args) => {
-        try {
-          const result = await getFailureEvents({
+      async (args) =>
+        runReadTool(options, 'get_failure_events', args, () =>
+          getFailureEvents({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
@@ -667,12 +690,7 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -685,20 +703,15 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         queueName: z.string().min(1),
         windowMinutes: z.number().int().min(1).max(1440).optional(),
       },
-      async (args) => {
-        try {
-          const result = await getQueueMetrics({
+      async (args) =>
+        runReadTool(options, 'get_queue_metrics', args, () =>
+          getQueueMetrics({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
             windowMinutes: args.windowMinutes,
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -712,21 +725,16 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         cursor: z.string().optional(),
         pageSize: z.number().int().min(1).max(100).optional(),
       },
-      async (args) => {
-        try {
-          const result = await getWorkers({
+      async (args) =>
+        runReadTool(options, 'get_workers', args, () =>
+          getWorkers({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
             cursor: parseCursor(args.cursor),
             pageSize: parsePageSize(args.pageSize),
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 
@@ -739,20 +747,15 @@ export function registerReadTools(server: McpServer, options: RegisterReadToolsO
         queueName: z.string().min(1),
         jobId: z.string().min(1),
       },
-      async (args) => {
-        try {
-          const result = await explainJobFailure({
+      async (args) =>
+        runReadTool(options, 'explain_job_failure', args, () =>
+          explainJobFailure({
             principal: getPrincipalFromContext(),
             connectionId: args.connectionId,
             queueName: args.queueName,
             jobId: args.jobId,
           })
-          return mcpToolSuccess(result)
-        } catch (error) {
-          const toolError = toToolError(error)
-          return mcpToolFailure(toolError)
-        }
-      }
+        )
     )
   }
 }

--- a/tasks/mcp-implementation-master-plan.md
+++ b/tasks/mcp-implementation-master-plan.md
@@ -81,13 +81,14 @@ Every incoming agent must complete this before writing code.
 
 ---
 
-## Implementation Status Snapshot (2026-05-26)
+## Implementation Status Snapshot (2026-05-28)
 
 - [x] Step 1 complete: MCP module + `/mcp` transport ingress on unified API app (PR-02 merged).
 - [x] Step 2 complete: OAuth discovery + token validation middleware (PR-03 merged).
-- [ ] Step 3 in progress: principal resolver + policy engine (PR-04 branch in progress).
-- [ ] Step 5 started: initial read tools (`list_connections`, `list_queues`, `get_queue`, `list_jobs`, `get_job`, `get_job_logs`, `get_job_stacktraces`) wired with policy + principal context and pagination scaffolding.
-- [ ] Steps 4, 6-7 pending (shared domain adapters expansion, hardening, deployment, GA closure).
+- [x] Step 3 complete: principal resolver + policy engine (PR-04 merged).
+- [x] Step 5 complete: read-only diagnostic tool catalog (PR-05 merged).
+- [x] Step 6 in progress: redaction, rate limits, audit expansion, telemetry (PR-06).
+- [ ] Steps 4, 7-8 pending (shared domain adapters expansion, deployment, GA closure).
 
 ---
 

--- a/tasks/mcp-pr-execution-playbook.md
+++ b/tasks/mcp-pr-execution-playbook.md
@@ -869,14 +869,54 @@ Finalize production quality and confirm spec/safety compliance.
 
 ---
 
+### PR Record: PR-06
+
+- PR ID: `PR-06`
+- Branch: `feat/no-linear-mcp-pr06-safety-hardening`
+- Linear issue: `NO-LINEAR`
+- PR URL:
+- Status: `in progress`
+- Agent owner: `cursor`
+- Start date: `2026-05-28`
+- Merge date:
+
+#### Scope Completed
+
+- [x] Central output sanitizer in `@durabull/mcp` applied to all read-tool responses with `_mcpSafety.redactionCount` metadata.
+- [x] Per-tool rate limiting middleware (60/min default, 30/min for heavy diagnostic tools) with JSON-RPC `429` responses.
+- [x] Ingress MCP rate limit telemetry hooks (`rate_limited_ingress`).
+- [x] Audit schema expansion (`input_hash`, `response_class`) and invocation audit on successful tool calls.
+- [x] Structured `mcp_telemetry` JSON logging for policy denies, rate limits, and tool outcomes.
+- [x] Docs app page: `integrations/mcp-server` + security/env var updates.
+
+#### Verification Evidence
+
+- [x] Commands run:
+  - [x] `bun run --filter @durabull/mcp test` (39 pass)
+  - [x] `bun run --filter @durabull/api test src/mcp/` (32 pass)
+  - [x] `bun run --filter @durabull/mcp typecheck`
+- [x] Tests added:
+  - [x] `packages/mcp/src/safety/sanitize-output.test.ts`
+  - [x] `apps/api/src/mcp/middleware/mcp-tool-rate-limit.test.ts`
+  - [x] `apps/api/src/mcp/audit/mcp-audit.test.ts`
+  - [x] `apps/api/src/mcp/tools/mcp-sanitize.test.ts`
+
+#### Handoff To Next PR
+
+- Next PR: `PR-07`
+- Known risks: in-memory rate limits are per-process; multi-replica deployments should plan Redis-backed limits.
+- Notes for next agent: document unified `/mcp` deployment for cloud/self-host and operator runbooks.
+
+---
+
 ## Live PR Tracker
 
 - [ ] PR-01 Security architecture baseline (folded into PR-04 completion work)
 - [x] PR-02 API `/mcp` ingress + transport (`@durabull/mcp` package + thin API mount)
 - [x] PR-03 OAuth discovery + token validation (merged — PR #89)
 - [x] PR-04 Principals + policy engine (merged — PR #94)
-- [ ] PR-05 Read-only diagnostic tools (complete on branch `feat/mcp-pr05-remaining-read-tools`; pending merge)
-- [ ] PR-06 Safety hardening
+- [x] PR-05 Read-only diagnostic tools (merged — PR #97)
+- [ ] PR-06 Safety hardening (in progress on `feat/no-linear-mcp-pr06-safety-hardening`)
 - [ ] PR-07 Deployment + operations
 - [ ] PR-08 GA readiness + security closure
 

--- a/tasks/mcp-readiness-review.md
+++ b/tasks/mcp-readiness-review.md
@@ -1,10 +1,7 @@
-# MCP Readiness Review — PR-03 Transport + OAuth (2026-05-26)
+# MCP Readiness Review — Post PR-05 / PR-06 (2026-05-28)
 
-This document summarizes readiness after addressing live-test recommendations (expired-token handling, operator docs, automated e2e smoke) and re-running full MCP e2e checks.
-
-**Branch at review time:** `cursor/mcp-pr03-oauth-discovery-token-validation`  
-**PR:** https://github.com/durabullhq/durabull/pull/89 (**merged**)  
-**Plan position:** Post-merge PR-03 baseline, with PR-04 principal/policy implementation now in progress.
+**Branch:** `feat/no-linear-mcp-pr06-safety-hardening`  
+**Plan position:** PR-06 safety hardening in progress; PR-07 deployment/ops is next.
 
 ---
 
@@ -12,148 +9,40 @@ This document summarizes readiness after addressing live-test recommendations (e
 
 | Dimension | Verdict |
 | --- | --- |
-| **PR-03 merge readiness** | **Merged** (PR #89); transport + OAuth discovery/auth slice is landed on `main`. |
-| **Production / customer diagnostics** | **Not ready** — only `ping` exists; policy + principals are now being added in PR-04, while diagnostic tools/redaction/deploy remain PR-05–08. |
-| **Full OAuth UX (browser PKCE)** | **Not manually verified** — registration + DB-seeded tokens exercised; authorize/consent UI flow not run in this pass. |
+| **Read-only diagnostic catalog** | **Complete** — all 11 tools + `ping` merged on `main` (PR #94, #97). |
+| **Authorization** | **Complete** — principals, policy engine, org/connection boundaries (PR #94). |
+| **Safety hardening (PR-06)** | **In progress** — redaction, per-tool rate limits, expanded audit, telemetry. |
+| **Production / GA** | **Not ready** — deployment runbooks (PR-07) and security closure (PR-08) remain. |
 
 ---
 
-## Recommendations addressed (this session)
+## What works today
 
-| Item | Status |
-| --- | --- |
-| Expired access tokens returned 200 via `getMcpSession` | **Fixed** — `isMcpAccessTokenExpired()` in `@durabull/mcp`; API middleware rejects expired sessions with `401` + `invalid_token` before scope checks. |
-| Operator doc `APP_BASE_URL` vs dev port | **Updated** — `docs/mcp-oauth-operator.md` |
-| Repeatable live e2e | **Added** — `tooling/scripts/mcp-e2e-smoke.ts` (`bun run mcp:e2e` from `tooling/scripts`) |
-| Integration test for expired token | **Added** — `apps/api/src/mcp/mount.test.ts` |
+- `/mcp` on same origin as API with OAuth bearer auth
+- Full read-only diagnostic tool catalog with scope-gated policy enforcement
+- Central output sanitization on all read-tool responses
+- Ingress + per-tool rate limits (in-memory; per-process)
+- Audit events with input hash + response class for tool invocations
+- Structured `mcp_telemetry` logs for operational signals
 
 ---
 
-## Automated verification (2026-05-26)
+## Remaining stack
 
-### Unit / integration tests
-
-| Command | Result |
+| PR | Capability |
 | --- | --- |
-| `bun run --filter @durabull/mcp test` | **30 pass** (includes `session.test.ts`, validate-token, bearer-middleware, routes) |
-| `bun run --filter @durabull/api test src/mcp/` | **7 pass** (includes expired OAuth token → 401) |
+| PR-07 | Cloud/self-host deploy docs, env contract, operator runbooks |
+| PR-08 | Security review closure, GA docs, staged E2E verification |
 
-### Live e2e smoke (`APP_BASE_URL=http://localhost:3001`)
+---
 
-Run from `tooling/scripts`:
+## Quick commands
 
 ```bash
-# Better Auth (default server config)
-APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
-
-# Authless local dev
-DURABULL_AUTHLESS=true APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
-```
-
-| Mode | Checks | Result |
-| --- | --- | --- |
-| Better Auth (`DURABULL_AUTHLESS=false`) | 10 | **10/10 PASS** |
-| Authless (`DURABULL_AUTHLESS=true`) | 9 (scope/expiry skipped) | **9/9 PASS** |
-
-**Better Auth checklist exercised:**
-
-1. PRM at app origin (`resource=http://localhost:3001/mcp`)
-2. `POST /mcp` without bearer → `401` + `WWW-Authenticate`
-3. Dynamic client registration (`POST /api/auth/mcp/register`)
-4. Token without `mcp:discover` → `403`
-5. Expired DB token → `401` (post-fix; required server restart)
-6. Valid token: `initialize` → `notifications/initialized` → `tools/list` → `tools/call ping` → `pong`
-7. `tools/list` without session → `400`
-8. Wrong `Host` → `403`
-
----
-
-## What works today (PR-02 + PR-03)
-
-- **Hosting:** `/mcp` on same origin as API (`apps/api`), not a separate service.
-- **Transport:** Streamable HTTP, session id on `initialize`, session required after init.
-- **Discovery:** PRM + AS metadata (Better Auth + app-origin fallbacks).
-- **Auth:** Bearer required; Better Auth `getMcpSession` / `withMcpAuth`; phase-1 `mcp:discover` scope gate.
-- **Tools:** `ping` only (conformance / connectivity).
-- **Dev:** Authless bearer `durabull-authless-mcp` when `DURABULL_AUTHLESS=true`.
-
----
-
-## Current update (PR-04 in progress)
-
-- Added principal-resolution path for delegated users + OAuth-linked service accounts.
-- Added centralized policy middleware on MCP `tools/call` with audit-event writes.
-- Added org/connection boundary checks and service-account policy-binding enforcement.
-- Added DAL schema + migration for `mcp_service_account*`, `mcp_policy_binding`, and `mcp_audit_event`.
-- Added integration coverage in `apps/api/src/mcp/mount.test.ts` for service-account allow/deny and delegated cross-org denial.
-
-## Current update (PR-05 kickoff)
-
-- Added MCP read-tool registration plumbing in `@durabull/mcp` and request-context propagation for tool handlers.
-- Added first customer-facing read tool: `list_connections` with bounded `pageSize` and cursor pagination.
-- Added next diagnostic tools: `list_queues`, `get_queue`, `list_jobs`, `get_job`, `get_job_logs`, and `get_job_stacktraces` behind the same policy/principal context path.
-- Added API handler implementation constrained by principal type:
-  - delegated users: only connections in org memberships
-  - service accounts: only connections in bound organization
-- Added integration coverage for delegated pagination, service-account scoped list access, and `get_job*` authorization/error paths.
-
----
-
-## Known gaps and deferred work
-
-### PR-03 follow-ups (non-blocking for merge if accepted)
-
-| Gap | Risk | Suggested follow-up |
-| --- | --- | --- |
-| Full OAuth code + PKCE + consent in browser | Medium — clients may fail in real Cursor/Claude flows until exercised | Manual or Playwright flow against `/api/auth/mcp/authorize`; document redirect URI setup |
-| RFC 8707 `resource` not enforced at token issuance | Low until multi-resource AS | Wire `resource` column + validation when enabling production clients |
-| AS metadata `scopes_supported` may list OIDC scopes only | Low — PRM lists MCP scopes | Confirm client libraries read PRM; align AS metadata if needed |
-| `packages/mcp` bearer middleware vs Better Auth path | Low — API uses Better Auth only | Keep package middleware for tests/future split; document single production path |
-
-### Stack blockers for “customer-ready MCP”
-
-| PR | Missing capability |
-| --- | --- |
-| PR-04 | Principal model, org/connection policy on tool calls |
-| PR-05 | Remaining diagnostics tools (`get_failure_events`, `get_queue_metrics`, `get_workers`, `explain_job_failure`) |
-| PR-06 | Redaction, rate limits, audit logging |
-| PR-07 | Cloud/self-host deploy, runbooks |
-| PR-08 | Security review closure, GA docs |
-
----
-
-## Security posture (phase-1 transport)
-
-| Control | Status |
-| --- | --- |
-| No anonymous `/mcp` | Enforced |
-| Host allowlist | Enforced (`403`) |
-| Scope least privilege (`mcp:discover` for transport) | Enforced (`403`) |
-| Expired tokens | Enforced (`401`) after fix |
-| Session fixation / unbounded sessions | Mitigated (init-only sessions, 256 cap) |
-| Write/destructive tools | None shipped |
-| Authless mode | Dev-only; must be off in production |
-
----
-
-## Post-merge recommendation
-
-- Keep PR-03 treated as transport/auth foundation only.
-- Complete PR-04 policy/principal merge next, then proceed with PR-05 read-only diagnostic tools.
-- Do not treat merged PR-03 as MCP GA or production customer diagnostics — that still requires PR-04–08.
-
----
-
-## Quick commands for reviewers
-
-```bash
-# Tests
 bun run --filter @durabull/mcp test
 bun run --filter @durabull/api test src/mcp/
 
-# Local server (Better Auth)
-DURABULL_AUTHLESS=false APP_BASE_URL=http://localhost:3001 PORT=3001 bun apps/api/src/index.ts
-
-# Live smoke
 cd tooling/scripts && APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
 ```
+
+See [MCP Server docs](/documentation/integrations/mcp-server) in the docs app for operator-facing guidance.


### PR DESCRIPTION
## Summary

- Adds central MCP output redaction (JWT, bearer tokens, API keys, DB URLs) with `_mcpSafety.redactionCount` metadata on tool responses.
- Introduces per-principal/per-tool rate limiting (60/min default, 30/min for heavy tools), expanded audit logging (`input_hash`, `response_class`), and observability signals for auth denials, rate limits, redaction, and audit failures.
- Updates docs (MCP integration guide, security/env vars) and task playbooks; includes DB migration for audit column hardening.

## Test plan

- [x] `bun run --filter @durabull/mcp test` (41 pass)
- [x] `bun run --filter @durabull/api test src/mcp/` (33 pass)
- [ ] Apply migration `20260528020000_mcp_pr06_audit_hardening` in staging
- [ ] Smoke MCP `tools/call` with scoped token; confirm redaction on failure payloads
- [ ] Verify 429 on per-tool rate limit burst; confirm audit row written on allow/deny

## Follow-ups (out of scope)

- Redis-backed rate limits for multi-replica deploys (PR-07 ops)
- Durable audit queue under extreme backpressure


Made with [Cursor](https://cursor.com)