### PR TITLE
Fix MCP OAuth scope compatibility for third-party clients

### DIFF
--- a/apps/api/src/mcp/auth/mount-well-known.ts
+++ b/apps/api/src/mcp/auth/mount-well-known.ts
@@ -1,9 +1,26 @@
 import { Hono } from 'hono'
 import { oAuthDiscoveryMetadata, oAuthProtectedResourceMetadata } from 'better-auth/plugins'
+import { MCP_OAUTH_SCOPES_SUPPORTED } from '@durabull/mcp/auth'
 
 import { getAuth } from '../../lib/auth'
 import { isAuthlessMode } from '../../lib/authless'
 import { buildAuthlessMcpProtectedResourceMetadata } from './authless-metadata'
+
+const REQUIRED_AUTHORIZATION_SERVER_SCOPES = [...MCP_OAUTH_SCOPES_SUPPORTED] as const
+
+function appendMissingScopes(
+  scopesSupported: unknown,
+  requiredScopes: readonly string[]
+): string[] {
+  const existing = Array.isArray(scopesSupported)
+    ? scopesSupported.filter((scope): scope is string => typeof scope === 'string')
+    : []
+  const merged = new Set(existing)
+  for (const scope of requiredScopes) {
+    merged.add(scope)
+  }
+  return Array.from(merged)
+}
 
 /**
  * App-origin well-known routes for MCP clients that cannot parse `WWW-Authenticate`.
@@ -31,7 +48,30 @@ export function mountMcpWellKnownRoutes(appBaseUrl: string) {
     }
 
     const auth = await getAuth()
-    return oAuthDiscoveryMetadata(auth)(c.req.raw)
+    const response = await oAuthDiscoveryMetadata(auth)(c.req.raw)
+    if (!response.ok) {
+      return response
+    }
+
+    let body: Record<string, unknown>
+    try {
+      body = (await response.clone().json()) as Record<string, unknown>
+    } catch {
+      return response
+    }
+
+    body.scopes_supported = appendMissingScopes(
+      body.scopes_supported,
+      REQUIRED_AUTHORIZATION_SERVER_SCOPES
+    )
+
+    const headers = new Headers(response.headers)
+    headers.set('Cache-Control', 'public, max-age=300')
+    headers.set('Content-Type', 'application/json')
+    return new Response(JSON.stringify(body), {
+      status: response.status,
+      headers,
+    })
   })
 
   return routes

--- a/apps/api/src/mcp/mount.test.ts
+++ b/apps/api/src/mcp/mount.test.ts
@@ -155,6 +155,23 @@ describe('api MCP ingress', () => {
     expect(metadata.authorization_servers).toContain('http://localhost:3000/api/auth')
   })
 
+  it('exposes MCP scopes in app-origin authorization server metadata', async () => {
+    mutableEnv.DURABULL_AUTHLESS = false
+    await closeDb()
+    ;({ app } = await createApiApp({ enableLogging: false }))
+
+    const response = await app.request('/.well-known/oauth-authorization-server')
+    expect(response.status).toBe(200)
+
+    const metadata = (await response.json()) as {
+      scopes_supported?: string[]
+    }
+    expect(metadata.scopes_supported).toBeDefined()
+    expect(metadata.scopes_supported).toContain('mcp:discover')
+    expect(metadata.scopes_supported).toContain('mcp:jobs:read')
+    expect(metadata.scopes_supported).toContain('openid')
+  })
+
   it('supports initialize, tools/list, and ping on one app instance', async () => {
     const initResponse = await postMcp({
       jsonrpc: MCP_JSON_RPC_VERSION,
@@ -279,7 +296,7 @@ describe('api MCP ingress', () => {
     expect(response.headers.get('WWW-Authenticate')).toContain('invalid_token')
   })
 
-  it('returns 403 for OAuth tokens without mcp:discover', async () => {
+  it('returns 403 for manually seeded OAuth tokens without mcp:discover', async () => {
     mutableEnv.DURABULL_AUTHLESS = false
     await closeDb()
     ;({ app } = await createApiApp({ enableLogging: false }))

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,8 +1,50 @@
 import { Hono } from 'hono'
+import {
+  getCanonicalMcpResourceUri,
+  MCP_TRANSPORT_REQUIRED_SCOPES,
+  normalizeResourceUri,
+  parseScopeString,
+} from '@durabull/mcp/auth'
+import { env } from '@durabull/env'
 import { getAuth } from '../lib/auth'
 import { getAuthlessContext, isAuthlessMode } from '../lib/authless'
 
 const app = new Hono()
+const OPENID_SCOPE = 'openid'
+
+function ensureMcpAuthorizeScopes(url: URL): URL {
+  if (!url.pathname.endsWith('/mcp/authorize')) {
+    return url
+  }
+
+  const resource = url.searchParams.get('resource')
+  if (!resource) {
+    return url
+  }
+
+  const canonicalResource = getCanonicalMcpResourceUri(env.APP_BASE_URL)
+  if (normalizeResourceUri(resource) !== normalizeResourceUri(canonicalResource)) {
+    return url
+  }
+
+  const currentScopes = parseScopeString(url.searchParams.get('scope') ?? '')
+  const hasMcpScope = currentScopes.some((scope) => scope.startsWith('mcp:'))
+  if (hasMcpScope) {
+    return url
+  }
+
+  const mergedScopes = new Set<string>(currentScopes)
+  if (!mergedScopes.has(OPENID_SCOPE)) {
+    mergedScopes.add(OPENID_SCOPE)
+  }
+  for (const scope of MCP_TRANSPORT_REQUIRED_SCOPES) {
+    mergedScopes.add(scope)
+  }
+
+  const rewritten = new URL(url.toString())
+  rewritten.searchParams.set('scope', Array.from(mergedScopes).join(' '))
+  return rewritten
+}
 
 /**
  * Handle all auth requests using Better Auth's handler.
@@ -35,7 +77,13 @@ app.all('/*', async (c) => {
   }
 
   const auth = await getAuth()
-  return auth.handler(c.req.raw)
+  const rewrittenUrl = ensureMcpAuthorizeScopes(new URL(c.req.url))
+  if (rewrittenUrl.toString() === c.req.url) {
+    return auth.handler(c.req.raw)
+  }
+
+  const rewrittenRequest = new Request(rewrittenUrl.toString(), c.req.raw)
+  return auth.handler(rewrittenRequest)
 })
 
 export default app

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -13,9 +13,13 @@ import { env } from '@durabull/env'
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { mcp, organization } from 'better-auth/plugins'
-import { getCanonicalMcpResourceUri } from '@durabull/mcp/auth'
+import {
+  getCanonicalMcpResourceUri,
+  MCP_PHASE1_SCOPES,
+  MCP_OAUTH_SCOPES_SUPPORTED,
+  normalizeResourceUri,
+} from '@durabull/mcp/auth'
 import { MCP_OAUTH_CONSENT_PATH } from './mcp-consent'
-import { MCP_PHASE1_SCOPES } from './mcp-scope-labels'
 
 const isProduction = env.NODE_ENV === 'production'
 
@@ -203,18 +207,23 @@ export async function createAuth(options?: CreateAuthOptions) {
             const canonicalResource = getCanonicalMcpResourceUri(
               options?.baseURL ?? env.APP_BASE_URL
             )
+            const normalizedResource = normalizeResourceUri(token.resource ?? canonicalResource)
             return {
               data: {
                 ...token,
-                resource: token.resource ?? canonicalResource,
+                resource: normalizedResource,
               },
             }
           },
           after: async (token: { id: string; resource: string | null }) => {
-            const canonicalResource = getCanonicalMcpResourceUri(
-              options?.baseURL ?? env.APP_BASE_URL
+            const canonicalResource = normalizeResourceUri(
+              getCanonicalMcpResourceUri(
+                options?.baseURL ?? env.APP_BASE_URL
+              )
             )
-            if (token.resource === canonicalResource) {
+
+            // Better Auth may occasionally persist null `resource` on MCP tokens; patch only that case.
+            if (typeof token.resource === 'string' && token.resource.trim().length > 0) {
               return
             }
 
@@ -245,13 +254,7 @@ export async function createAuth(options?: CreateAuthOptions) {
           consentPage: MCP_OAUTH_CONSENT_PATH,
           scopes: [...MCP_PHASE1_SCOPES],
           metadata: {
-            scopes_supported: [
-              'openid',
-              'profile',
-              'email',
-              'offline_access',
-              ...MCP_PHASE1_SCOPES,
-            ],
+            scopes_supported: [...MCP_OAUTH_SCOPES_SUPPORTED],
           },
         },
       }),

--- a/packages/mcp/src/auth/index.ts
+++ b/packages/mcp/src/auth/index.ts
@@ -7,7 +7,9 @@ export {
   getMcpProtectedResourceMetadataUrl,
 } from './resource-uri'
 export {
+  MCP_OAUTH_SCOPES_SUPPORTED,
   MCP_PHASE1_SCOPES,
+  OIDC_CORE_SCOPES,
   MCP_SCOPE_DIAGNOSTICS_READ,
   MCP_SCOPE_DISCOVER,
   MCP_SCOPE_FAILURES_READ,
@@ -21,6 +23,7 @@ export {
 export type { McpAccessTokenClaims, McpTokenValidationResult } from './types'
 export { isMcpAccessTokenExpired, toAccessTokenExpiry } from './session'
 export { extractBearerToken, validateMcpAccessTokenClaims } from './validate-token'
+export { normalizeResourceUri } from './normalize-resource-uri'
 export {
   buildMcpInsufficientScopeResponse,
   buildMcpMissingBearerResponse,

--- a/packages/mcp/src/auth/normalize-resource-uri.ts
+++ b/packages/mcp/src/auth/normalize-resource-uri.ts
@@ -1,0 +1,10 @@
+export function normalizeResourceUri(uri: string): string {
+  try {
+    const url = new URL(uri)
+    url.hash = ''
+    const pathname = url.pathname.replace(/\/+$/, '') || '/'
+    return `${url.origin}${pathname}`
+  } catch {
+    return uri.replace(/\/+$/, '')
+  }
+}

--- a/packages/mcp/src/auth/scopes.ts
+++ b/packages/mcp/src/auth/scopes.ts
@@ -13,6 +13,9 @@ export const MCP_PHASE1_SCOPES = [
   MCP_SCOPE_DIAGNOSTICS_READ,
 ] as const
 
+export const OIDC_CORE_SCOPES = ['openid', 'profile', 'email', 'offline_access'] as const
+export const MCP_OAUTH_SCOPES_SUPPORTED = [...OIDC_CORE_SCOPES, ...MCP_PHASE1_SCOPES] as const
+
 export type McpPhase1Scope = (typeof MCP_PHASE1_SCOPES)[number]
 
 /** Minimum scope required to use MCP transport (initialize, tools/list, ping). */

--- a/packages/mcp/src/auth/validate-token.test.ts
+++ b/packages/mcp/src/auth/validate-token.test.ts
@@ -81,6 +81,18 @@ describe('validateMcpAccessTokenClaims', () => {
     }
   })
 
+  it('accepts equivalent resource URIs with trailing slash differences', () => {
+    const result = validateMcpAccessTokenClaims(
+      baseClaims({ resource: 'https://app.example.com/mcp/' }),
+      {
+        canonicalResourceUri: 'https://app.example.com/mcp',
+        requiredScopes: [MCP_SCOPE_DISCOVER],
+      }
+    )
+
+    expect(result.ok).toBe(true)
+  })
+
   it('returns 403 with missing scopes when scope is insufficient', () => {
     const result = validateMcpAccessTokenClaims(baseClaims({ scopes: ['openid'] }), {
       canonicalResourceUri,

--- a/packages/mcp/src/auth/validate-token.ts
+++ b/packages/mcp/src/auth/validate-token.ts
@@ -1,22 +1,12 @@
 import { missingScopes, tokenHasScopes } from './scopes'
 import type { McpAccessTokenClaims, McpTokenValidationResult } from './types'
+import { normalizeResourceUri } from './normalize-resource-uri'
 
 export interface ValidateMcpAccessTokenOptions {
   canonicalResourceUri: string
   requiredScopes: readonly string[]
   /** When true, tokens must include a resource indicator matching the canonical URI. */
   requireResourceIndicator?: boolean
-}
-
-function normalizeResourceUri(uri: string): string {
-  try {
-    const url = new URL(uri)
-    url.hash = ''
-    const pathname = url.pathname.replace(/\/+$/, '') || '/'
-    return `${url.origin}${pathname}`
-  } catch {
-    return uri.replace(/\/+$/, '')
-  }
 }
 
 export function extractBearerToken(authorizationHeader: string | undefined): string | null {


### PR DESCRIPTION
## Summary
- ensure MCP authorize requests targeting the canonical MCP resource always include transport scope when clients omit `mcp:*` scopes
- centralize resource URI normalization and shared OAuth scope constants across MCP auth metadata and token validation paths
- add/adjust MCP auth tests for authorization-server scope metadata and trailing-slash resource matching behavior

## Test plan
- [x] `bun test packages/mcp/src/auth/validate-token.test.ts`
- [x] `bun test apps/api/src/mcp/mount.test.ts`
- [x] `bun test packages/auth/src/mcp-consent.test.ts`

## Linear
- [ ] Link related Linear issue (please provide issue ID)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved MCP authorization support by automatically ensuring all required OAuth scopes are included in authorization requests for MCP operations.
  * OAuth discovery endpoints now properly expose the complete set of MCP-supported authentication scopes, enabling better integration with third-party MCP clients and tools.

* **Bug Fixes**
  * Fixed resource URI normalization to properly handle and consistently process URLs with trailing slashes across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->