### PR TITLE
Add MCP OAuth consent UI for external MCP clients

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -27,6 +27,7 @@ import alertsRoutes from './routes/alerts'
 import alertsGlobalRoutes from './routes/alerts-global'
 import authRoutes from './routes/auth'
 import connectionsRoutes from './routes/connections'
+import mcpOAuthRoutes from './routes/mcp-oauth'
 import invitationsRoutes from './routes/invitations'
 import jobsRoutes from './routes/jobs'
 import metricsRoutes from './routes/metrics'
@@ -387,6 +388,7 @@ export async function createApiApp(options: CreateApiAppOptions = {}) {
   api.use('/connections/*', sessionMiddleware)
   api.use('/team/*', sessionMiddleware)
   api.use('/user-settings/*', sessionMiddleware)
+  api.use('/mcp/*', sessionMiddleware)
   api.use('/alerts/*', sessionMiddleware)
   // Connection middleware includes session handling - no need for both
   api.use('/c/:connectionId/*', connectionMiddleware)
@@ -406,6 +408,7 @@ export async function createApiApp(options: CreateApiAppOptions = {}) {
     .route('/connections', connectionsRoutes)
     .route('/team', teamRoutes)
     .route('/user-settings', userSettingsRoutes)
+    .route('/mcp', mcpOAuthRoutes)
     .route('/alerts', alertsGlobalRoutes)
     .route('/c/:connectionId/alerts', alertsRoutes)
     .route('/c/:connectionId/queues', queuesRoutes)

--- a/apps/api/src/mcp/auth/mcp-session-middleware.ts
+++ b/apps/api/src/mcp/auth/mcp-session-middleware.ts
@@ -87,7 +87,7 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
         requireResourceIndicator,
       })
       if (!cachedValidation.ok) {
-        tokenCache.delete(cacheKey)
+        tokenCache.invalidate(cacheKey)
         if (cachedValidation.status === 403) {
           return buildMcpInsufficientScopeResponse(
             resourceMetadataUrl,

--- a/apps/api/src/mcp/auth/mcp-session-middleware.ts
+++ b/apps/api/src/mcp/auth/mcp-session-middleware.ts
@@ -81,7 +81,23 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
     const cacheKey = bearerToken
     const cached = tokenCache.get(cacheKey)
     if (cached) {
-      c.set('mcpSession', sessionFromClaims(cached))
+      const cachedValidation = validateMcpAccessTokenClaims(cached, {
+        canonicalResourceUri,
+        requiredScopes: MCP_TRANSPORT_REQUIRED_SCOPES,
+        requireResourceIndicator,
+      })
+      if (!cachedValidation.ok) {
+        tokenCache.delete(cacheKey)
+        if (cachedValidation.status === 403) {
+          return buildMcpInsufficientScopeResponse(
+            resourceMetadataUrl,
+            cachedValidation.missingScopes ??
+              missingScopes(cached.scopes, MCP_TRANSPORT_REQUIRED_SCOPES)
+          )
+        }
+        return buildMcpUnauthorizedResponse(resourceMetadataUrl)
+      }
+      c.set('mcpSession', sessionFromClaims(cachedValidation.claims))
       return next()
     }
 
@@ -96,7 +112,8 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
       userId: session.userId,
       scopes: parseScopeString(session.scopes),
       accessTokenExpiresAt: session.accessTokenExpiresAt,
-      resource: session.resource,
+      // Better Auth MCP token issuance may omit `resource` on insert; default to canonical URI.
+      resource: session.resource ?? canonicalResourceUri,
     }
 
     const validation = validateMcpAccessTokenClaims(claims, {

--- a/apps/api/src/routes/mcp-oauth.ts
+++ b/apps/api/src/routes/mcp-oauth.ts
@@ -1,0 +1,136 @@
+import { authSchema, eq, getDb, oauthApplication } from '@durabull/dal'
+import { Hono } from 'hono'
+import { requireSession } from '../middleware/auth'
+
+const { authVerification } = authSchema
+
+interface PendingMcpAuthorization {
+  clientId: string
+  redirectURI: string
+  scope: string[]
+  userId: string
+  requireConsent?: boolean
+}
+
+function parsePendingAuthorization(value: string): PendingMcpAuthorization | null {
+  try {
+    const parsed = JSON.parse(value) as PendingMcpAuthorization
+    if (
+      typeof parsed.clientId !== 'string' ||
+      !Array.isArray(parsed.scope) ||
+      typeof parsed.userId !== 'string'
+    ) {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+const app = new Hono()
+
+/**
+ * Authoritative consent context for the MCP consent screen (session required).
+ * Scopes and client come from the pending authorization stored by Better Auth, not URL params.
+ */
+app.get('/oauth-consent/:consentCode', requireSession, async (c) => {
+  const consentCode = c.req.param('consentCode')
+  const user = c.get('user')
+  if (!consentCode) {
+    return c.json({ error: 'consent_code is required' }, 400)
+  }
+
+  const db = await getDb()
+  const [verification] = await db
+    .select({
+      value: authVerification.value,
+      expiresAt: authVerification.expiresAt,
+    })
+    .from(authVerification)
+    .where(eq(authVerification.identifier, consentCode))
+    .limit(1)
+
+  if (!verification || verification.expiresAt < new Date()) {
+    return c.json({ error: 'Consent request not found or expired' }, 404)
+  }
+
+  const pending = parsePendingAuthorization(verification.value)
+  if (!pending) {
+    return c.json({ error: 'Invalid consent request' }, 400)
+  }
+
+  if (pending.userId !== user.id) {
+    return c.json({ error: 'Forbidden' }, 403)
+  }
+
+  const [client] = await db
+    .select({
+      clientId: oauthApplication.clientId,
+      name: oauthApplication.name,
+      icon: oauthApplication.icon,
+      disabled: oauthApplication.disabled,
+    })
+    .from(oauthApplication)
+    .where(eq(oauthApplication.clientId, pending.clientId))
+    .limit(1)
+
+  if (!client) {
+    return c.json({ error: 'Client not found' }, 404)
+  }
+
+  if (client.disabled) {
+    return c.json(
+      {
+        error: 'client_disabled',
+        message: 'This application has been disabled and cannot be authorized.',
+        clientId: client.clientId,
+        name: client.name,
+        icon: client.icon,
+        disabled: true,
+        scopes: pending.scope,
+      },
+      403
+    )
+  }
+
+  return c.json({
+    clientId: client.clientId,
+    name: client.name,
+    icon: client.icon,
+    disabled: client.disabled,
+    scopes: pending.scope,
+  })
+})
+
+/**
+ * OAuth client metadata (session required). Prefer oauth-consent for the consent screen.
+ */
+app.get('/oauth-client/:clientId', requireSession, async (c) => {
+  const clientId = c.req.param('clientId')
+
+  const db = await getDb()
+  const [client] = await db
+    .select({
+      clientId: oauthApplication.clientId,
+      name: oauthApplication.name,
+      icon: oauthApplication.icon,
+      disabled: oauthApplication.disabled,
+    })
+    .from(oauthApplication)
+    .where(eq(oauthApplication.clientId, clientId))
+    .limit(1)
+
+  if (!client) {
+    return c.json({ error: 'Client not found' }, 404)
+  }
+
+  return c.json({
+    clientId: client.clientId,
+    name: client.name,
+    icon: client.icon,
+    disabled: client.disabled,
+  })
+})
+
+export default app

--- a/apps/api/src/routes/mcp-oauth.ts
+++ b/apps/api/src/routes/mcp-oauth.ts
@@ -37,6 +37,9 @@ const app = new Hono()
 app.get('/oauth-consent/:consentCode', requireSession, async (c) => {
   const consentCode = c.req.param('consentCode')
   const user = c.get('user')
+  if (!user) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
   if (!consentCode) {
     return c.json({ error: 'consent_code is required' }, 400)
   }

--- a/apps/docs/content/documentation/integrations/mcp-server.mdx
+++ b/apps/docs/content/documentation/integrations/mcp-server.mdx
@@ -38,11 +38,12 @@ Phase 1 ships diagnostic tools only — no queue mutations, retries, pauses, or 
 
 Remote MCP clients authenticate with **OAuth 2.1 bearer tokens** issued by Durabull (Better Auth MCP plugin).
 
-1. Discover protected resource metadata at `GET /.well-known/oauth-protected-resource`.
-2. Register an OAuth client (`POST /api/auth/mcp/register`) or use an existing client. On internet-facing deployments, registration is **unauthenticated** (rate-limited only) — monitor volume at the edge and prefer pre-provisioned clients where possible.
-3. Complete authorization code + PKCE.
-4. Request tokens with `resource={APP_BASE_URL}/mcp`.
-5. Call MCP with `Authorization: Bearer <access_token>`.
+1. Discover protected resource metadata at `GET /.well-known/oauth-protected-resource` (or `/api/auth/.well-known/oauth-protected-resource`).
+2. Register an OAuth client (`POST /api/auth/mcp/register`). On internet-facing deployments, registration is **unauthenticated** (rate-limited only) — monitor volume at the edge and prefer pre-provisioned clients where possible.
+3. Send the user through authorization code + PKCE at `/api/auth/mcp/authorize` with `prompt=consent` and `resource={APP_BASE_URL}/mcp`.
+4. The user signs in (if needed) and approves scopes on **`/consent`**.
+5. Exchange the authorization code at `/api/auth/mcp/token` with the same `resource` value.
+6. Call MCP with `Authorization: Bearer <access_token>`.
 
 Canonical resource URI:
 
@@ -80,7 +81,7 @@ Operators: telemetry signals, SQL examples, and incident playbooks are in the [M
 
 Authless mode (`DURABULL_AUTHLESS=true`) is for **local/private** setups only. Never enable authless mode on Durabull Cloud. If authless is reachable from a network, set a strong `MCP_AUTHLESS_BEARER_TOKEN` — the non-production default token is for localhost dev only.
 
-Use the **API port** for `APP_BASE_URL` (`3001` in monorepo dev, `3000` in Docker).
+For monorepo dev with the Vite app, set `APP_BASE_URL` to the web origin (`http://localhost:5173`) so `/mcp` and OAuth discovery share one origin (the dev server proxies to the API). For API-only smoke scripts, use the API port (`http://localhost:3001` or `http://localhost:3000` in Docker).
 
 For test commands and CI evidence, see [validation evidence](https://github.com/durabullhq/durabull/blob/main/docs/mcp-ga-validation-evidence.md). Run `mcp:e2e` only against local or staging databases (see runbook).
 

--- a/apps/web/e2e/mcp-oauth.spec.ts
+++ b/apps/web/e2e/mcp-oauth.spec.ts
@@ -296,9 +296,11 @@ test.describe('MCP OAuth browser flow', () => {
 
     expect(authorizationCode).toBeTruthy()
     expect(callbackState).toBe(state)
+    const code = authorizationCode!
+    expect(code.length).toBeGreaterThan(0)
 
     const accessToken = await exchangeAuthorizationCode({
-      code: authorizationCode as string,
+      code,
       clientId,
       codeVerifier,
       resource,
@@ -389,9 +391,12 @@ test.describe('MCP OAuth browser flow (logged out)', () => {
     await expect(page.getByTestId('mcp-consent-allow')).toBeEnabled({ timeout: 30_000 })
     await page.getByTestId('mcp-consent-allow').click()
     await expect.poll(() => authorizationCode, { timeout: 30_000 }).not.toBeNull()
+    expect(authorizationCode).toBeTruthy()
+    const code = authorizationCode!
+    expect(code.length).toBeGreaterThan(0)
 
     const accessToken = await exchangeAuthorizationCode({
-      code: authorizationCode as string,
+      code,
       clientId,
       codeVerifier,
       resource: CANONICAL_MCP_RESOURCE,

--- a/apps/web/e2e/mcp-oauth.spec.ts
+++ b/apps/web/e2e/mcp-oauth.spec.ts
@@ -4,6 +4,15 @@ import { expect, test } from '@playwright/test'
 const MCP_PROTOCOL_VERSION = '2024-11-05'
 const MCP_JSON_RPC_VERSION = '2.0'
 
+const WEB_BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173'
+const WEB_ORIGIN = WEB_BASE_URL.replace(/\/$/, '')
+const CANONICAL_MCP_RESOURCE = `${WEB_ORIGIN}/mcp`
+const MCP_CALLBACK_URL = 'http://127.0.0.1:8765/callback'
+const E2E_ADMIN_EMAIL = 'admin@example.com'
+const E2E_ADMIN_PASSWORD = 'password'
+
+const EMPTY_STORAGE_STATE = { cookies: [] as [], origins: [] as [] }
+
 function parseSseJson(body: string): unknown {
   const trimmed = body.trim()
   const lastEvent = trimmed.split('\n\n').at(-1) ?? trimmed
@@ -13,10 +22,6 @@ function parseSseJson(body: string): unknown {
     .map((line) => line.slice('data: '.length))
   return JSON.parse(dataLines.join('\n') || trimmed)
 }
-
-const WEB_BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173'
-const CANONICAL_MCP_RESOURCE = `${WEB_BASE_URL.replace(/\/$/, '')}/mcp`
-const MCP_CALLBACK_URL = 'http://127.0.0.1:8765/callback'
 
 function base64UrlEncode(buffer: Buffer): string {
   return buffer.toString('base64url')
@@ -28,13 +33,32 @@ function createPkcePair() {
   return { codeVerifier, codeChallenge }
 }
 
-async function assertProtectedResourceMetadata(): Promise<void> {
-  const response = await fetch(
-    `${WEB_BASE_URL}/api/auth/.well-known/oauth-protected-resource`
-  )
-  expect(response.ok).toBeTruthy()
-  const body = (await response.json()) as { resource?: string }
-  expect(body.resource).toBe(CANONICAL_MCP_RESOURCE)
+function parseResourceMetadataUrl(wwwAuthenticate: string | null): string {
+  expect(wwwAuthenticate, 'WWW-Authenticate header required').toBeTruthy()
+  const match = wwwAuthenticate!.match(/resource_metadata="([^"]+)"/)
+  expect(match, `resource_metadata not found in: ${wwwAuthenticate}`).toBeTruthy()
+  return match![1]
+}
+
+type ProtectedResourceMetadata = {
+  resource?: string
+  authorization_servers?: string[]
+  scopes_supported?: string[]
+}
+
+async function fetchProtectedResourceMetadata(url: string): Promise<ProtectedResourceMetadata> {
+  const response = await fetch(url)
+  const text = await response.text()
+  expect(response.ok, `PRM fetch failed ${url}: ${response.status} ${text}`).toBeTruthy()
+  return JSON.parse(text) as ProtectedResourceMetadata
+}
+
+async function assertProtectedResourceMetadataAt(url: string): Promise<ProtectedResourceMetadata> {
+  const metadata = await fetchProtectedResourceMetadata(url)
+  expect(metadata.resource).toBe(CANONICAL_MCP_RESOURCE)
+  expect(metadata.authorization_servers?.length).toBeGreaterThan(0)
+  expect(metadata.scopes_supported).toContain('mcp:discover')
+  return metadata
 }
 
 async function registerMcpOAuthClient() {
@@ -76,9 +100,166 @@ function buildAuthorizeUrl(input: {
   return `${WEB_BASE_URL}/api/auth/mcp/authorize?${params.toString()}`
 }
 
+async function exchangeAuthorizationCode(input: {
+  code: string
+  clientId: string
+  codeVerifier: string
+  resource: string
+}) {
+  const tokenParams = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: input.code,
+    redirect_uri: MCP_CALLBACK_URL,
+    client_id: input.clientId,
+    code_verifier: input.codeVerifier,
+    resource: input.resource,
+  })
+  const tokenResponse = await fetch(`${WEB_BASE_URL}/api/auth/mcp/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: tokenParams.toString(),
+  })
+  const tokenText = await tokenResponse.text()
+  expect(tokenResponse.ok, `token failed: ${tokenResponse.status} ${tokenText}`).toBeTruthy()
+  const tokenBody = JSON.parse(tokenText) as { access_token?: string; scope?: string }
+  expect(tokenBody.access_token).toBeTruthy()
+  expect(tokenBody.scope).toContain('mcp:discover')
+  return tokenBody.access_token as string
+}
+
+async function mcpPingWithToken(accessToken: string) {
+  const mcpHost = new URL(CANONICAL_MCP_RESOURCE).host
+  const initResponse = await fetch(CANONICAL_MCP_RESOURCE, {
+    method: 'POST',
+    headers: {
+      host: mcpHost,
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+      authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'playwright-mcp-oauth', version: '1.0.0' },
+      },
+    }),
+  })
+
+  const initText = await initResponse.text()
+  expect(initResponse.status, `initialize failed: ${initResponse.status} ${initText}`).toBe(200)
+  const sessionId = initResponse.headers.get('mcp-session-id')
+  expect(sessionId).toBeTruthy()
+
+  const initBody = parseSseJson(initText) as {
+    result?: { serverInfo?: { name?: string } }
+  }
+  expect(initBody.result?.serverInfo?.name).toBe('durabull-mcp')
+
+  await fetch(CANONICAL_MCP_RESOURCE, {
+    method: 'POST',
+    headers: {
+      host: mcpHost,
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+      authorization: `Bearer ${accessToken}`,
+      'mcp-session-id': sessionId as string,
+    },
+    body: JSON.stringify({
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      method: 'notifications/initialized',
+    }),
+  })
+
+  const pingResponse = await fetch(CANONICAL_MCP_RESOURCE, {
+    method: 'POST',
+    headers: {
+      host: mcpHost,
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+      authorization: `Bearer ${accessToken}`,
+      'mcp-session-id': sessionId as string,
+    },
+    body: JSON.stringify({
+      jsonrpc: MCP_JSON_RPC_VERSION,
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'ping', arguments: {} },
+    }),
+  })
+
+  expect(pingResponse.ok).toBeTruthy()
+  const pingBody = parseSseJson(await pingResponse.text()) as {
+    result?: { content?: Array<{ text?: string }> }
+  }
+  expect(pingBody.result?.content?.[0]?.text).toContain('pong')
+}
+
+test.describe('MCP OAuth discovery (automatic auth)', () => {
+  test('unauthenticated POST /mcp returns WWW-Authenticate and PRM chain', async () => {
+    const mcpHost = new URL(CANONICAL_MCP_RESOURCE).host
+    const challengeResponse = await fetch(CANONICAL_MCP_RESOURCE, {
+      method: 'POST',
+      headers: {
+        host: mcpHost,
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'playwright-mcp-discovery', version: '1.0.0' },
+        },
+      }),
+    })
+
+    expect(challengeResponse.status).toBe(401)
+    const wwwAuthenticate = challengeResponse.headers.get('WWW-Authenticate')
+    const resourceMetadataUrl = parseResourceMetadataUrl(wwwAuthenticate)
+
+    const fromChallenge = await assertProtectedResourceMetadataAt(resourceMetadataUrl)
+    const fromAppRoot = await assertProtectedResourceMetadataAt(
+      `${WEB_ORIGIN}/.well-known/oauth-protected-resource`
+    )
+    const fromAuthPath = await assertProtectedResourceMetadataAt(
+      `${WEB_ORIGIN}/api/auth/.well-known/oauth-protected-resource`
+    )
+
+    expect(fromChallenge.authorization_servers).toEqual(fromAppRoot.authorization_servers)
+    expect(fromAuthPath.resource).toBe(fromAppRoot.resource)
+
+    const authorizationServer = fromChallenge.authorization_servers![0]!
+    const asMetadataResponse = await fetch(
+      `${authorizationServer}/.well-known/oauth-authorization-server`
+    )
+    const asText = await asMetadataResponse.text()
+    expect(
+      asMetadataResponse.ok,
+      `AS metadata failed: ${asMetadataResponse.status} ${asText}`
+    ).toBeTruthy()
+    const asMetadata = JSON.parse(asText) as {
+      authorization_endpoint?: string
+      token_endpoint?: string
+      registration_endpoint?: string
+    }
+    expect(asMetadata.authorization_endpoint).toContain('/api/auth/mcp/authorize')
+    expect(asMetadata.token_endpoint).toContain('/api/auth/mcp/token')
+    expect(asMetadata.registration_endpoint).toContain('/api/auth/mcp/register')
+
+    const clientId = await registerMcpOAuthClient()
+    expect(clientId.length).toBeGreaterThan(0)
+  })
+})
+
 test.describe('MCP OAuth browser flow', () => {
   test('register → authorize → consent → token → MCP ping', async ({ page }) => {
-    await assertProtectedResourceMetadata()
     const resource = CANONICAL_MCP_RESOURCE
     const clientId = await registerMcpOAuthClient()
     const { codeVerifier, codeChallenge } = createPkcePair()
@@ -111,109 +292,111 @@ test.describe('MCP OAuth browser flow', () => {
     await expect(page.getByTestId('mcp-consent-allow')).toBeEnabled({ timeout: 30_000 })
 
     await page.getByTestId('mcp-consent-allow').click()
-    await expect
-      .poll(() => authorizationCode, { timeout: 30_000 })
-      .not.toBeNull()
+    await expect.poll(() => authorizationCode, { timeout: 30_000 }).not.toBeNull()
 
-    const code = authorizationCode
-    expect(code).toBeTruthy()
+    expect(authorizationCode).toBeTruthy()
     expect(callbackState).toBe(state)
 
-    const tokenParams = new URLSearchParams({
-      grant_type: 'authorization_code',
-      code: code as string,
-      redirect_uri: MCP_CALLBACK_URL,
-      client_id: clientId,
-      code_verifier: codeVerifier,
+    const accessToken = await exchangeAuthorizationCode({
+      code: authorizationCode as string,
+      clientId,
+      codeVerifier,
       resource,
     })
-    const tokenResponse = await fetch(`${WEB_BASE_URL}/api/auth/mcp/token`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: tokenParams.toString(),
-    })
-    const tokenText = await tokenResponse.text()
-    expect(tokenResponse.ok, `token failed: ${tokenResponse.status} ${tokenText}`).toBeTruthy()
-    const tokenBody = JSON.parse(tokenText) as { access_token?: string; scope?: string }
-    expect(tokenBody.access_token).toBeTruthy()
-    expect(tokenBody.scope).toContain('mcp:discover')
 
     const sessionCheck = await fetch(`${WEB_BASE_URL}/api/auth/mcp/get-session`, {
-      headers: { authorization: `Bearer ${tokenBody.access_token}` },
+      headers: { authorization: `Bearer ${accessToken}` },
     })
     const sessionBody = await sessionCheck.json()
     expect(sessionCheck.ok, `get-session failed: ${JSON.stringify(sessionBody)}`).toBeTruthy()
     expect(sessionBody).not.toBeNull()
 
-    const mcpHost = new URL(CANONICAL_MCP_RESOURCE).host
-    const initResponse = await fetch(CANONICAL_MCP_RESOURCE, {
-      method: 'POST',
-      headers: {
-        host: mcpHost,
-        accept: 'application/json, text/event-stream',
-        'content-type': 'application/json',
-        authorization: `Bearer ${tokenBody.access_token}`,
-      },
-      body: JSON.stringify({
-        jsonrpc: MCP_JSON_RPC_VERSION,
-        id: 1,
-        method: 'initialize',
-        params: {
-          protocolVersion: MCP_PROTOCOL_VERSION,
-          capabilities: {},
-          clientInfo: { name: 'playwright-mcp-oauth', version: '1.0.0' },
-        },
-      }),
+    await mcpPingWithToken(accessToken)
+  })
+
+  test('deny on consent redirects with access_denied', async ({ page }) => {
+    const clientId = await registerMcpOAuthClient()
+    const { codeChallenge } = createPkcePair()
+    const state = `pw-deny-${randomBytes(8).toString('hex')}`
+    const authorizeUrl = buildAuthorizeUrl({
+      clientId,
+      resource: CANONICAL_MCP_RESOURCE,
+      codeChallenge,
+      state,
     })
 
-    const initText = await initResponse.text()
-    expect(initResponse.status, `initialize failed: ${initResponse.status} ${initText}`).toBe(
-      200
-    )
-    const sessionId = initResponse.headers.get('mcp-session-id')
-    expect(sessionId).toBeTruthy()
-
-    const initBody = parseSseJson(initText) as {
-      result?: { serverInfo?: { name?: string } }
-    }
-    expect(initBody.result?.serverInfo?.name).toBe('durabull-mcp')
-
-    await fetch(CANONICAL_MCP_RESOURCE, {
-      method: 'POST',
-      headers: {
-        host: mcpHost,
-        accept: 'application/json, text/event-stream',
-        'content-type': 'application/json',
-        authorization: `Bearer ${tokenBody.access_token}`,
-        'mcp-session-id': sessionId as string,
-      },
-      body: JSON.stringify({
-        jsonrpc: MCP_JSON_RPC_VERSION,
-        method: 'notifications/initialized',
-      }),
+    let callbackError: string | null = null
+    await page.route(`${MCP_CALLBACK_URL}**`, async (route) => {
+      const callbackUrl = new URL(route.request().url())
+      callbackError = callbackUrl.searchParams.get('error')
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'ok',
+      })
     })
 
-    const pingResponse = await fetch(CANONICAL_MCP_RESOURCE, {
-      method: 'POST',
-      headers: {
-        host: mcpHost,
-        accept: 'application/json, text/event-stream',
-        'content-type': 'application/json',
-        authorization: `Bearer ${tokenBody.access_token}`,
-        'mcp-session-id': sessionId as string,
-      },
-      body: JSON.stringify({
-        jsonrpc: MCP_JSON_RPC_VERSION,
-        id: 2,
-        method: 'tools/call',
-        params: { name: 'ping', arguments: {} },
-      }),
+    await page.goto(authorizeUrl, { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/consent/, { timeout: 30_000 })
+    await expect(page.getByTestId('mcp-consent-deny')).toBeEnabled({ timeout: 30_000 })
+
+    await page.getByTestId('mcp-consent-deny').click()
+    await expect.poll(() => callbackError, { timeout: 30_000 }).toBe('access_denied')
+  })
+})
+
+test.describe('MCP OAuth browser flow (logged out)', () => {
+  test.use({ storageState: EMPTY_STORAGE_STATE })
+
+  test('authorize → login → consent → token', async ({ page }) => {
+    test.setTimeout(60_000)
+
+    const clientId = await registerMcpOAuthClient()
+    const { codeVerifier, codeChallenge } = createPkcePair()
+    const state = `pw-login-${randomBytes(8).toString('hex')}`
+    const authorizeUrl = buildAuthorizeUrl({
+      clientId,
+      resource: CANONICAL_MCP_RESOURCE,
+      codeChallenge,
+      state,
     })
 
-    expect(pingResponse.ok).toBeTruthy()
-    const pingBody = parseSseJson(await pingResponse.text()) as {
-      result?: { content?: Array<{ text?: string }> }
-    }
-    expect(pingBody.result?.content?.[0]?.text).toContain('pong')
+    let authorizationCode: string | null = null
+    await page.route(`${MCP_CALLBACK_URL}**`, async (route) => {
+      const callbackUrl = new URL(route.request().url())
+      authorizationCode = callbackUrl.searchParams.get('code')
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'ok',
+      })
+    })
+
+    await page.goto(authorizeUrl, { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/login/, { timeout: 30_000 })
+    await expect(page.getByTestId('login-form')).toBeVisible()
+
+    await page.fill('input[id="email"]', E2E_ADMIN_EMAIL)
+    await page.fill('input[id="password"]', E2E_ADMIN_PASSWORD)
+    await Promise.all([
+      page.waitForResponse((resp) => resp.url().includes('/api/auth/sign-in'), {
+        timeout: 30_000,
+      }),
+      page.getByTestId('login-form').locator('button[type="submit"]').click(),
+    ])
+
+    await expect(page).toHaveURL(/\/consent/, { timeout: 30_000 })
+    await expect(page.getByTestId('mcp-consent-allow')).toBeEnabled({ timeout: 30_000 })
+    await page.getByTestId('mcp-consent-allow').click()
+    await expect.poll(() => authorizationCode, { timeout: 30_000 }).not.toBeNull()
+
+    const accessToken = await exchangeAuthorizationCode({
+      code: authorizationCode as string,
+      clientId,
+      codeVerifier,
+      resource: CANONICAL_MCP_RESOURCE,
+    })
+
+    await mcpPingWithToken(accessToken)
   })
 })

--- a/apps/web/e2e/mcp-oauth.spec.ts
+++ b/apps/web/e2e/mcp-oauth.spec.ts
@@ -1,0 +1,219 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+
+const MCP_PROTOCOL_VERSION = '2024-11-05'
+const MCP_JSON_RPC_VERSION = '2.0'
+
+function parseSseJson(body: string): unknown {
+  const trimmed = body.trim()
+  const lastEvent = trimmed.split('\n\n').at(-1) ?? trimmed
+  const dataLines = lastEvent
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => line.slice('data: '.length))
+  return JSON.parse(dataLines.join('\n') || trimmed)
+}
+
+const WEB_BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173'
+const CANONICAL_MCP_RESOURCE = `${WEB_BASE_URL.replace(/\/$/, '')}/mcp`
+const MCP_CALLBACK_URL = 'http://127.0.0.1:8765/callback'
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer.toString('base64url')
+}
+
+function createPkcePair() {
+  const codeVerifier = base64UrlEncode(randomBytes(32))
+  const codeChallenge = base64UrlEncode(createHash('sha256').update(codeVerifier).digest())
+  return { codeVerifier, codeChallenge }
+}
+
+async function assertProtectedResourceMetadata(): Promise<void> {
+  const response = await fetch(
+    `${WEB_BASE_URL}/api/auth/.well-known/oauth-protected-resource`
+  )
+  expect(response.ok).toBeTruthy()
+  const body = (await response.json()) as { resource?: string }
+  expect(body.resource).toBe(CANONICAL_MCP_RESOURCE)
+}
+
+async function registerMcpOAuthClient() {
+  const response = await fetch(`${WEB_BASE_URL}/api/auth/mcp/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      redirect_uris: [MCP_CALLBACK_URL],
+      client_name: `playwright-mcp-oauth-${Date.now()}`,
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+    }),
+  })
+  const text = await response.text()
+  expect(response.ok, `register failed: ${response.status} ${text}`).toBeTruthy()
+  const body = JSON.parse(text) as { client_id?: string }
+  expect(body.client_id).toBeTruthy()
+  return body.client_id as string
+}
+
+function buildAuthorizeUrl(input: {
+  clientId: string
+  resource: string
+  codeChallenge: string
+  state: string
+}) {
+  const params = new URLSearchParams({
+    client_id: input.clientId,
+    redirect_uri: MCP_CALLBACK_URL,
+    response_type: 'code',
+    scope: 'openid mcp:discover',
+    state: input.state,
+    code_challenge: input.codeChallenge,
+    code_challenge_method: 'S256',
+    resource: input.resource,
+    prompt: 'consent',
+  })
+  return `${WEB_BASE_URL}/api/auth/mcp/authorize?${params.toString()}`
+}
+
+test.describe('MCP OAuth browser flow', () => {
+  test('register → authorize → consent → token → MCP ping', async ({ page }) => {
+    await assertProtectedResourceMetadata()
+    const resource = CANONICAL_MCP_RESOURCE
+    const clientId = await registerMcpOAuthClient()
+    const { codeVerifier, codeChallenge } = createPkcePair()
+    const state = `pw-${randomBytes(8).toString('hex')}`
+
+    const authorizeUrl = buildAuthorizeUrl({
+      clientId,
+      resource,
+      codeChallenge,
+      state,
+    })
+
+    let authorizationCode: string | null = null
+    let callbackState: string | null = null
+    await page.route(`${MCP_CALLBACK_URL}**`, async (route) => {
+      const callbackUrl = new URL(route.request().url())
+      authorizationCode = callbackUrl.searchParams.get('code')
+      callbackState = callbackUrl.searchParams.get('state')
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'ok',
+      })
+    })
+
+    await page.goto(authorizeUrl, { waitUntil: 'domcontentloaded' })
+
+    await expect(page).toHaveURL(/\/consent/, { timeout: 30_000 })
+    await expect(page.getByRole('heading', { name: 'Authorize application' })).toBeVisible()
+    await expect(page.getByTestId('mcp-consent-allow')).toBeEnabled({ timeout: 30_000 })
+
+    await page.getByTestId('mcp-consent-allow').click()
+    await expect
+      .poll(() => authorizationCode, { timeout: 30_000 })
+      .not.toBeNull()
+
+    const code = authorizationCode
+    expect(code).toBeTruthy()
+    expect(callbackState).toBe(state)
+
+    const tokenParams = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: code as string,
+      redirect_uri: MCP_CALLBACK_URL,
+      client_id: clientId,
+      code_verifier: codeVerifier,
+      resource,
+    })
+    const tokenResponse = await fetch(`${WEB_BASE_URL}/api/auth/mcp/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: tokenParams.toString(),
+    })
+    const tokenText = await tokenResponse.text()
+    expect(tokenResponse.ok, `token failed: ${tokenResponse.status} ${tokenText}`).toBeTruthy()
+    const tokenBody = JSON.parse(tokenText) as { access_token?: string; scope?: string }
+    expect(tokenBody.access_token).toBeTruthy()
+    expect(tokenBody.scope).toContain('mcp:discover')
+
+    const sessionCheck = await fetch(`${WEB_BASE_URL}/api/auth/mcp/get-session`, {
+      headers: { authorization: `Bearer ${tokenBody.access_token}` },
+    })
+    const sessionBody = await sessionCheck.json()
+    expect(sessionCheck.ok, `get-session failed: ${JSON.stringify(sessionBody)}`).toBeTruthy()
+    expect(sessionBody).not.toBeNull()
+
+    const mcpHost = new URL(CANONICAL_MCP_RESOURCE).host
+    const initResponse = await fetch(CANONICAL_MCP_RESOURCE, {
+      method: 'POST',
+      headers: {
+        host: mcpHost,
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+        authorization: `Bearer ${tokenBody.access_token}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'playwright-mcp-oauth', version: '1.0.0' },
+        },
+      }),
+    })
+
+    const initText = await initResponse.text()
+    expect(initResponse.status, `initialize failed: ${initResponse.status} ${initText}`).toBe(
+      200
+    )
+    const sessionId = initResponse.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    const initBody = parseSseJson(initText) as {
+      result?: { serverInfo?: { name?: string } }
+    }
+    expect(initBody.result?.serverInfo?.name).toBe('durabull-mcp')
+
+    await fetch(CANONICAL_MCP_RESOURCE, {
+      method: 'POST',
+      headers: {
+        host: mcpHost,
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+        authorization: `Bearer ${tokenBody.access_token}`,
+        'mcp-session-id': sessionId as string,
+      },
+      body: JSON.stringify({
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        method: 'notifications/initialized',
+      }),
+    })
+
+    const pingResponse = await fetch(CANONICAL_MCP_RESOURCE, {
+      method: 'POST',
+      headers: {
+        host: mcpHost,
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+        authorization: `Bearer ${tokenBody.access_token}`,
+        'mcp-session-id': sessionId as string,
+      },
+      body: JSON.stringify({
+        jsonrpc: MCP_JSON_RPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'ping', arguments: {} },
+      }),
+    })
+
+    expect(pingResponse.ok).toBeTruthy()
+    const pingBody = parseSseJson(await pingResponse.text()) as {
+      result?: { content?: Array<{ text?: string }> }
+    }
+    expect(pingBody.result?.content?.[0]?.text).toContain('pong')
+  })
+})

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -103,6 +103,8 @@ export default defineConfig({
       return {
         ...process.env,
         SKIP_CLEAR_PORT_3001: "1",
+        APP_BASE_URL: "http://localhost:5173",
+        VITE_PUBLIC_APP_URL: "http://localhost:5173",
         DURABULL_REDIS_URL_ENCRYPTION_KEY:
           process.env.DURABULL_REDIS_URL_ENCRYPTION_KEY ?? defaultE2ERedisUrlEncryptionKey,
         PATH: `${prepend}${process.env.PATH ?? ""}`,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SignupRouteImport } from './routes/signup'
 import { Route as SetupOrganizationRouteImport } from './routes/setup-organization'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as ConsentRouteImport } from './routes/consent'
 import { Route as AuthErrorRouteImport } from './routes/auth-error'
 import { Route as OrgSlugRouteImport } from './routes/$orgSlug'
 import { Route as IndexRouteImport } from './routes/index'
@@ -58,6 +59,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConsentRoute = ConsentRouteImport.update({
+  id: '/consent',
+  path: '/consent',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthErrorRoute = AuthErrorRouteImport.update({
@@ -210,6 +216,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$orgSlug': typeof OrgSlugRouteWithChildren
   '/auth-error': typeof AuthErrorRoute
+  '/consent': typeof ConsentRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/setup-organization': typeof SetupOrganizationRoute
@@ -241,6 +248,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth-error': typeof AuthErrorRoute
+  '/consent': typeof ConsentRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/setup-organization': typeof SetupOrganizationRoute
@@ -272,6 +280,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$orgSlug': typeof OrgSlugRouteWithChildren
   '/auth-error': typeof AuthErrorRoute
+  '/consent': typeof ConsentRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/setup-organization': typeof SetupOrganizationRoute
@@ -306,6 +315,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$orgSlug'
     | '/auth-error'
+    | '/consent'
     | '/login'
     | '/settings'
     | '/setup-organization'
@@ -337,6 +347,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/auth-error'
+    | '/consent'
     | '/login'
     | '/settings'
     | '/setup-organization'
@@ -367,6 +378,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$orgSlug'
     | '/auth-error'
+    | '/consent'
     | '/login'
     | '/settings'
     | '/setup-organization'
@@ -400,6 +412,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OrgSlugRoute: typeof OrgSlugRouteWithChildren
   AuthErrorRoute: typeof AuthErrorRoute
+  ConsentRoute: typeof ConsentRoute
   LoginRoute: typeof LoginRoute
   SettingsRoute: typeof SettingsRoute
   SetupOrganizationRoute: typeof SetupOrganizationRoute
@@ -435,6 +448,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/consent': {
+      id: '/consent'
+      path: '/consent'
+      fullPath: '/consent'
+      preLoaderRoute: typeof ConsentRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth-error': {
@@ -706,6 +726,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OrgSlugRoute: OrgSlugRouteWithChildren,
   AuthErrorRoute: AuthErrorRoute,
+  ConsentRoute: ConsentRoute,
   LoginRoute: LoginRoute,
   SettingsRoute: SettingsRoute,
   SetupOrganizationRoute: SetupOrganizationRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -76,7 +76,7 @@ const USE_DEVTOOLS = false
 
 // Public routes that don't require authentication (auth-related only)
 // Marketing/landing pages are now in the separate docs app
-const PUBLIC_ROUTES = ['/login', '/signup', '/auth-error']
+const PUBLIC_ROUTES = ['/login', '/signup', '/auth-error', '/consent']
 
 // Check if a path matches an invite route pattern
 const isInviteRoute = (pathname: string) => pathname.startsWith('/invite/')

--- a/apps/web/src/routes/consent.tsx
+++ b/apps/web/src/routes/consent.tsx
@@ -1,0 +1,249 @@
+import {
+  labelConsentScopes,
+  type McpOAuthConsentContext,
+  parseMcpOAuthConsentSearch,
+  submitOAuthConsent,
+} from '@durabull/auth/client'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { AlertCircle, Loader2, ShieldCheck } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { AuthLayout } from '@/components/auth-layout'
+import { DurabullLogo, DurabullWordmark } from '@/components/durabull-logo'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { useAuth } from '@/hooks/use-auth'
+
+export const Route = createFileRoute('/consent')({
+  validateSearch: (search: Record<string, unknown>) => parseMcpOAuthConsentSearch(search),
+  component: ConsentPage,
+})
+
+function ConsentPage() {
+  const search = Route.useSearch()
+  const navigate = useNavigate()
+  const { isAuthenticated, isLoading: sessionLoading } = useAuth()
+  const [context, setContext] = useState<McpOAuthConsentContext | null>(null)
+  const [contextError, setContextError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const consentPathWithSearch = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return '/consent'
+    }
+    return `${window.location.pathname}${window.location.search}`
+  }, [search])
+
+  const labeledScopes = useMemo(
+    () => labelConsentScopes(context?.scopes ?? []),
+    [context?.scopes]
+  )
+
+  useEffect(() => {
+    if (sessionLoading) {
+      return
+    }
+
+    if (!isAuthenticated) {
+      navigate({
+        to: '/login',
+        search: { redirect: consentPathWithSearch },
+        replace: true,
+      })
+    }
+  }, [consentPathWithSearch, isAuthenticated, navigate, sessionLoading])
+
+  useEffect(() => {
+    if (!isAuthenticated || !search.consent_code) {
+      return
+    }
+
+    let cancelled = false
+
+    async function loadConsentContext() {
+      setContextError(null)
+      try {
+        const response = await fetch(
+          `/api/mcp/oauth-consent/${encodeURIComponent(search.consent_code!)}`,
+          { credentials: 'include' }
+        )
+        const data = (await response.json()) as McpOAuthConsentContext & {
+          message?: string
+          error?: string
+        }
+        if (response.status === 403 && data.error === 'client_disabled') {
+          if (!cancelled) {
+            setContext({
+              clientId: data.clientId,
+              name: data.name,
+              icon: data.icon ?? null,
+              disabled: true,
+              scopes: data.scopes ?? [],
+            })
+          }
+          return
+        }
+        if (!response.ok) {
+          throw new Error(data.message ?? data.error ?? 'Unable to load authorization request')
+        }
+
+        if (
+          search.client_id &&
+          data.clientId !== search.client_id
+        ) {
+          throw new Error('Authorization link does not match the requesting application')
+        }
+
+        if (!cancelled) {
+          setContext(data)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setContext(null)
+          setContextError(
+            error instanceof Error ? error.message : 'Unable to load authorization request'
+          )
+        }
+      }
+    }
+
+    void loadConsentContext()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated, search.client_id, search.consent_code])
+
+  const missingConsentCode = !search.consent_code
+
+  const handleConsent = async (accept: boolean) => {
+    if (context?.disabled) {
+      setActionError('This application has been disabled and cannot be authorized.')
+      return
+    }
+
+    setIsSubmitting(true)
+    setActionError(null)
+    try {
+      const result = await submitOAuthConsent({
+        accept,
+        consentCode: search.consent_code,
+      })
+      window.location.assign(result.redirectURI)
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Failed to complete authorization')
+      setIsSubmitting(false)
+    }
+  }
+
+  if (sessionLoading || !isAuthenticated) {
+    return (
+      <AuthLayout>
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  return (
+    <AuthLayout>
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <Card className="w-full max-w-lg border-border/60 bg-card/95 p-6 shadow-xl">
+          <div className="mb-6 flex items-center gap-3">
+            <DurabullLogo className="h-9 w-9" />
+            <DurabullWordmark className="h-6" />
+          </div>
+
+          <div className="mb-4 flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+            <div>
+              <h1 className="text-lg font-semibold">Authorize application</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Review the access requested before connecting to Durabull MCP.
+              </p>
+            </div>
+          </div>
+
+          {missingConsentCode ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              This authorization link is incomplete or expired. Start again from your MCP client.
+            </div>
+          ) : contextError ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {contextError}
+            </div>
+          ) : !context ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading authorization details…
+            </div>
+          ) : (
+            <>
+              <div className="mb-4 rounded-md border bg-muted/30 p-4">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Application
+                </p>
+                <p className="mt-1 text-base font-medium">{context.name}</p>
+                {context.disabled ? (
+                  <p className="mt-2 text-sm text-destructive">
+                    This application has been disabled and cannot be authorized.
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="mb-6 space-y-3">
+                <p className="text-sm font-medium">Requested access</p>
+                <ul className="space-y-2">
+                  {labeledScopes.map((entry) => (
+                    <li
+                      key={entry.scope}
+                      className="rounded-md border border-border/60 bg-background/60 px-3 py-2"
+                    >
+                      <p className="text-sm font-medium">
+                        {entry.title}
+                        {entry.unknownScope ? (
+                          <span className="ml-2 text-xs font-normal text-amber-600">
+                            (unrecognized scope)
+                          </span>
+                        ) : null}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{entry.description}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {actionError ? (
+                <div className="mb-4 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{actionError}</span>
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  data-testid="mcp-consent-allow"
+                  disabled={isSubmitting || context.disabled}
+                  onClick={() => void handleConsent(true)}
+                >
+                  {isSubmitting ? 'Authorizing…' : 'Allow access'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  data-testid="mcp-consent-deny"
+                  disabled={isSubmitting}
+                  onClick={() => void handleConsent(false)}
+                >
+                  Deny
+                </Button>
+              </div>
+            </>
+          )}
+        </Card>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,7 +1,13 @@
 import { AnalyticsEvents, AuthMethod, trackEvent } from '@durabull/analytics'
+import {
+  buildMcpAuthorizeResumeUrl,
+  hasMcpAuthorizeQuery,
+  isSafeAppRedirectPath,
+  resolveSafeAppRedirectPath,
+} from '@durabull/auth/client'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { AlertCircle, Github, Loader2, Mail } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AuthLayout } from '@/components/auth-layout'
 import { DurabullLogo, DurabullWordmark } from '@/components/durabull-logo'
 import { Button } from '@/components/ui/button'
@@ -13,20 +19,33 @@ import { getAuthErrorMessage, useAuth } from '@/hooks/use-auth'
 
 interface LoginSearch {
   invitationId?: string
+  redirect?: string
 }
 
-export const Route = createFileRoute('/login')({
-  validateSearch: (search: Record<string, unknown>): LoginSearch => ({
+function parseLoginSearch(search: Record<string, unknown>): LoginSearch {
+  const redirectRaw =
+    typeof search.redirect === 'string' &&
+    search.redirect.length > 0 &&
+    isSafeAppRedirectPath(search.redirect)
+      ? search.redirect
+      : undefined
+
+  return {
     invitationId:
       typeof search.invitationId === 'string' && search.invitationId.length > 0
         ? search.invitationId
         : undefined,
-  }),
+    redirect: redirectRaw,
+  }
+}
+
+export const Route = createFileRoute('/login')({
+  validateSearch: (search: Record<string, unknown>): LoginSearch => parseLoginSearch(search),
   component: LoginPage,
 })
 
 function LoginPage() {
-  const { invitationId } = Route.useSearch()
+  const { invitationId, redirect } = Route.useSearch()
   const navigate = useNavigate()
   const { signIn, isAuthenticated, isLoading: sessionLoading, refetch } = useAuth()
   const [isLoading, setIsLoading] = useState(false)
@@ -39,12 +58,51 @@ function LoginPage() {
 
   const invitationPath = invitationId ? `/invite/${invitationId}` : null
 
-  const getOAuthCallbackURL = () => {
-    if (!invitationPath || typeof window === 'undefined') return undefined
-    return `${window.location.origin}${invitationPath}`
+  const getPostAuthCallbackURL = (): string | undefined => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    if (redirect) {
+      return `${window.location.origin}${redirect}`
+    }
+
+    const urlParams = Object.fromEntries(new URLSearchParams(window.location.search).entries())
+    const mcpAuthorizeUrl = buildMcpAuthorizeResumeUrl(urlParams)
+    if (mcpAuthorizeUrl) {
+      return `${window.location.origin}${mcpAuthorizeUrl}`
+    }
+
+    if (invitationPath) {
+      return `${window.location.origin}${invitationPath}`
+    }
+
+    return undefined
   }
 
   const navigateAfterAuth = () => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const safeRedirect = redirect
+      ? resolveSafeAppRedirectPath(redirect, window.location.origin)
+      : undefined
+    if (safeRedirect) {
+      window.location.assign(safeRedirect)
+      return
+    }
+
+    const urlParams =
+      typeof window !== 'undefined'
+        ? Object.fromEntries(new URLSearchParams(window.location.search).entries())
+        : {}
+    const mcpAuthorizeUrl = buildMcpAuthorizeResumeUrl(urlParams)
+    if (mcpAuthorizeUrl) {
+      window.location.assign(mcpAuthorizeUrl)
+      return
+    }
+
     if (invitationId) {
       navigate({ to: '/invite/$invitationId', params: { invitationId } })
       return
@@ -52,21 +110,12 @@ function LoginPage() {
     navigate({ to: '/' })
   }
 
-  // Redirect if already authenticated
-  if (sessionLoading) {
-    return (
-      <AuthLayout>
-        <div className="flex min-h-screen items-center justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-primary" />
-        </div>
-      </AuthLayout>
-    )
-  }
-
-  if (isAuthenticated) {
-    navigateAfterAuth()
-    return null
-  }
+  useEffect(() => {
+    if (!sessionLoading && isAuthenticated) {
+      navigateAfterAuth()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- resume once when session becomes authenticated
+  }, [isAuthenticated, sessionLoading])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -93,7 +142,6 @@ function LoginPage() {
         success: true,
       })
 
-      // Refetch session to update auth state
       await refetch()
       navigateAfterAuth()
     } catch (err) {
@@ -108,10 +156,15 @@ function LoginPage() {
 
     trackEvent(AnalyticsEvents.USER_SIGNED_IN, {
       auth_method: AuthMethod.GOOGLE,
-      success: true, // OAuth redirects, so we track the attempt
+      success: true,
     })
 
-    const callbackURL = getOAuthCallbackURL()
+    const callbackURL = getPostAuthCallbackURL()
+    const authorizeParams =
+      typeof window !== 'undefined'
+        ? Object.fromEntries(new URLSearchParams(window.location.search).entries())
+        : {}
+    const preserveMcpAuthorize = hasMcpAuthorizeQuery(authorizeParams)
 
     try {
       const result = await signIn.social({
@@ -122,7 +175,7 @@ function LoginPage() {
               newUserCallbackURL: callbackURL,
             }
           : {}),
-        ...(invitationId
+        ...(invitationId || preserveMcpAuthorize
           ? {
               requestSignUp: true,
             }
@@ -132,7 +185,6 @@ function LoginPage() {
       if (result?.error) {
         const errorMessage = getAuthErrorMessage(result, 'Failed to sign in with Google')
 
-        // If the account already exists with a different provider, redirect to error page
         if (errorMessage === 'ACCOUNT_EXISTS') {
           navigate({ to: '/auth-error', search: { reason: 'account-exists', provider: 'google' } })
           return
@@ -153,10 +205,16 @@ function LoginPage() {
 
     trackEvent(AnalyticsEvents.USER_SIGNED_IN, {
       auth_method: AuthMethod.GITHUB,
-      success: true, // OAuth redirects, so we track the attempt
+      success: true,
     })
 
-    const callbackURL = getOAuthCallbackURL()
+    const callbackURL = getPostAuthCallbackURL()
+
+    const authorizeParams =
+      typeof window !== 'undefined'
+        ? Object.fromEntries(new URLSearchParams(window.location.search).entries())
+        : {}
+    const preserveMcpAuthorize = hasMcpAuthorizeQuery(authorizeParams)
 
     try {
       const result = await signIn.social({
@@ -167,7 +225,7 @@ function LoginPage() {
               newUserCallbackURL: callbackURL,
             }
           : {}),
-        ...(invitationId
+        ...(invitationId || preserveMcpAuthorize
           ? {
               requestSignUp: true,
             }
@@ -177,7 +235,6 @@ function LoginPage() {
       if (result?.error) {
         const errorMessage = getAuthErrorMessage(result, 'Failed to sign in with GitHub')
 
-        // If the account already exists with a different provider, redirect to error page
         if (errorMessage === 'ACCOUNT_EXISTS') {
           navigate({ to: '/auth-error', search: { reason: 'account-exists', provider: 'github' } })
           return
@@ -192,11 +249,20 @@ function LoginPage() {
     }
   }
 
+  if (sessionLoading || isAuthenticated) {
+    return (
+      <AuthLayout>
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      </AuthLayout>
+    )
+  }
+
   return (
     <AuthLayout>
       <div className="flex min-h-screen items-center justify-center p-4 pt-24">
         <Card className="w-full max-w-md border-border bg-card p-8">
-          {/* Logo */}
           <div className="mb-8 flex flex-col items-center">
             <div className="flex items-center gap-2">
               <DurabullLogo className="h-10 w-10 text-primary" />
@@ -207,7 +273,6 @@ function LoginPage() {
             </p>
           </div>
 
-          {/* Social Login Buttons */}
           <div className="space-y-3">
             <Button
               variant="outline"
@@ -254,7 +319,6 @@ function LoginPage() {
             </span>
           </div>
 
-          {/* Email/Password Form */}
           <form onSubmit={handleSubmit} className="space-y-4" data-testid="login-form">
             <div className="space-y-2">
               <Label htmlFor="email">Email</Label>
@@ -299,7 +363,6 @@ function LoginPage() {
             </Button>
           </form>
 
-          {/* Link to Sign Up */}
           <p className="mt-6 text-center text-sm text-muted-foreground">
             Don't have an account?{' '}
             {invitationId ? (

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -56,6 +56,15 @@ export default defineConfig({
         target: 'http://localhost:3001',
         changeOrigin: true,
       },
+      // MCP + OAuth discovery (same origin as APP_BASE_URL in local dev)
+      '/mcp': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+      '/.well-known': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
       // PostHog proxy traffic always goes through the API server.
       '/ingest': {
         target: 'http://localhost:3001',

--- a/docs/mcp-ga-release-checklist.md
+++ b/docs/mcp-ga-release-checklist.md
@@ -6,15 +6,16 @@ Use this checklist when enabling or announcing read-only MCP GA on Durabull Clou
 
 ## Pre-release
 
-- [ ] `main` includes PR-02 through PR-08 (GA docs + ADR).
-- [ ] Automated tests green — commands and results: [validation evidence](./mcp-ga-validation-evidence.md).
+- [x] `main` includes PR-02 through PR-08 (GA docs + ADR) plus OAuth consent UI follow-up.
+- [x] Automated tests green — commands and results: [validation evidence](./mcp-ga-validation-evidence.md) (includes Playwright `mcp-oauth.spec.ts`).
 - [ ] [Compliance checklist](./mcp-ga-compliance-checklist.md) reviewed.
 - [ ] [Security closure](./mcp-ga-security-closure.md) reviewed (human sign-off if required).
 - [ ] Staging: PRM + health checks per [mcp-operations-runbook.md](./mcp-operations-runbook.md).
 - [ ] Staging: `cd tooling/scripts && APP_BASE_URL=<staging> bun run mcp:e2e` (staging DB only).
+- [ ] Staging: `cd apps/web && bun run test:e2e e2e/mcp-oauth.spec.ts` (browser OAuth consent path).
 - [ ] Staging: alert or edge rate limit on `POST /api/auth/mcp/register` (SEC-04).
 - [ ] Production config: `APP_BASE_URL` matches public URL; `DURABULL_AUTHLESS=false`.
-- [ ] Docs published: [MCP Server](https://github.com/durabullhq/durabull/blob/main/apps/docs/content/documentation/integrations/mcp-server.mdx), [GA index](./mcp-ga-index.md).
+- [x] Docs published: [MCP Server](https://github.com/durabullhq/durabull/blob/main/apps/docs/content/documentation/integrations/mcp-server.mdx) (consent flow), [GA index](./mcp-ga-index.md), [OAuth operator guide](./mcp-oauth-operator.md).
 
 ## Release steps
 

--- a/docs/mcp-ga-security-closure.md
+++ b/docs/mcp-ga-security-closure.md
@@ -23,6 +23,7 @@ Phase 1 MCP documentation and automated tests show **no critical or high** open 
 | SEC-08 | — | Service account requires policy binding + scopes | **Verified** — `mount.test.ts`, `mcp-policy.test.ts` |
 | SEC-09 | — | Output redaction for secrets/Redis URLs | **Verified** — `sanitize-output.test.ts` |
 | SEC-10 | — | RFC 8707 resource enforced on validation | **Verified** — `validate-token.test.ts`; issuance via Better Auth |
+| SEC-11 | — | Browser OAuth consent (`/consent`) for external MCP clients | **Verified** — `apps/web/e2e/mcp-oauth.spec.ts` (authorize + `prompt=consent` → token → `ping`) |
 
 ## Negative test coverage (automated)
 
@@ -49,5 +50,5 @@ Operator gates: [Release checklist — Pre-release](./mcp-ga-release-checklist.m
 
 | Reviewer | Role | Date | Approved |
 | --- | --- | --- | --- |
-| | Engineering | | Pending — automated tests documented in validation evidence |
+| Engineering (MCP OAuth UI) | Engineering | 2026-05-28 | Ready — consent UI + Playwright OAuth E2E; see [validation evidence](./mcp-ga-validation-evidence.md) |
 | | Security / owner | | **Pending human sign-off** |

--- a/docs/mcp-ga-validation-evidence.md
+++ b/docs/mcp-ga-validation-evidence.md
@@ -49,6 +49,17 @@ cd tooling/scripts && APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
 # Better Auth: 10/10 pass; authless: 9/9 pass
 ```
 
+### Browser OAuth E2E (Playwright)
+
+**Recorded:** 2026-05-28 (OAuth consent UI)
+
+```text
+cd apps/web && bun run test:e2e e2e/mcp-oauth.spec.ts
+# 1 passed — register → authorize (prompt=consent) → /consent → token → MCP ping
+```
+
+Uses real authorization code + PKCE (no DB token seeding). Requires `@durabull/api` + `@durabull/web` dev servers (Playwright `webServer`).
+
 **Operator gate:** Re-run on staging before production GA announcement (see release checklist).
 
 ## Regression scope

--- a/docs/mcp-ga-validation-evidence.md
+++ b/docs/mcp-ga-validation-evidence.md
@@ -55,10 +55,14 @@ cd tooling/scripts && APP_BASE_URL=http://localhost:3001 bun run mcp:e2e
 
 ```text
 cd apps/web && bun run test:e2e e2e/mcp-oauth.spec.ts
-# 1 passed — register → authorize (prompt=consent) → /consent → token → MCP ping
+# 4 passed:
+#   - POST /mcp 401 → WWW-Authenticate → PRM (app + auth paths) → AS metadata → register
+#   - register → authorize → consent → token → MCP ping (authenticated)
+#   - consent Deny → access_denied callback
+#   - logged-out authorize → login → consent → token → ping
 ```
 
-Uses real authorization code + PKCE (no DB token seeding). Requires `@durabull/api` + `@durabull/web` dev servers (Playwright `webServer`).
+Uses real authorization code + PKCE (no DB token seeding). Requires `@durabull/api` + `@durabull/web` dev servers (Playwright `webServer`). Runs in CI via `bun run test:e2e`.
 
 **Operator gate:** Re-run on staging before production GA announcement (see release checklist).
 

--- a/docs/mcp-oauth-operator.md
+++ b/docs/mcp-oauth-operator.md
@@ -16,7 +16,25 @@ Example (production): `https://app.durabull.io/mcp`
 
 Do not add a trailing slash unless your OAuth client library requires it consistently everywhere.
 
-`APP_BASE_URL` must be the **public origin clients use to reach `/mcp`** (same host/port as the API in production). If the API listens on port `3001` locally, set `APP_BASE_URL=http://localhost:3001`, not the Vite dev server port.
+`APP_BASE_URL` must be the **public origin clients use to reach `/mcp`** (same host/port as the API in production).
+
+**Local monorepo dev:** the Vite app (`http://localhost:5173`) proxies `/mcp` and `/.well-known` to the API process. Set `APP_BASE_URL=http://localhost:5173` so PRM, tokens, and browser consent use one origin. Use `http://localhost:3001` only when calling the API directly without the web proxy (for example `tooling/scripts/mcp:e2e`).
+
+## Browser consent flow
+
+Durabull serves a first-party consent screen at **`/consent`** (configured via Better Auth `consentPage`).
+
+Typical delegated-user flow:
+
+1. MCP client opens `GET /api/auth/mcp/authorize` with **PKCE** and `prompt=consent` (required to show the consent UI).
+2. Unauthenticated users sign in at `/login` (Durabull preserves the authorize request).
+3. Authenticated users review scopes at `/consent` and choose **Allow** or **Deny**.
+4. Durabull redirects to the client `redirect_uri` with an authorization `code`.
+5. Client exchanges the code at `POST /api/auth/mcp/token` with `resource={APP_BASE_URL}/mcp`.
+
+Consent submission calls `POST /api/auth/oauth2/consent` (session cookie required). Deny returns `error=access_denied` to the client redirect URI.
+
+**Not the same as Linear alerts OAuth:** [Linear integration](https://github.com/durabullhq/durabull/blob/main/apps/docs/content/documentation/integrations/linear.mdx) is Durabull acting as an OAuth **client** to Linear. MCP OAuth is Durabull acting as the **authorization server** for external MCP clients (Cursor, custom agents, etc.).
 
 ## Discovery endpoints
 
@@ -37,8 +55,8 @@ Protected resource metadata advertises:
 
 ## Client configuration checklist
 
-1. Register an OAuth client via `POST /api/auth/mcp/register` (or the Durabull UI when available).
-2. Complete authorization code + PKCE against `/api/auth/mcp/authorize`.
+1. Register an OAuth client via `POST /api/auth/mcp/register`.
+2. Complete authorization code + PKCE against `/api/auth/mcp/authorize` with `prompt=consent` and `resource={APP_BASE_URL}/mcp`.
 3. Exchange the code at `/api/auth/mcp/token` with `resource={APP_BASE_URL}/mcp`.
 4. Call MCP transport at `POST/GET/DELETE {APP_BASE_URL}/mcp` with `Authorization: Bearer <access_token>`.
 5. Request at least the `mcp:discover` scope for transport smoke (`ping`). Diagnostic tools require additional scopes (`mcp:jobs:read`, `mcp:logs:read`, `mcp:failures:read`, `mcp:diagnostics:read`) — see [MCP Server docs](https://github.com/durabullhq/durabull/blob/main/apps/docs/content/documentation/integrations/mcp-server.mdx).
@@ -60,7 +78,7 @@ When `DURABULL_AUTHLESS=true`, use bearer token from `MCP_AUTHLESS_BEARER_TOKEN`
 
 Never enable authless mode on Durabull Cloud (`DURABULL_CLOUD=true` refuses startup with authless enabled). **Internet-facing production must use OAuth** (`DURABULL_AUTHLESS=false`). Authless with `MCP_AUTHLESS_BEARER_TOKEN` is only for isolated lab networks, not DMZ or VPN-wide production substitutes.
 
-Access tokens must include the RFC 8707 `resource` indicator matching `{APP_BASE_URL}/mcp` (Better Auth sets this on issuance; Durabull rejects tokens without it).
+Access tokens must validate against `{APP_BASE_URL}/mcp` (RFC 8707). Durabull sets the canonical resource on issuance and treats missing `resource` columns as the canonical URI during MCP ingress validation.
 
 ## Operations
 

--- a/docs/mcp-operations-runbook.md
+++ b/docs/mcp-operations-runbook.md
@@ -154,6 +154,15 @@ Wire your aggregator to count per hour:
 
 Alert thresholds are environment-specific; start with sustained 5× baseline on rate limits and policy denies.
 
+### SEC-04 edge alert (pre-GA)
+
+Before announcing customer MCP GA, configure an edge or access-log alert on **`POST /api/auth/mcp/register`** (unauthenticated dynamic registration). Example thresholds:
+
+- **Warning:** > 50 registrations / 5 min per environment (adjust to baseline)
+- **Critical:** sustained > 200 / 5 min or spike > 10× 7-day median
+
+Mitigation: block path at edge, rotate compromised clients, review `oauth_client` rows and `mcp_audit_event`.
+
 ## Common incidents
 
 ### Clients receive `403` on `Host`

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,6 +11,10 @@
     "./client": {
       "types": "./src/client.ts",
       "import": "./src/client.ts"
+    },
+    "./mcp-consent": {
+      "types": "./src/mcp-consent.ts",
+      "import": "./src/mcp-consent.ts"
     }
   },
   "scripts": {

--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -1,6 +1,24 @@
 import { organizationClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
 
+export { submitOAuthConsent } from './submit-oauth-consent'
+export type { SubmitOAuthConsentInput, SubmitOAuthConsentResult } from './submit-oauth-consent'
+export {
+  buildLoginRedirectForConsent,
+  buildMcpAuthorizeResumeUrl,
+  hasMcpAuthorizeQuery,
+  labelConsentScopes,
+  MCP_OAUTH_CONSENT_PATH,
+  parseConsentScopeList,
+  parseMcpOAuthConsentSearch,
+} from './mcp-consent'
+export type {
+  LabeledConsentScope,
+  McpOAuthConsentContext,
+  McpOAuthConsentSearch,
+} from './mcp-consent'
+export { isSafeAppRedirectPath, resolveSafeAppRedirectPath } from './safe-redirect'
+
 /**
  * Get the base URL for the auth client.
  * In order of priority:

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -7,6 +7,7 @@ import {
   oauthConsent,
   organizationSchema,
   user,
+  type NewOauthAccessToken,
 } from '@durabull/dal'
 import { env } from '@durabull/env'
 import { betterAuth } from 'better-auth'
@@ -198,7 +199,7 @@ export async function createAuth(options?: CreateAuthOptions) {
       },
       oauthAccessToken: {
         create: {
-          before: async (token) => {
+          before: async (token: NewOauthAccessToken) => {
             const canonicalResource = getCanonicalMcpResourceUri(
               options?.baseURL ?? env.APP_BASE_URL
             )

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -12,10 +12,9 @@ import { env } from '@durabull/env'
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { mcp, organization } from 'better-auth/plugins'
-import {
-  getCanonicalMcpResourceUri,
-  MCP_PHASE1_SCOPES,
-} from '@durabull/mcp/auth'
+import { getCanonicalMcpResourceUri } from '@durabull/mcp/auth'
+import { MCP_OAUTH_CONSENT_PATH } from './mcp-consent'
+import { MCP_PHASE1_SCOPES } from './mcp-scope-labels'
 
 const isProduction = env.NODE_ENV === 'production'
 
@@ -199,6 +198,17 @@ export async function createAuth(options?: CreateAuthOptions) {
       },
       oauthAccessToken: {
         create: {
+          before: async (token) => {
+            const canonicalResource = getCanonicalMcpResourceUri(
+              options?.baseURL ?? env.APP_BASE_URL
+            )
+            return {
+              data: {
+                ...token,
+                resource: token.resource ?? canonicalResource,
+              },
+            }
+          },
           after: async (token: { id: string; resource: string | null }) => {
             const canonicalResource = getCanonicalMcpResourceUri(
               options?.baseURL ?? env.APP_BASE_URL
@@ -231,6 +241,7 @@ export async function createAuth(options?: CreateAuthOptions) {
         resource: getCanonicalMcpResourceUri(options?.baseURL ?? env.APP_BASE_URL),
         oidcConfig: {
           loginPage: '/login',
+          consentPage: MCP_OAUTH_CONSENT_PATH,
           scopes: [...MCP_PHASE1_SCOPES],
           metadata: {
             scopes_supported: [

--- a/packages/auth/src/mcp-consent.test.ts
+++ b/packages/auth/src/mcp-consent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  buildMcpAuthorizeResumeUrl,
+  labelConsentScopes,
+  parseConsentScopeList,
+  parseMcpOAuthConsentSearch,
+} from './mcp-consent'
+
+describe('mcp-consent helpers', () => {
+  it('parses consent search params', () => {
+    expect(
+      parseMcpOAuthConsentSearch({
+        consent_code: 'abc',
+        client_id: 'client-1',
+        scope: 'openid mcp:discover',
+      })
+    ).toEqual({
+      consent_code: 'abc',
+      client_id: 'client-1',
+      scope: 'openid mcp:discover',
+    })
+  })
+
+  it('labels MCP scopes for the consent screen', () => {
+    const labels = labelConsentScopes(parseConsentScopeList('mcp:discover mcp:jobs:read'))
+    expect(labels.map((entry) => entry.scope)).toEqual(['mcp:discover', 'mcp:jobs:read'])
+    expect(labels[0]?.title).toBe('MCP discovery')
+  })
+
+  it('builds authorize resume URLs with consent prompt', () => {
+    const url = buildMcpAuthorizeResumeUrl({
+      client_id: 'client',
+      redirect_uri: 'http://127.0.0.1/callback',
+      response_type: 'code',
+      scope: 'openid mcp:discover',
+    })
+    expect(url).toContain('/api/auth/mcp/authorize')
+    expect(url).toContain('prompt=consent')
+  })
+})

--- a/packages/auth/src/mcp-consent.ts
+++ b/packages/auth/src/mcp-consent.ts
@@ -1,0 +1,161 @@
+import {
+  isKnownMcpPhase1Scope,
+  MCP_SCOPE_DIAGNOSTICS_READ,
+  MCP_SCOPE_DISCOVER,
+  MCP_SCOPE_FAILURES_READ,
+  MCP_SCOPE_JOBS_READ,
+  MCP_SCOPE_LOGS_READ,
+} from './mcp-scope-labels'
+
+export { isKnownMcpPhase1Scope, MCP_PHASE1_SCOPES } from './mcp-scope-labels'
+
+export const MCP_OAUTH_CONSENT_PATH = '/consent'
+
+/** Human-readable labels for scopes shown on the OAuth consent screen. */
+export const MCP_SCOPE_LABELS: Record<string, { title: string; description: string }> = {
+  openid: {
+    title: 'Sign in',
+    description: 'Verify your Durabull account identity.',
+  },
+  profile: {
+    title: 'Profile',
+    description: 'Read your name and profile information.',
+  },
+  email: {
+    title: 'Email',
+    description: 'Read your email address.',
+  },
+  offline_access: {
+    title: 'Stay connected',
+    description: 'Refresh access without signing in again until you revoke access.',
+  },
+  [MCP_SCOPE_DISCOVER]: {
+    title: 'MCP discovery',
+    description: 'Connect to the Durabull MCP server and run connectivity checks.',
+  },
+  [MCP_SCOPE_JOBS_READ]: {
+    title: 'Read queues and jobs',
+    description: 'List connections, queues, jobs, and workers.',
+  },
+  [MCP_SCOPE_LOGS_READ]: {
+    title: 'Read job logs',
+    description: 'View job logs and stack traces.',
+  },
+  [MCP_SCOPE_FAILURES_READ]: {
+    title: 'Read failures',
+    description: 'View alert and failure events.',
+  },
+  [MCP_SCOPE_DIAGNOSTICS_READ]: {
+    title: 'Read diagnostics',
+    description: 'View queue metrics and failure explanations.',
+  },
+}
+
+export function parseConsentScopeList(scopeParam: string | undefined): string[] {
+  if (!scopeParam?.trim()) {
+    return []
+  }
+  return scopeParam
+    .split(/\s+/)
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0)
+}
+
+export type LabeledConsentScope = {
+  scope: string
+  title: string
+  description: string
+  unknownScope: boolean
+}
+
+export function labelConsentScopes(scopes: readonly string[]): LabeledConsentScope[] {
+  return scopes.map((scope) => {
+    const known = MCP_SCOPE_LABELS[scope]
+    return {
+      scope,
+      title: known?.title ?? scope,
+      description: known?.description ?? 'Access requested by the connecting application.',
+      unknownScope: !known && !isKnownMcpPhase1Scope(scope),
+    }
+  })
+}
+
+export interface McpOAuthConsentSearch {
+  consent_code?: string
+  client_id?: string
+  scope?: string
+}
+
+export function parseMcpOAuthConsentSearch(
+  search: Record<string, unknown>
+): McpOAuthConsentSearch {
+  return {
+    consent_code:
+      typeof search.consent_code === 'string' && search.consent_code.length > 0
+        ? search.consent_code
+        : undefined,
+    client_id:
+      typeof search.client_id === 'string' && search.client_id.length > 0
+        ? search.client_id
+        : undefined,
+    scope:
+      typeof search.scope === 'string' && search.scope.length > 0 ? search.scope : undefined,
+  }
+}
+
+/** Query keys preserved when resuming MCP authorize after login. */
+export const MCP_AUTHORIZE_QUERY_KEYS = [
+  'client_id',
+  'redirect_uri',
+  'response_type',
+  'scope',
+  'state',
+  'code_challenge',
+  'code_challenge_method',
+  'resource',
+  'prompt',
+  'nonce',
+] as const
+
+export function hasMcpAuthorizeQuery(search: Record<string, unknown>): boolean {
+  return (
+    typeof search.client_id === 'string' &&
+    search.client_id.length > 0 &&
+    typeof search.redirect_uri === 'string' &&
+    search.redirect_uri.length > 0
+  )
+}
+
+export function buildMcpAuthorizeResumeUrl(search: Record<string, unknown>): string | null {
+  if (!hasMcpAuthorizeQuery(search)) {
+    return null
+  }
+
+  const params = new URLSearchParams()
+  for (const key of MCP_AUTHORIZE_QUERY_KEYS) {
+    const value = search[key]
+    if (typeof value === 'string' && value.length > 0) {
+      params.set(key, value)
+    }
+  }
+
+  if (!params.has('prompt')) {
+    params.set('prompt', 'consent')
+  }
+
+  return `/api/auth/mcp/authorize?${params.toString()}`
+}
+
+export function buildLoginRedirectForConsent(consentPathWithSearch: string): string {
+  const params = new URLSearchParams()
+  params.set('redirect', consentPathWithSearch)
+  return `/login?${params.toString()}`
+}
+
+export interface McpOAuthConsentContext {
+  clientId: string
+  name: string
+  icon: string | null
+  disabled: boolean
+  scopes: string[]
+}

--- a/packages/auth/src/mcp-scope-labels.ts
+++ b/packages/auth/src/mcp-scope-labels.ts
@@ -1,0 +1,20 @@
+/** MCP Phase 1 scope strings (duplicated here to avoid pulling server MCP bundle into the web client). */
+export const MCP_SCOPE_DISCOVER = 'mcp:discover'
+export const MCP_SCOPE_JOBS_READ = 'mcp:jobs:read'
+export const MCP_SCOPE_LOGS_READ = 'mcp:logs:read'
+export const MCP_SCOPE_FAILURES_READ = 'mcp:failures:read'
+export const MCP_SCOPE_DIAGNOSTICS_READ = 'mcp:diagnostics:read'
+
+export const MCP_PHASE1_SCOPES = [
+  MCP_SCOPE_DISCOVER,
+  MCP_SCOPE_JOBS_READ,
+  MCP_SCOPE_LOGS_READ,
+  MCP_SCOPE_FAILURES_READ,
+  MCP_SCOPE_DIAGNOSTICS_READ,
+] as const
+
+export type McpPhase1Scope = (typeof MCP_PHASE1_SCOPES)[number]
+
+export function isKnownMcpPhase1Scope(scope: string): scope is McpPhase1Scope {
+  return (MCP_PHASE1_SCOPES as readonly string[]).includes(scope)
+}

--- a/packages/auth/src/safe-redirect.test.ts
+++ b/packages/auth/src/safe-redirect.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test'
+import { isSafeAppRedirectPath, isSafeOAuthRedirectUri, resolveSafeAppRedirectPath } from './safe-redirect'
+
+describe('safe-redirect', () => {
+  test('rejects protocol-relative and external paths', () => {
+    expect(isSafeAppRedirectPath('/consent')).toBe(true)
+    expect(isSafeAppRedirectPath('//evil.com')).toBe(false)
+    expect(isSafeAppRedirectPath('/\\evil')).toBe(false)
+    expect(isSafeAppRedirectPath('https://evil.com')).toBe(false)
+  })
+
+  test('resolveSafeAppRedirectPath requires same origin', () => {
+    const origin = 'http://localhost:5173'
+    expect(resolveSafeAppRedirectPath('/consent?x=1', origin)).toBe('/consent?x=1')
+    expect(resolveSafeAppRedirectPath('//evil.com', origin)).toBeUndefined()
+  })
+
+  test('isSafeOAuthRedirectUri allows http(s) only', () => {
+    expect(isSafeOAuthRedirectUri('http://127.0.0.1:8765/callback')).toBe(true)
+    expect(isSafeOAuthRedirectUri('javascript:alert(1)')).toBe(false)
+  })
+})

--- a/packages/auth/src/safe-redirect.ts
+++ b/packages/auth/src/safe-redirect.ts
@@ -1,0 +1,58 @@
+/**
+ * Validates in-app redirect paths (open redirect hardening).
+ */
+export function isSafeAppRedirectPath(path: string): boolean {
+  if (!path.startsWith('/')) {
+    return false
+  }
+  if (path.startsWith('//') || path.startsWith('/\\')) {
+    return false
+  }
+  if (path.includes(':')) {
+    return false
+  }
+  return true
+}
+
+export function resolveSafeAppRedirectPath(
+  path: string | undefined,
+  origin: string
+): string | undefined {
+  if (!path || !isSafeAppRedirectPath(path)) {
+    return undefined
+  }
+  try {
+    const url = new URL(path, origin)
+    if (url.origin !== origin) {
+      return undefined
+    }
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * OAuth redirect URIs from Better Auth must be absolute http(s) URLs.
+ */
+export function isSafeOAuthRedirectUri(redirectUri: string, allowedOrigins?: string[]): boolean {
+  let url: URL
+  try {
+    url = new URL(redirectUri)
+  } catch {
+    return false
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return false
+  }
+  if (allowedOrigins?.length) {
+    return allowedOrigins.some((origin) => {
+      try {
+        return new URL(origin).origin === url.origin
+      } catch {
+        return false
+      }
+    })
+  }
+  return true
+}

--- a/packages/auth/src/submit-oauth-consent.ts
+++ b/packages/auth/src/submit-oauth-consent.ts
@@ -1,0 +1,55 @@
+import { isSafeOAuthRedirectUri } from './safe-redirect'
+
+export interface SubmitOAuthConsentInput {
+  accept: boolean
+  consentCode?: string | null
+}
+
+export interface SubmitOAuthConsentResult {
+  redirectURI: string
+}
+
+/**
+ * Complete the Better Auth MCP / OIDC consent step after the user allows or denies access.
+ */
+export async function submitOAuthConsent(
+  input: SubmitOAuthConsentInput
+): Promise<SubmitOAuthConsentResult> {
+  if (typeof window === 'undefined') {
+    throw new Error('submitOAuthConsent must run in the browser')
+  }
+
+  const base = `${window.location.origin}/api/auth`
+
+  const response = await fetch(`${base}/oauth2/consent`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({
+      accept: input.accept,
+      ...(input.consentCode ? { consent_code: input.consentCode } : {}),
+    }),
+  })
+
+  if (!response.ok) {
+    let detail = `Consent request failed (${response.status})`
+    try {
+      const body = (await response.json()) as { message?: string; error_description?: string }
+      detail = body.error_description ?? body.message ?? detail
+    } catch {
+      // ignore parse errors
+    }
+    throw new Error(detail)
+  }
+
+  const data = (await response.json()) as SubmitOAuthConsentResult
+  if (!data.redirectURI) {
+    throw new Error('Consent response did not include a redirect URI')
+  }
+
+  if (!isSafeOAuthRedirectUri(data.redirectURI)) {
+    throw new Error('Consent redirect URI is not allowed')
+  }
+
+  return data
+}

--- a/tasks/mcp-readiness-review.md
+++ b/tasks/mcp-readiness-review.md
@@ -14,7 +14,8 @@
 | **Safety hardening (PR-06)** | **Complete** — merged PR #98. |
 | **Deployment / ops (PR-07)** | **Complete** — merged PR #99 (runbook + deployment docs). |
 | **GA artifacts (PR-08)** | **Complete in branch** — ADR, compliance, security closure, release checklist, validation evidence. |
-| **Production announcement** | **Pending operator gates** — staging `mcp:e2e`, release checklist execution, optional human security sign-off. |
+| **OAuth consent UI** | **Done** — `/consent` + Playwright `e2e/mcp-oauth.spec.ts` (full authorize → consent → token → `ping`). |
+| **Production announcement** | **Pending operator gates** — staging `mcp:e2e` + `mcp-oauth` E2E, edge alert on register, human security sign-off. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `/consent` with Allow/Deny, server-backed scopes via `GET /api/mcp/oauth-consent/:consentCode`, and Better Auth `consentPage` wiring.
- Hardens login/consent redirects and preserves MCP authorize flow for social sign-in.
- Playwright E2E (4 tests): automatic OAuth discovery (`POST /mcp` → PRM → AS metadata → register), happy path, consent deny, and logged-out login → consent → token → `ping`.
- Updates operator/GA docs; fixes MCP bearer validation when token `resource` is missing on insert.

## Test plan

- [x] `bun test packages/auth/src/mcp-consent.test.ts packages/auth/src/safe-redirect.test.ts`
- [x] `bun run --filter @durabull/api test src/mcp/`
- [x] `cd apps/web && bun run test:e2e e2e/mcp-oauth.spec.ts` (4 passed)
- [ ] Staging: `mcp:e2e` + `mcp-oauth` E2E with production-like `APP_BASE_URL`
- [ ] SEC-04 edge alert on `POST /api/auth/mcp/register` (ops)