### PR TITLE
feat(jobs): search jobs by data payload

### DIFF
--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -26,6 +26,18 @@ async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+// Substring match against the job's serialized data payload (e.g. a `message`
+// field nested anywhere in the payload). Case-insensitive.
+function jobDataMatches(data: unknown, search: string): boolean {
+  try {
+    return JSON.stringify(data ?? {})
+      .toLowerCase()
+      .includes(search.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
 async function removeJobWithRetries(
   queue: Awaited<ReturnType<typeof getQueue>>,
   jobId: string
@@ -87,6 +99,7 @@ const app = new Hono()
     const status = c.req.query('status')
     const name = c.req.query('name')
     const jobId = c.req.query('jobId')?.trim()
+    const dataSearch = c.req.query('data')?.trim()
     const pageStr = c.req.query('page')
     const cursorStr = c.req.query('cursor')
     const pageSizeStr = c.req.query('pageSize')
@@ -106,7 +119,11 @@ const app = new Hono()
       if (job) {
         const state = await job.getState()
 
-        if ((status && state !== status) || (name && !job.name.toLowerCase().includes(name.toLowerCase()))) {
+        if (
+          (status && state !== status) ||
+          (name && !job.name.toLowerCase().includes(name.toLowerCase())) ||
+          (dataSearch && !jobDataMatches(job.data, dataSearch))
+        ) {
           return c.json({
             jobs: [],
             total: 0,
@@ -166,7 +183,7 @@ const app = new Hono()
       states = [status as JobState]
     }
 
-    const needsClientFilter = !!(name || jobId)
+    const needsClientFilter = !!(name || jobId || dataSearch)
 
     if (needsClientFilter) {
       // Fetch each state separately so we know the status without per-job getState() calls,
@@ -194,6 +211,7 @@ const app = new Hono()
                 .includes(jobId.toLowerCase())
             : true
         )
+        .filter(({ job }) => (dataSearch ? jobDataMatches(job.data, dataSearch) : true))
 
       const mappedJobs = filtered.map(({ job, state }) => ({
         id: job.id ?? '',

--- a/apps/web/e2e/fixtures/test.ts
+++ b/apps/web/e2e/fixtures/test.ts
@@ -168,10 +168,20 @@ export async function getJobs(
   page: Page,
   connectionId: string,
   queueName: string,
-  options?: { status?: string; page?: number; pageSize?: number }
+  options?: {
+    status?: string
+    name?: string
+    jobId?: string
+    data?: string
+    page?: number
+    pageSize?: number
+  }
 ): Promise<{ jobs: JobSummary[]; total: number }> {
   const params = new URLSearchParams()
   if (options?.status) params.set('status', options.status)
+  if (options?.name) params.set('name', options.name)
+  if (options?.jobId) params.set('jobId', options.jobId)
+  if (options?.data) params.set('data', options.data)
   params.set('page', String(options?.page ?? 1))
   params.set('pageSize', String(options?.pageSize ?? 20))
   const response = await page.request.get(

--- a/apps/web/e2e/jobs.spec.ts
+++ b/apps/web/e2e/jobs.spec.ts
@@ -113,6 +113,53 @@ test.describe('Jobs', () => {
     }
   })
 
+  test('search filters jobs by data payload', async ({ page }) => {
+    await ensureActiveOrg(page)
+    const connectionId = await getDefaultConnectionId(page)
+    const queueName = await getTestQueueName(page, connectionId)
+    const createdJobs: string[] = []
+
+    try {
+      const token = `e2e-payload-${Date.now()}`
+      const jobId = await createJob(page, {
+        connectionId,
+        queueName,
+        name: `e2e-data-search-${Date.now()}`,
+        data: { message: token },
+        // Keep the job out of active processing so it stays findable.
+        delay: 10 * 60 * 1000,
+      })
+      createdJobs.push(jobId)
+
+      // API: searching the payload finds the job; a non-matching term does not.
+      await expect
+        .poll(
+          async () => {
+            const result = await getJobs(page, connectionId, queueName, { data: token })
+            return result.jobs.map((job) => String(job.id))
+          },
+          { timeout: 15000 }
+        )
+        .toContain(jobId)
+
+      const miss = await getJobs(page, connectionId, queueName, { data: `${token}-nope` })
+      expect(miss.jobs.map((job) => String(job.id))).not.toContain(jobId)
+
+      // UI: the data search input narrows the table to the matching job.
+      await page.goto(`/${TEST_ORG_SLUG}/c/${connectionId}/queues/${queueName}`)
+      const dataInput = page.getByLabel('Search jobs by data payload')
+      await expect(dataInput).toBeVisible({ timeout: 15000 })
+
+      await dataInput.fill(token)
+      await expect(page.getByTestId(`job-row-${jobId}`)).toBeVisible({ timeout: 15000 })
+
+      await dataInput.fill(`${token}-nope`)
+      await expect(page.getByTestId(`job-row-${jobId}`)).toHaveCount(0, { timeout: 15000 })
+    } finally {
+      await safeRemoveJobs(page, { connectionId, queueName, jobIds: createdJobs })
+    }
+  })
+
   test('invoke promotes a delayed job', async ({ page }) => {
     await ensureActiveOrg(page)
     const connectionId = await getDefaultConnectionId(page)

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -214,7 +214,7 @@ export const queryKeys = {
   jobs: (
     connectionId: string,
     queueName: string,
-    filters?: { status?: string; name?: string; jobId?: string; pageSize?: number }
+    filters?: { status?: string; name?: string; jobId?: string; data?: string; pageSize?: number }
   ) => ['jobs', connectionId, queueName, filters] as const,
   job: (connectionId: string, queueName: string, jobId: string) =>
     ['job', connectionId, queueName, jobId] as const,
@@ -357,7 +357,7 @@ export function useQueueMetrics(queueName: string, options?: QueueMetricsOptions
 // Job Queries - uses fetchApi since route doesn't have zValidator for query params
 export function useJobs(
   queueName: string,
-  filters?: { status?: string; name?: string; jobId?: string; pageSize?: number }
+  filters?: { status?: string; name?: string; jobId?: string; data?: string; pageSize?: number }
 ) {
   const connectionId = useConnectionIdFromContextOrRoute()
 
@@ -368,6 +368,7 @@ export function useJobs(
       if (filters?.status) params.set('status', filters.status)
       if (filters?.name) params.set('name', filters.name)
       if (filters?.jobId) params.set('jobId', filters.jobId)
+      if (filters?.data) params.set('data', filters.data)
       if (filters?.pageSize) params.set('pageSize', filters.pageSize.toString())
       if (pageParam) params.set('cursor', pageParam)
       const query = params.toString()

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
@@ -97,6 +97,7 @@ const queueSearchSchema = z.object({
   status: z.enum(['', 'waiting', 'active', 'delayed', 'completed', 'failed']).catch(''),
   jobId: z.string().catch(''),
   name: z.string().catch(''),
+  data: z.string().catch(''),
   hideScheduled: z
     .union([z.literal(0), z.literal(1), z.literal('0'), z.literal('1')])
     .transform((value) => (value === 1 || value === '1' ? 1 : 0))
@@ -147,12 +148,22 @@ export const Route = createFileRoute('/$orgSlug/c/$connectionId/queues/$queueNam
 
 function QueueDetailPage() {
   const { orgSlug, connectionId, queueName } = Route.useParams()
-  const { section, tab, status, jobId, name = '', hideScheduled, page } = Route.useSearch()
+  const {
+    section,
+    tab,
+    status,
+    jobId,
+    name = '',
+    data: dataSearch = '',
+    hideScheduled,
+    page,
+  } = Route.useSearch()
   const navigate = useNavigate()
   const matchRoute = useMatchRoute()
   const [selectedJobs, setSelectedJobs] = useState<Set<string>>(new Set())
   const [jobIdInput, setJobIdInput] = useState(jobId)
   const [nameInput, setNameInput] = useState(name)
+  const [dataInput, setDataInput] = useState(dataSearch)
   const [addJobDialogOpen, setAddJobDialogOpen] = useState(false)
   const [retryDialogOpen, setRetryDialogOpen] = useState(false)
   const [purgeDialogOpen, setPurgeDialogOpen] = useState(false)
@@ -195,6 +206,7 @@ function QueueDetailPage() {
     status: status || undefined,
     jobId: jobId || undefined,
     name: name || undefined,
+    data: dataSearch || undefined,
     pageSize: 20,
   })
   const {
@@ -217,7 +229,7 @@ function QueueDetailPage() {
   const removeMutation = useRemoveJobs()
   const invokeMutation = useInvokeJobs()
   const hideScheduledJobs = hideScheduled === 1
-  const hasClientSideJobFilter = Boolean(jobId || name)
+  const hasClientSideJobFilter = Boolean(jobId || name || dataSearch)
   const [visibleJobCount, setVisibleJobCount] = useState(20)
   const allJobs = useMemo(
     () => jobsData?.pages.flatMap((pageData) => pageData.jobs) ?? [],
@@ -240,7 +252,7 @@ function QueueDetailPage() {
 
   useEffect(() => {
     setVisibleJobCount(20)
-  }, [jobId, name, status, hideScheduled, queueName])
+  }, [jobId, name, dataSearch, status, hideScheduled, queueName])
   const jobsScrollRef = useRef<HTMLDivElement | null>(null)
   const metricsPoints = metrics?.series.points ?? []
   const metricsTotals = metrics?.series.totals
@@ -312,6 +324,10 @@ function QueueDetailPage() {
     setNameInput(name)
   }, [name])
 
+  useEffect(() => {
+    setDataInput(dataSearch)
+  }, [dataSearch])
+
   const handleCopyPrometheus = useCallback(async () => {
     if (!prometheusText || typeof navigator === 'undefined' || !navigator.clipboard) {
       return
@@ -332,13 +348,22 @@ function QueueDetailPage() {
     const timer = setTimeout(() => {
       navigate({
         to: '.',
-        search: { section, tab, status, jobId: normalizedJobId, name, hideScheduled, page: 1 },
+        search: {
+          section,
+          tab,
+          status,
+          jobId: normalizedJobId,
+          name,
+          data: dataSearch,
+          hideScheduled,
+          page: 1,
+        },
         replace: true,
       })
     }, 300)
 
     return () => clearTimeout(timer)
-  }, [jobIdInput, jobId, section, tab, status, name, hideScheduled, navigate])
+  }, [jobIdInput, jobId, section, tab, status, name, dataSearch, hideScheduled, navigate])
 
   useEffect(() => {
     const normalizedName = nameInput.trim()
@@ -350,13 +375,40 @@ function QueueDetailPage() {
     const timer = setTimeout(() => {
       navigate({
         to: '.',
-        search: { section, tab, status, jobId, name: normalizedName, hideScheduled, page: 1 },
+        search: {
+          section,
+          tab,
+          status,
+          jobId,
+          name: normalizedName,
+          data: dataSearch,
+          hideScheduled,
+          page: 1,
+        },
         replace: true,
       })
     }, 300)
 
     return () => clearTimeout(timer)
-  }, [nameInput, name, section, tab, status, jobId, hideScheduled, navigate])
+  }, [nameInput, name, section, tab, status, jobId, dataSearch, hideScheduled, navigate])
+
+  useEffect(() => {
+    const normalizedData = dataInput.trim()
+
+    if (normalizedData === dataSearch) {
+      return
+    }
+
+    const timer = setTimeout(() => {
+      navigate({
+        to: '.',
+        search: { section, tab, status, jobId, name, data: normalizedData, hideScheduled, page: 1 },
+        replace: true,
+      })
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [dataInput, dataSearch, section, tab, status, jobId, name, hideScheduled, navigate])
 
   useEffect(() => {
     const container = jobsScrollRef.current
@@ -651,6 +703,7 @@ function QueueDetailPage() {
               status,
               jobId,
               name,
+              data: dataSearch,
               hideScheduled,
               page,
             },
@@ -1381,13 +1434,23 @@ function QueueDetailPage() {
           onValueChange={(newTab) =>
             navigate({
               to: '.',
-              search: { section, tab: newTab as typeof tab, status, jobId, name, hideScheduled, page },
+              search: {
+                section,
+                tab: newTab as typeof tab,
+                status,
+                jobId,
+                name,
+                data: dataSearch,
+                hideScheduled,
+                page,
+              },
               replace: true,
             })
           }
         >
           {/* Toolbar: filters on left, tab toggle on right */}
-          <div className="flex items-center justify-between gap-3">
+          {/* pt-1.5 keeps focus rings from being clipped by the Tabs' overflow-hidden */}
+          <div className="flex items-center justify-between gap-3 pt-1.5">
             <div className="flex items-center gap-2">
               {tab === 'jobs' && (
                 <>
@@ -1401,7 +1464,16 @@ function QueueDetailPage() {
                       })
                       navigate({
                         to: '.',
-                        search: { section, tab, status: newStatus, jobId, name, hideScheduled, page: 1 },
+                        search: {
+                          section,
+                          tab,
+                          status: newStatus,
+                          jobId,
+                          name,
+                          data: dataSearch,
+                          hideScheduled,
+                          page: 1,
+                        },
                         replace: true,
                       })
                     }}
@@ -1428,6 +1500,13 @@ function QueueDetailPage() {
                     className="w-48 max-w-full"
                     aria-label="Search jobs by name"
                   />
+                  <Input
+                    value={dataInput}
+                    onChange={(e) => setDataInput(e.target.value)}
+                    placeholder="Search in job data"
+                    className="w-48 max-w-full"
+                    aria-label="Search jobs by data payload"
+                  />
                   <label className="inline-flex items-center gap-2 text-sm text-muted-foreground">
                     <input
                       type="checkbox"
@@ -1441,6 +1520,7 @@ function QueueDetailPage() {
                             status,
                             jobId,
                             name,
+                            data: dataSearch,
                             hideScheduled: e.target.checked ? 1 : 0,
                             page: 1,
                           },


### PR DESCRIPTION
## Summary

- Adds a **"Search in job data"** filter to the queue jobs view, so a job can be found by content in its payload (e.g. a `message` field, or any nested value) — previously you could only filter by job id or name.
- New `data` query param on `GET /:queueName/jobs` that case-insensitively substring-matches the serialized job data (`JSON.stringify(job.data)`), wired into the existing client-filter path alongside `name`/`jobId`.
- Threads the filter through the `useJobs` hook, query keys, and the queue detail route (URL search param + debounced input mirroring the existing id/name boxes).
- Fixes a focus ring on the jobs toolbar being clipped at the top by the Tabs' `overflow-hidden` (affected all toolbar controls, not just the new one).

<img width="1822" height="899" alt="image" src="https://github.com/user-attachments/assets/f38cb375-dd45-4baa-99f0-bb080c7eaae2" />


## How it works

The `name`/`jobId` filters already use a path that fetches jobs across all states and substring-matches in memory. The `data` filter slots into that same path, so there is no new scanning behavior or change to the pagination model — it just adds one more predicate.

## Test plan

- [x] API: `?data=<token>` finds a job by a top-level `message` field; `?data=acme` matches a nested `customer: "acme-corp"` value; a non-matching term returns no jobs.
- [x] UI (authless dev against seeded Redis): typing the token narrows the table to the matching job; a non-match shows the empty state; clearing restores the list.
- [x] Focus ring on the toolbar inputs renders fully (no top clipping).
- [x] Added an e2e test (`apps/web/e2e/jobs.spec.ts`) covering API + UI behavior; extended the `getJobs` fixture with `data`/`name`/`jobId`.
- [x] `tsc` and `biome` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added data payload search: Users can now filter jobs by searching their data content using the new "Search in job data" input field in the jobs interface. Data filtering is also available via API requests using the `data` query parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai —>

