### PR TITLE
ci(docker-publish): attest SLSA build provenance for GHCR image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   docker:
@@ -66,6 +68,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: push
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
@@ -79,6 +82,14 @@ jobs:
             DURABULL_BUILD_ID=${{ env.DURABULL_BUILD_ID }}
             DURABULL_BUILD_TIME=${{ env.DURABULL_BUILD_TIME }}
             DURABULL_RELEASE_CHANNEL=docker
+
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
   trigger-cloud-deploy-hook:
     name: Trigger Cloud Deploy Hook


### PR DESCRIPTION
## Summary
- Adds `actions/attest-build-provenance@v2` to the Docker Publish workflow so each tag-triggered GHCR push is accompanied by a signed SLSA build provenance attestation.
- Grants the `id-token: write` and `attestations: write` permissions required for sigstore OIDC, and gives the build/push step an `id` so its manifest digest is addressable.
- Gates the attest step on `github.event_name != 'pull_request'` so it only runs on real publishes — same condition that already gates `push:` in the build action.

## Notes for reviewers
- `useblacksmith/build-push-action@v2` is a drop-in fork of `docker/build-push-action` and exposes `outputs.digest` identically; on a multi-platform build that digest is the manifest list, which is the correct `subject-digest` for the attestation.
- No build behavior or image contents change — only an additional attestation is published.

## Test plan
- [ ] Cut a `v*` tag (or trigger via test tag) and confirm the workflow's "Attest build provenance" step succeeds.
- [ ] Verify the attestation lands on the registry: `gh attestation verify oci://ghcr.io/durabullhq/durabull:<tag> --repo durabullhq/durabull`.
- [ ] Confirm existing build, smoke test, and deploy-hook jobs still pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Docker image publishing workflow to include automatic build provenance attestation, strengthening supply chain security verification for published container images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->