### PR TITLE
fix(mcp-oauth): grant phase-1 scopes and force consent for Linear

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,50 +1,10 @@
 import { Hono } from 'hono'
-import {
-  getCanonicalMcpResourceUri,
-  MCP_TRANSPORT_REQUIRED_SCOPES,
-  normalizeResourceUri,
-  parseScopeString,
-} from '@durabull/mcp/auth'
 import { env } from '@durabull/env'
 import { getAuth } from '../lib/auth'
 import { getAuthlessContext, isAuthlessMode } from '../lib/authless'
+import { ensureMcpAuthorizeScopes } from './mcp-authorize-scopes'
 
 const app = new Hono()
-const OPENID_SCOPE = 'openid'
-
-function ensureMcpAuthorizeScopes(url: URL): URL {
-  if (!url.pathname.endsWith('/mcp/authorize')) {
-    return url
-  }
-
-  const resource = url.searchParams.get('resource')
-  if (!resource) {
-    return url
-  }
-
-  const canonicalResource = getCanonicalMcpResourceUri(env.APP_BASE_URL)
-  if (normalizeResourceUri(resource) !== normalizeResourceUri(canonicalResource)) {
-    return url
-  }
-
-  const currentScopes = parseScopeString(url.searchParams.get('scope') ?? '')
-  const hasMcpScope = currentScopes.some((scope) => scope.startsWith('mcp:'))
-  if (hasMcpScope) {
-    return url
-  }
-
-  const mergedScopes = new Set<string>(currentScopes)
-  if (!mergedScopes.has(OPENID_SCOPE)) {
-    mergedScopes.add(OPENID_SCOPE)
-  }
-  for (const scope of MCP_TRANSPORT_REQUIRED_SCOPES) {
-    mergedScopes.add(scope)
-  }
-
-  const rewritten = new URL(url.toString())
-  rewritten.searchParams.set('scope', Array.from(mergedScopes).join(' '))
-  return rewritten
-}
 
 /**
  * Handle all auth requests using Better Auth's handler.
@@ -77,7 +37,7 @@ app.all('/*', async (c) => {
   }
 
   const auth = await getAuth()
-  const rewrittenUrl = ensureMcpAuthorizeScopes(new URL(c.req.url))
+  const rewrittenUrl = ensureMcpAuthorizeScopes(new URL(c.req.url), env.APP_BASE_URL)
   if (rewrittenUrl.toString() === c.req.url) {
     return auth.handler(c.req.raw)
   }

--- a/apps/api/src/routes/mcp-authorize-scopes.test.ts
+++ b/apps/api/src/routes/mcp-authorize-scopes.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test'
+import { MCP_PHASE1_SCOPES } from '@durabull/mcp/auth'
+
+import { ensureMcpAuthorizeScopes } from './mcp-authorize-scopes'
+
+const APP_BASE_URL = 'https://app.example.com'
+const CANONICAL_RESOURCE = `${APP_BASE_URL}/mcp`
+
+function authorizeUrl(scope?: string, extra?: Record<string, string>): URL {
+  const url = new URL(`${APP_BASE_URL}/api/auth/mcp/authorize`)
+  url.searchParams.set('client_id', 'client-1')
+  url.searchParams.set('redirect_uri', 'https://linear.example/callback')
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('resource', CANONICAL_RESOURCE)
+  if (scope !== undefined) {
+    url.searchParams.set('scope', scope)
+  }
+  for (const [key, value] of Object.entries(extra ?? {})) {
+    url.searchParams.set(key, value)
+  }
+  return url
+}
+
+describe('ensureMcpAuthorizeScopes', () => {
+  it('leaves non-authorize paths unchanged', () => {
+    const url = new URL(`${APP_BASE_URL}/api/auth/session`)
+    expect(ensureMcpAuthorizeScopes(url, APP_BASE_URL).toString()).toBe(url.toString())
+  })
+
+  it('leaves authorize without resource unchanged', () => {
+    const url = authorizeUrl('openid')
+    url.searchParams.delete('resource')
+    expect(ensureMcpAuthorizeScopes(url, APP_BASE_URL).toString()).toBe(url.toString())
+  })
+
+  it('leaves authorize with non-canonical resource unchanged', () => {
+    const url = authorizeUrl('openid')
+    url.searchParams.set('resource', 'https://other.example/mcp')
+    expect(ensureMcpAuthorizeScopes(url, APP_BASE_URL).toString()).toBe(url.toString())
+  })
+
+  it('adds phase-1 MCP scopes and openid when scope is omitted', () => {
+    const url = authorizeUrl(undefined)
+    url.searchParams.delete('scope')
+    const rewritten = ensureMcpAuthorizeScopes(url, APP_BASE_URL)
+    const scopes = new Set(rewritten.searchParams.get('scope')?.split(/\s+/) ?? [])
+    expect(scopes.has('openid')).toBe(true)
+    for (const scope of MCP_PHASE1_SCOPES) {
+      expect(scopes.has(scope)).toBe(true)
+    }
+    expect(rewritten.searchParams.get('prompt')).toBe('consent')
+  })
+
+  it('expands minimal mcp:discover-only requests to full phase-1 scopes', () => {
+    const rewritten = ensureMcpAuthorizeScopes(authorizeUrl('openid mcp:discover'), APP_BASE_URL)
+    const scopes = rewritten.searchParams.get('scope')?.split(/\s+/) ?? []
+    expect(scopes).toEqual(
+      expect.arrayContaining(['openid', ...MCP_PHASE1_SCOPES])
+    )
+    expect(rewritten.searchParams.get('prompt')).toBe('consent')
+  })
+
+  it('forces prompt=consent when prompt is omitted', () => {
+    const rewritten = ensureMcpAuthorizeScopes(
+      authorizeUrl([...MCP_PHASE1_SCOPES, 'openid'].join(' ')),
+      APP_BASE_URL
+    )
+    expect(rewritten.searchParams.get('prompt')).toBe('consent')
+  })
+
+  it('replaces prompt=none with consent', () => {
+    const rewritten = ensureMcpAuthorizeScopes(
+      authorizeUrl('openid mcp:discover', { prompt: 'none' }),
+      APP_BASE_URL
+    )
+    expect(rewritten.searchParams.get('prompt')).toBe('consent')
+  })
+
+  it('preserves an explicit non-none prompt', () => {
+    const rewritten = ensureMcpAuthorizeScopes(
+      authorizeUrl([...MCP_PHASE1_SCOPES, 'openid'].join(' '), { prompt: 'login' }),
+      APP_BASE_URL
+    )
+    expect(rewritten.searchParams.get('prompt')).toBe('login')
+  })
+
+  it('is a no-op when scopes and prompt are already complete', () => {
+    const url = authorizeUrl([...MCP_PHASE1_SCOPES, 'openid'].join(' '), { prompt: 'consent' })
+    expect(ensureMcpAuthorizeScopes(url, APP_BASE_URL).toString()).toBe(url.toString())
+  })
+})

--- a/apps/api/src/routes/mcp-authorize-scopes.ts
+++ b/apps/api/src/routes/mcp-authorize-scopes.ts
@@ -1,0 +1,63 @@
+import {
+  getCanonicalMcpResourceUri,
+  MCP_PHASE1_SCOPES,
+  normalizeResourceUri,
+  parseScopeString,
+} from '@durabull/mcp/auth'
+
+const OPENID_SCOPE = 'openid'
+
+/**
+ * Normalize MCP authorize requests for third-party clients (e.g. Linear) that omit
+ * `prompt=consent` and request no or minimal `mcp:*` scopes.
+ *
+ * Without `prompt=consent`, Better Auth may auto-approve using a prior narrow
+ * `oauth_consent` row (often only `mcp:discover`), which blocks jobs/logs tools.
+ */
+export function ensureMcpAuthorizeScopes(url: URL, appBaseUrl: string): URL {
+  if (!url.pathname.endsWith('/mcp/authorize')) {
+    return url
+  }
+
+  const resource = url.searchParams.get('resource')
+  if (!resource) {
+    return url
+  }
+
+  const canonicalResource = getCanonicalMcpResourceUri(appBaseUrl)
+  if (normalizeResourceUri(resource) !== normalizeResourceUri(canonicalResource)) {
+    return url
+  }
+
+  const mergedScopes = new Set(parseScopeString(url.searchParams.get('scope') ?? ''))
+  let changed = false
+
+  if (!mergedScopes.has(OPENID_SCOPE)) {
+    mergedScopes.add(OPENID_SCOPE)
+    changed = true
+  }
+
+  for (const scope of MCP_PHASE1_SCOPES) {
+    if (!mergedScopes.has(scope)) {
+      mergedScopes.add(scope)
+      changed = true
+    }
+  }
+
+  const prompt = url.searchParams.get('prompt')
+  const needsConsentPrompt = !prompt || prompt === 'none'
+  if (needsConsentPrompt) {
+    changed = true
+  }
+
+  if (!changed) {
+    return url
+  }
+
+  const rewritten = new URL(url.toString())
+  rewritten.searchParams.set('scope', Array.from(mergedScopes).join(' '))
+  if (needsConsentPrompt) {
+    rewritten.searchParams.set('prompt', 'consent')
+  }
+  return rewritten
+}

--- a/docs/mcp-oauth-operator.md
+++ b/docs/mcp-oauth-operator.md
@@ -26,7 +26,7 @@ Durabull serves a first-party consent screen at **`/consent`** (configured via B
 
 Typical delegated-user flow:
 
-1. MCP client opens `GET /api/auth/mcp/authorize` with **PKCE** and `prompt=consent` (required to show the consent UI).
+1. MCP client opens `GET /api/auth/mcp/authorize` with **PKCE** and `resource={APP_BASE_URL}/mcp`. Durabull rewrites authorize requests for the canonical MCP resource to include all phase-1 read scopes and `prompt=consent` when the client omits them (common for Linear and other hosted MCP clients).
 2. Unauthenticated users sign in at `/login` (Durabull preserves the authorize request).
 3. Authenticated users review scopes at `/consent` and choose **Allow** or **Deny**.
 4. Durabull redirects to the client `redirect_uri` with an authorization `code`.
@@ -56,10 +56,12 @@ Protected resource metadata advertises:
 ## Client configuration checklist
 
 1. Register an OAuth client via `POST /api/auth/mcp/register`.
-2. Complete authorization code + PKCE against `/api/auth/mcp/authorize` with `prompt=consent` and `resource={APP_BASE_URL}/mcp`.
+2. Complete authorization code + PKCE against `/api/auth/mcp/authorize` with `resource={APP_BASE_URL}/mcp` (Durabull injects phase-1 scopes and `prompt=consent` when missing).
 3. Exchange the code at `/api/auth/mcp/token` with `resource={APP_BASE_URL}/mcp`.
 4. Call MCP transport at `POST/GET/DELETE {APP_BASE_URL}/mcp` with `Authorization: Bearer <access_token>`.
-5. Request at least the `mcp:discover` scope for transport smoke (`ping`). Diagnostic tools require additional scopes (`mcp:jobs:read`, `mcp:logs:read`, `mcp:failures:read`, `mcp:diagnostics:read`) — see [MCP Server docs](https://github.com/durabullhq/durabull/blob/main/apps/docs/content/documentation/integrations/mcp-server.mdx).
+5. Request at least the `mcp:discover` scope for transport smoke (`ping`). Queue/job/log tools require the full phase-1 read bundle (`mcp:jobs:read`, `mcp:logs:read`, `mcp:failures:read`, `mcp:diagnostics:read`). Authorize requests without explicit `mcp:*` scopes are expanded server-side to that bundle.
+
+**Linear / re-authorize:** If a connection was approved before this behavior, disconnect the MCP integration in Linear and authorize again so a new token is issued with the full scope set.
 
 Dynamic client registration (`POST /api/auth/mcp/register`) is rate-limited (**20 registrations/minute** per bearer or `cf-connecting-ip` / `x-real-ip`) but unauthenticated. Configure your edge to set one of those headers if you rely on per-IP limits behind a proxy. Monitor registration volume on public deployments and block at the edge if abused.
 


### PR DESCRIPTION
## Summary
- Expand MCP authorize requests for the canonical `/mcp` resource to include all phase-1 read scopes (`mcp:jobs:read`, `mcp:logs:read`, etc.), not only `mcp:discover`.
- Inject `prompt=consent` when clients omit it or send `prompt=none`, so Better Auth shows `/consent` instead of silently reusing a narrow prior consent.
- Add unit tests and update the MCP OAuth operator guide (including Linear re-authorize steps).

## Test plan
- [x] `bun test apps/api/src/routes/mcp-authorize-scopes.test.ts`
- [ ] Deploy and disconnect/reconnect Durabull MCP in Linear; confirm consent screen lists jobs/logs/diagnostics scopes
- [ ] After approving, verify queue/job MCP tool calls succeed


Made with [Cursor](https://cursor.com)