### PR TITLE
feat(analytics): server capture and MCP PostHog telemetry

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import { secureHeaders } from 'hono/secure-headers'
 
 import { getAuth } from './lib/auth'
 import { isAuthlessMode } from './lib/authless'
+import { bootstrapServerAnalytics } from './lib/configure-server-analytics'
 import { getAppVersionPayload } from './lib/build-info'
 import { mountMcpWellKnownRoutes } from './mcp/auth/mount-well-known'
 import { mountMcpIngress } from './mcp/mount'
@@ -38,6 +39,8 @@ import teamRoutes from './routes/team'
 import telemetryRoutes, { getTelemetryStatus } from './routes/telemetry'
 import userSettingsRoutes from './routes/user-settings'
 import workersRoutes from './routes/workers'
+
+bootstrapServerAnalytics()
 
 const DEFAULT_POSTHOG_API_HOST = 'https://us.i.posthog.com'
 const DEFAULT_POSTHOG_UI_HOST = 'https://us.posthog.com'

--- a/apps/api/src/lib/configure-server-analytics.ts
+++ b/apps/api/src/lib/configure-server-analytics.ts
@@ -1,0 +1,70 @@
+import {
+  configureServerAnalytics,
+  DURABULL_CLOUD_API_HOST,
+  DEFAULT_CLOUD_COLLECT_URL,
+  TELEMETRY_DISCLOSURE_URL,
+} from '@durabull/analytics/server'
+import { getDatabaseMode, shouldUseEnvConnections, telemetryInstallationRepository } from '@durabull/dal'
+import { env } from '@durabull/env'
+
+import { isAuthlessMode } from './authless'
+
+function isDurabullManagedPosthogProject(): boolean {
+  if (env.DURABULL_CLOUD === true) return true
+
+  try {
+    return new URL(env.APP_BASE_URL).hostname === DURABULL_CLOUD_API_HOST
+  } catch {
+    return false
+  }
+}
+
+function getDurabullTelemetryPosthogKey(): string | null {
+  return env.DURABULL_TELEMETRY_POSTHOG_KEY?.trim() || env.POSTHOG_KEY?.trim() || null
+}
+
+let cachedAnonymousInstanceId: string | null = null
+
+export function bootstrapServerAnalytics(): void {
+  const appPosthogKey = env.POSTHOG_KEY?.trim() || null
+  const durabullTelemetryPosthogKey = getDurabullTelemetryPosthogKey()
+
+  configureServerAnalytics({
+    enabled: env.NODE_ENV === 'production' && env.CI !== true,
+    collectEnabled: env.DURABULL_CLOUD === true || isDurabullManagedPosthogProject(),
+    dedupeIdentifiedPosthogEvents:
+      !!appPosthogKey &&
+      isDurabullManagedPosthogProject() &&
+      durabullTelemetryPosthogKey === appPosthogKey,
+    disclosureUrl: TELEMETRY_DISCLOSURE_URL,
+    hmacSecret:
+      env.DURABULL_TELEMETRY_HMAC_SECRET?.trim() || env.BETTER_AUTH_SECRET?.trim() || null,
+    durabullTelemetryPosthogKey,
+    durabullTelemetryPosthogHost: env.DURABULL_TELEMETRY_POSTHOG_HOST?.trim() || null,
+    appPosthogKey,
+    appPosthogHost: env.POSTHOG_HOST?.trim() || null,
+    cloudCollectUrl: DEFAULT_CLOUD_COLLECT_URL,
+    getRuntimeContext: () => ({
+      authless: isAuthlessMode(),
+      env_connections: shouldUseEnvConnections(),
+      environment: env.NODE_ENV ?? 'development',
+      persistence: getDatabaseMode(),
+      stateless: getDatabaseMode() === 'pglite',
+    }),
+    resolveAnonymousInstanceId: async () => {
+      if (cachedAnonymousInstanceId) {
+        return cachedAnonymousInstanceId
+      }
+
+      const existing = await telemetryInstallationRepository.readAnonymousInstanceId()
+      cachedAnonymousInstanceId =
+        existing ?? (await telemetryInstallationRepository.getOrCreateAnonymousInstanceId())
+      return cachedAnonymousInstanceId
+    },
+  })
+}
+
+/** Test-only: clear cached installation id when re-bootstrapping. */
+export function resetCachedAnonymousInstanceIdForTests(): void {
+  cachedAnonymousInstanceId = null
+}

--- a/apps/api/src/mcp/audit/mcp-audit.ts
+++ b/apps/api/src/mcp/audit/mcp-audit.ts
@@ -14,6 +14,7 @@ export interface McpAuditEventInput {
   correlationId: string
   principalType: 'delegated_user' | 'service_account'
   principalId: string
+  userId?: string | null
   organizationId?: string | null
   connectionId?: string | null
   toolName: string
@@ -64,6 +65,10 @@ export function writeMcpAuditEventNonBlocking(input: McpAuditEventInput): void {
       signal: 'policy_denied',
       toolName: input.toolName,
       principalId: input.principalId,
+      principalType: input.principalType,
+      userId: input.userId,
+      organizationId: input.organizationId,
+      denialReason: input.denialReason,
       correlationId: input.correlationId,
     })
   } else if (input.responseClass === 'rate_limited') {
@@ -71,6 +76,9 @@ export function writeMcpAuditEventNonBlocking(input: McpAuditEventInput): void {
       signal: 'rate_limited_tool',
       toolName: input.toolName,
       principalId: input.principalId,
+      principalType: input.principalType,
+      userId: input.userId,
+      organizationId: input.organizationId,
       correlationId: input.correlationId,
     })
   }
@@ -86,6 +94,9 @@ export function writeMcpAuditEventNonBlocking(input: McpAuditEventInput): void {
       signal: 'audit_dropped',
       toolName: input.toolName,
       principalId: input.principalId,
+      principalType: input.principalType,
+      userId: input.userId,
+      organizationId: input.organizationId,
       correlationId: input.correlationId,
     })
     if (droppedAuditEvents === 1 || droppedAuditEvents % AUDIT_DROP_LOG_INTERVAL === 0) {

--- a/apps/api/src/mcp/auth/mcp-session-middleware.ts
+++ b/apps/api/src/mcp/auth/mcp-session-middleware.ts
@@ -18,6 +18,7 @@ import {
   getAuthlessMcpBearerToken,
   getMcpAuthConfig,
 } from './mcp-auth-config'
+import { recordMcpTelemetry } from '../observability/mcp-telemetry'
 import { resolveMcpSessionFromAccessToken } from './resolve-mcp-session'
 
 /** OAuth access token session resolved for MCP ingress (Better Auth `oauth_access_token` shape). */
@@ -62,6 +63,9 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
     return createMiddleware(async (c, next) => {
       const token = extractBearerToken(c.req.header('Authorization'))
       if (!token || token !== authlessBearer) {
+        recordMcpTelemetry({
+          signal: !token ? 'auth_missing_bearer' : 'auth_unauthorized',
+        })
         return token
           ? buildMcpUnauthorizedResponse(resourceMetadataUrl)
           : buildMcpMissingBearerResponse(resourceMetadataUrl)
@@ -75,6 +79,7 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
   return createMiddleware(async (c, next) => {
     const bearerToken = extractBearerToken(c.req.header('Authorization'))
     if (!bearerToken) {
+      recordMcpTelemetry({ signal: 'auth_missing_bearer' })
       return buildMcpMissingBearerResponse(resourceMetadataUrl)
     }
 
@@ -89,12 +94,19 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
       if (!cachedValidation.ok) {
         tokenCache.invalidate(cacheKey)
         if (cachedValidation.status === 403) {
+          recordMcpTelemetry({
+            signal: 'auth_forbidden',
+            principalId: cached.clientId,
+            principalType: cached.userId ? 'delegated_user' : 'service_account',
+            userId: cached.userId,
+          })
           return buildMcpInsufficientScopeResponse(
             resourceMetadataUrl,
             cachedValidation.missingScopes ??
               missingScopes(cached.scopes, MCP_TRANSPORT_REQUIRED_SCOPES)
           )
         }
+        recordMcpTelemetry({ signal: 'auth_unauthorized', principalId: cached.clientId })
         return buildMcpUnauthorizedResponse(resourceMetadataUrl)
       }
       c.set('mcpSession', sessionFromClaims(cachedValidation.claims))
@@ -103,6 +115,7 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
 
     const session = await resolveMcpSessionFromAccessToken(bearerToken)
     if (!session) {
+      recordMcpTelemetry({ signal: 'auth_unauthorized' })
       return buildMcpUnauthorizedResponse(resourceMetadataUrl)
     }
 
@@ -124,12 +137,22 @@ export async function createMcpSessionMiddleware(appBaseUrl: string) {
 
     if (!validation.ok) {
       if (validation.status === 403) {
+        recordMcpTelemetry({
+          signal: 'auth_forbidden',
+          principalId: claims.clientId,
+          principalType: claims.userId ? 'delegated_user' : 'service_account',
+          userId: claims.userId,
+        })
         return buildMcpInsufficientScopeResponse(
           resourceMetadataUrl,
           validation.missingScopes ?? missingScopes(claims.scopes, MCP_TRANSPORT_REQUIRED_SCOPES)
         )
       }
 
+      recordMcpTelemetry({
+        signal: 'auth_unauthorized',
+        principalId: claims.clientId,
+      })
       return buildMcpUnauthorizedResponse(resourceMetadataUrl)
     }
 

--- a/apps/api/src/mcp/json-rpc-tool-call.ts
+++ b/apps/api/src/mcp/json-rpc-tool-call.ts
@@ -56,3 +56,9 @@ export function isMcpToolsCallMethod(body: unknown): boolean {
     (body as { method?: string }).method === 'tools/call'
   )
 }
+
+export function parseMcpJsonRpcMethod(body: unknown): string | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  const method = (body as { method?: unknown }).method
+  return typeof method === 'string' && method.trim().length > 0 ? method.trim() : null
+}

--- a/apps/api/src/mcp/mount.ts
+++ b/apps/api/src/mcp/mount.ts
@@ -68,7 +68,11 @@ export async function mountMcpIngress() {
           signal: input.responseClass === 'success' ? 'tool_success' : 'tool_error',
           toolName: input.toolName,
           principalId: decision.principalId,
+          principalType: decision.principalType,
+          userId: principal.type === 'delegated_user' ? principal.userId : null,
+          organizationId: decision.organizationId,
           correlationId: decision.correlationId,
+          redactionCount: input.redactionCount,
         })
 
         writeMcpAuditEventNonBlocking({
@@ -106,6 +110,11 @@ export async function mountMcpIngress() {
           recordMcpTelemetry({
             signal: 'redaction_applied',
             count: redactionCount,
+            toolName: decision?.toolName,
+            principalId: decision?.principalId,
+            principalType: decision?.principalType,
+            userId: principal.type === 'delegated_user' ? principal.userId : null,
+            organizationId: decision?.organizationId,
             correlationId: decision?.correlationId,
           })
         },

--- a/apps/api/src/mcp/observability/mcp-analytics-queue.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics-queue.ts
@@ -1,0 +1,52 @@
+import type { McpAnalyticsInput } from './mcp-analytics'
+
+const MAX_ANALYTICS_IN_FLIGHT = 8
+const MAX_ANALYTICS_QUEUE_DEPTH = 512
+
+let analyticsInFlight = 0
+const pendingAnalytics: McpAnalyticsInput[] = []
+
+export type ProcessMcpAnalytics = (input: McpAnalyticsInput) => Promise<void>
+
+export function enqueueMcpAnalytics(
+  input: McpAnalyticsInput,
+  process: ProcessMcpAnalytics
+): void {
+  if (analyticsInFlight < MAX_ANALYTICS_IN_FLIGHT && pendingAnalytics.length === 0) {
+    dispatchMcpAnalytics(input, process)
+    return
+  }
+
+  if (pendingAnalytics.length >= MAX_ANALYTICS_QUEUE_DEPTH) {
+    return
+  }
+
+  pendingAnalytics.push(input)
+  flushPendingMcpAnalytics(process)
+}
+
+function dispatchMcpAnalytics(input: McpAnalyticsInput, process: ProcessMcpAnalytics): void {
+  analyticsInFlight += 1
+  void process(input)
+    .catch(() => {
+      // Analytics must never affect MCP behavior.
+    })
+    .finally(() => {
+      analyticsInFlight -= 1
+      flushPendingMcpAnalytics(process)
+    })
+}
+
+function flushPendingMcpAnalytics(process: ProcessMcpAnalytics): void {
+  while (analyticsInFlight < MAX_ANALYTICS_IN_FLIGHT && pendingAnalytics.length > 0) {
+    const next = pendingAnalytics.shift()
+    if (!next) break
+    dispatchMcpAnalytics(next, process)
+  }
+}
+
+/** Test-only */
+export function resetMcpAnalyticsQueueForTests(): void {
+  analyticsInFlight = 0
+  pendingAnalytics.length = 0
+}

--- a/apps/api/src/mcp/observability/mcp-analytics.test.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { AnalyticsEvents } from '@durabull/analytics/events'
+import { configureServerAnalytics, resetServerAnalyticsForTests } from '@durabull/analytics/server'
+import { env } from '@durabull/env'
+
+import {
+  resetCachedAnonymousInstanceIdForTests,
+} from '../../lib/configure-server-analytics'
+
+const captureAnonymousServerEvent = mock(async () => {})
+const captureIdentifiedServerEvent = mock(async () => {})
+
+mock.module('@durabull/analytics/server', () => ({
+  captureAnonymousServerEvent,
+  captureIdentifiedServerEvent,
+  hashMcpAnalyticsSessionId: (value: string) => `session-${value}`,
+  shouldDedupeIdentifiedPosthogEvents: () => false,
+  getTelemetryHmacSecret: () => 'test-secret',
+  resolveIdentifiedDistinctIds: ({ userId, organizationId }: { userId?: string; organizationId?: string }) => {
+    if (userId) {
+      return { distinctId: `hashed-user:${userId}`, organizationGroup: null }
+    }
+    if (organizationId) {
+      return { distinctId: `hashed-org:${organizationId}`, organizationGroup: `hashed-org:${organizationId}` }
+    }
+    return { distinctId: null, organizationGroup: null }
+  },
+  tryGetServerAnalyticsOptions: () => ({
+    enabled: true,
+    resolveAnonymousInstanceId: async () => 'test-instance-id',
+  }),
+  configureServerAnalytics,
+  resetServerAnalyticsForTests,
+}))
+
+const { recordMcpAnalytics, recordMcpTelemetryAnalytics } = await import('./mcp-analytics')
+const { resetMcpAnalyticsQueueForTests } = await import('./mcp-analytics-queue')
+const { resetMcpTelemetryForTests } = await import('./mcp-telemetry')
+
+const mutableEnv = env as {
+  BETTER_AUTH_SECRET?: string
+  CI?: boolean
+  NODE_ENV?: 'development' | 'test' | 'production'
+}
+
+const originalNodeEnv = mutableEnv.NODE_ENV
+const originalCi = mutableEnv.CI
+const originalSecret = mutableEnv.BETTER_AUTH_SECRET
+
+describe('mcp analytics', () => {
+  beforeEach(() => {
+    mutableEnv.NODE_ENV = 'production'
+    mutableEnv.CI = false
+    mutableEnv.BETTER_AUTH_SECRET = 'test-secret'
+    resetServerAnalyticsForTests()
+    resetCachedAnonymousInstanceIdForTests()
+    configureServerAnalytics({
+      enabled: true,
+      collectEnabled: true,
+      dedupeIdentifiedPosthogEvents: false,
+      disclosureUrl: 'https://durabull.io/privacy',
+      hmacSecret: 'test-secret',
+      durabullTelemetryPosthogKey: 'phc_test',
+      durabullTelemetryPosthogHost: 'https://us.i.posthog.com',
+      appPosthogKey: 'phc_app',
+      appPosthogHost: null,
+      cloudCollectUrl: 'https://app.durabull.io/api/telemetry/collect',
+      getRuntimeContext: () => ({
+        authless: false,
+        env_connections: false,
+        environment: 'production',
+        persistence: 'postgres',
+        stateless: false,
+      }),
+      resolveAnonymousInstanceId: async () => 'test-instance-id',
+    })
+    resetMcpTelemetryForTests()
+    resetMcpAnalyticsQueueForTests()
+    captureAnonymousServerEvent.mockClear()
+    captureIdentifiedServerEvent.mockClear()
+  })
+
+  afterEach(() => {
+    mutableEnv.NODE_ENV = originalNodeEnv
+    mutableEnv.CI = originalCi
+    mutableEnv.BETTER_AUTH_SECRET = originalSecret
+    resetServerAnalyticsForTests()
+    resetCachedAnonymousInstanceIdForTests()
+  })
+
+  it('maps tool success telemetry to mcp_tool_called analytics', async () => {
+    recordMcpTelemetryAnalytics('tool_success', {
+      toolName: 'list_jobs',
+      principalId: 'principal-1',
+      principalType: 'delegated_user',
+      userId: 'user-1',
+      organizationId: null,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(captureAnonymousServerEvent).toHaveBeenCalled()
+    expect(captureIdentifiedServerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: AnalyticsEvents.MCP_TOOL_CALLED,
+        distinctId: 'hashed-user:user-1',
+        properties: expect.objectContaining({
+          tool_name: 'list_jobs',
+          response_class: 'success',
+        }),
+      })
+    )
+  })
+
+  it('records anonymous-only auth failures without identity', async () => {
+    recordMcpTelemetryAnalytics('auth_missing_bearer', {})
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(captureAnonymousServerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: AnalyticsEvents.MCP_AUTH_FAILED,
+        properties: expect.objectContaining({
+          mcp_auth_failure: 'missing_bearer',
+        }),
+      })
+    )
+    expect(captureIdentifiedServerEvent).not.toHaveBeenCalled()
+  })
+
+  it('records rpc requests for service accounts with hashed org distinct id', async () => {
+    recordMcpAnalytics({
+      event: AnalyticsEvents.MCP_RPC_REQUESTED,
+      properties: { mcp_method: 'tools/list' },
+      identity: {
+        principalType: 'service_account',
+        principalId: 'sa-1',
+        organizationId: 'org-1',
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(captureIdentifiedServerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: 'hashed-org:org-1',
+        organizationId: 'hashed-org:org-1',
+      })
+    )
+  })
+
+  it('does not emit product analytics for redaction-only signals', async () => {
+    recordMcpTelemetryAnalytics('redaction_applied', {
+      toolName: 'list_jobs',
+      principalId: 'principal-1',
+      principalType: 'delegated_user',
+      userId: 'user-1',
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(captureAnonymousServerEvent).not.toHaveBeenCalled()
+    expect(captureIdentifiedServerEvent).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/mcp/observability/mcp-analytics.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics.ts
@@ -1,0 +1,270 @@
+import { AnalyticsEvents, AnalyticsProperties } from '@durabull/analytics/events'
+import {
+  captureAnonymousServerEvent,
+  captureIdentifiedServerEvent,
+  hashMcpAnalyticsSessionId,
+  resolveIdentifiedDistinctIds,
+  shouldDedupeIdentifiedPosthogEvents,
+  tryGetServerAnalyticsOptions,
+} from '@durabull/analytics/server'
+
+import { APP_VERSION } from '../../lib/build-info'
+import { enqueueMcpAnalytics } from './mcp-analytics-queue'
+import type { McpTelemetrySignal } from './mcp-telemetry-signals'
+
+export type McpPrincipalType = 'delegated_user' | 'service_account'
+
+export interface McpAnalyticsIdentity {
+  principalType: McpPrincipalType
+  principalId: string
+  userId?: string | null
+  organizationId?: string | null
+}
+
+export interface McpAnalyticsInput {
+  event: string
+  properties?: Record<string, unknown>
+  identity?: McpAnalyticsIdentity | null
+  sessionKey?: string
+}
+
+function categorizeDenialReason(reason: string | null | undefined): string {
+  if (!reason) return 'unknown'
+  const normalized = reason.toLowerCase()
+  if (normalized.includes('missing_scopes') || normalized.includes('scope')) return 'scope'
+  if (normalized.includes('connection')) return 'connection'
+  if (normalized.includes('principal')) return 'principal'
+  if (normalized.includes('org')) return 'organization'
+  return 'policy'
+}
+
+function buildBaseProperties(
+  properties: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    [AnalyticsProperties.SERVER_VERSION]: APP_VERSION,
+    ...properties,
+  }
+}
+
+async function processMcpAnalytics(input: McpAnalyticsInput): Promise<void> {
+  const options = tryGetServerAnalyticsOptions()
+  if (!options?.enabled) return
+
+  const properties = buildBaseProperties(input.properties)
+  const identity = input.identity ?? null
+  const identified = identity
+    ? resolveIdentifiedDistinctIds({
+        userId: identity.userId,
+        organizationId: identity.organizationId,
+      })
+    : { distinctId: null, organizationGroup: null }
+  const hasIdentifiedIdentity = identified.distinctId != null
+  const shouldSkipAnonymous = shouldDedupeIdentifiedPosthogEvents() && hasIdentifiedIdentity
+
+  const tasks: Promise<void>[] = []
+
+  if (!shouldSkipAnonymous) {
+    const anonymousInstanceId = await options.resolveAnonymousInstanceId()
+    const secret = options.hmacSecret
+    const sessionId =
+      input.sessionKey ??
+      (identity && secret
+        ? hashMcpAnalyticsSessionId(identity.principalId, secret)
+        : 'mcp-server')
+
+    tasks.push(
+      captureAnonymousServerEvent({
+        anonymousInstanceId,
+        event: input.event,
+        properties,
+        sessionId,
+      })
+    )
+  }
+
+  if (identified.distinctId) {
+    tasks.push(
+      captureIdentifiedServerEvent({
+        event: input.event,
+        properties,
+        distinctId: identified.distinctId,
+        organizationId: identified.organizationGroup,
+      })
+    )
+  }
+
+  if (tasks.length > 0) {
+    await Promise.all(tasks)
+  }
+}
+
+export function recordMcpAnalytics(input: McpAnalyticsInput): void {
+  enqueueMcpAnalytics(input, processMcpAnalytics)
+}
+
+export function recordMcpRpcAnalytics(input: {
+  mcpMethod: string
+  identity?: McpAnalyticsIdentity | null
+}): void {
+  recordMcpAnalytics({
+    event: AnalyticsEvents.MCP_RPC_REQUESTED,
+    properties: {
+      [AnalyticsProperties.MCP_METHOD]: input.mcpMethod,
+      [AnalyticsProperties.PRINCIPAL_TYPE]: input.identity?.principalType,
+    },
+    identity: input.identity,
+  })
+}
+
+export function recordMcpToolAnalytics(input: {
+  toolName: string
+  responseClass: 'success' | 'tool_error'
+  principalType: McpPrincipalType
+  identity: McpAnalyticsIdentity
+  redactionCount?: number
+}): void {
+  recordMcpAnalytics({
+    event: AnalyticsEvents.MCP_TOOL_CALLED,
+    properties: {
+      [AnalyticsProperties.TOOL_NAME]: input.toolName,
+      [AnalyticsProperties.RESPONSE_CLASS]: input.responseClass,
+      [AnalyticsProperties.PRINCIPAL_TYPE]: input.principalType,
+      [AnalyticsProperties.SUCCESS]: input.responseClass === 'success',
+      ...(input.redactionCount && input.redactionCount > 0
+        ? { redaction_count: input.redactionCount }
+        : {}),
+    },
+    identity: input.identity,
+  })
+}
+
+export function recordMcpToolDeniedAnalytics(input: {
+  toolName: string
+  principalType: McpPrincipalType
+  denialReason?: string | null
+  identity: McpAnalyticsIdentity
+}): void {
+  recordMcpAnalytics({
+    event: AnalyticsEvents.MCP_TOOL_DENIED,
+    properties: {
+      [AnalyticsProperties.TOOL_NAME]: input.toolName,
+      [AnalyticsProperties.PRINCIPAL_TYPE]: input.principalType,
+      [AnalyticsProperties.RESPONSE_CLASS]: 'policy_denied',
+      [AnalyticsProperties.DENIAL_REASON_CATEGORY]: categorizeDenialReason(input.denialReason),
+      [AnalyticsProperties.SUCCESS]: false,
+    },
+    identity: input.identity,
+  })
+}
+
+export function recordMcpAuthFailedAnalytics(input: {
+  failure: 'missing_bearer' | 'unauthorized' | 'insufficient_scope'
+  identity?: McpAnalyticsIdentity | null
+}): void {
+  recordMcpAnalytics({
+    event: AnalyticsEvents.MCP_AUTH_FAILED,
+    properties: {
+      [AnalyticsProperties.MCP_AUTH_FAILURE]: input.failure,
+      [AnalyticsProperties.SUCCESS]: false,
+      [AnalyticsProperties.PRINCIPAL_TYPE]: input.identity?.principalType,
+    },
+    identity: input.identity,
+  })
+}
+
+export function recordMcpRateLimitedAnalytics(input: {
+  scope: 'ingress' | 'tool'
+  toolName?: string
+  identity?: McpAnalyticsIdentity | null
+}): void {
+  recordMcpAnalytics({
+    event: AnalyticsEvents.MCP_RATE_LIMITED,
+    properties: {
+      [AnalyticsProperties.MCP_RATE_LIMIT_SCOPE]: input.scope,
+      [AnalyticsProperties.TOOL_NAME]: input.toolName,
+      [AnalyticsProperties.SUCCESS]: false,
+      [AnalyticsProperties.PRINCIPAL_TYPE]: input.identity?.principalType,
+    },
+    identity: input.identity,
+  })
+}
+
+export function recordMcpTelemetryAnalytics(
+  signal: McpTelemetrySignal,
+  context: {
+    toolName?: string
+    principalId?: string
+    principalType?: McpPrincipalType
+    userId?: string | null
+    organizationId?: string | null
+    denialReason?: string | null
+    redactionCount?: number
+  }
+): void {
+  const identity =
+    context.principalId && context.principalType
+      ? {
+          principalType: context.principalType,
+          principalId: context.principalId,
+          userId: context.userId,
+          organizationId: context.organizationId,
+        }
+      : null
+
+  switch (signal) {
+    case 'tool_success':
+      if (!context.toolName || !identity) return
+      recordMcpToolAnalytics({
+        toolName: context.toolName,
+        responseClass: 'success',
+        principalType: identity.principalType,
+        identity,
+        redactionCount: context.redactionCount,
+      })
+      return
+    case 'tool_error':
+      if (!context.toolName || !identity) return
+      recordMcpToolAnalytics({
+        toolName: context.toolName,
+        responseClass: 'tool_error',
+        principalType: identity.principalType,
+        identity,
+      })
+      return
+    case 'policy_denied':
+      if (!context.toolName || !identity) return
+      recordMcpToolDeniedAnalytics({
+        toolName: context.toolName,
+        principalType: identity.principalType,
+        denialReason: context.denialReason,
+        identity,
+      })
+      return
+    case 'rate_limited_ingress':
+      recordMcpRateLimitedAnalytics({ scope: 'ingress', identity })
+      return
+    case 'rate_limited_tool':
+      recordMcpRateLimitedAnalytics({
+        scope: 'tool',
+        toolName: context.toolName,
+        identity,
+      })
+      return
+    case 'auth_missing_bearer':
+      recordMcpAuthFailedAnalytics({ failure: 'missing_bearer', identity })
+      return
+    case 'auth_unauthorized':
+      recordMcpAuthFailedAnalytics({ failure: 'unauthorized', identity })
+      return
+    case 'auth_forbidden':
+      recordMcpAuthFailedAnalytics({ failure: 'insufficient_scope', identity })
+      return
+    case 'redaction_applied':
+    case 'audit_dropped':
+    case 'audit_write_failed':
+      return
+    default:
+      return
+  }
+}

--- a/apps/api/src/mcp/observability/mcp-telemetry-signals.ts
+++ b/apps/api/src/mcp/observability/mcp-telemetry-signals.ts
@@ -1,0 +1,12 @@
+export type McpTelemetrySignal =
+  | 'auth_missing_bearer'
+  | 'auth_unauthorized'
+  | 'auth_forbidden'
+  | 'policy_denied'
+  | 'rate_limited_ingress'
+  | 'rate_limited_tool'
+  | 'tool_success'
+  | 'tool_error'
+  | 'redaction_applied'
+  | 'audit_dropped'
+  | 'audit_write_failed'

--- a/apps/api/src/mcp/observability/mcp-telemetry.ts
+++ b/apps/api/src/mcp/observability/mcp-telemetry.ts
@@ -1,19 +1,18 @@
-export type McpTelemetrySignal =
-  | 'auth_unauthorized'
-  | 'auth_forbidden'
-  | 'policy_denied'
-  | 'rate_limited_ingress'
-  | 'rate_limited_tool'
-  | 'tool_success'
-  | 'tool_error'
-  | 'redaction_applied'
-  | 'audit_dropped'
-  | 'audit_write_failed'
+import type { McpPrincipalType } from './mcp-analytics'
+import { recordMcpTelemetryAnalytics } from './mcp-analytics'
+import type { McpTelemetrySignal } from './mcp-telemetry-signals'
+
+export type { McpTelemetrySignal } from './mcp-telemetry-signals'
 
 export interface McpTelemetryEvent {
   signal: McpTelemetrySignal
   toolName?: string
   principalId?: string
+  principalType?: McpPrincipalType
+  userId?: string | null
+  organizationId?: string | null
+  denialReason?: string | null
+  redactionCount?: number
   correlationId?: string
   count?: number
 }
@@ -24,6 +23,16 @@ let telemetryLoggingEnabled = process.env.MCP_TELEMETRY_LOG !== 'false'
 export function recordMcpTelemetry(event: McpTelemetryEvent): void {
   const increment = Math.max(1, event.count ?? 1)
   signalTotals.set(event.signal, (signalTotals.get(event.signal) ?? 0) + increment)
+
+  recordMcpTelemetryAnalytics(event.signal, {
+    toolName: event.toolName,
+    principalId: event.principalId,
+    principalType: event.principalType,
+    userId: event.userId,
+    organizationId: event.organizationId,
+    denialReason: event.denialReason,
+    redactionCount: event.redactionCount,
+  })
 
   if (!telemetryLoggingEnabled) return
 

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -3,11 +3,19 @@ import { createMiddleware } from 'hono/factory'
 
 import type { McpSession } from '../auth/mcp-session-middleware'
 import { hashMcpToolInput, writeMcpAuditEventNonBlocking } from '../audit/mcp-audit'
-import { parseMcpJsonRpcPayloadId, parseMcpToolCallBody, isMcpToolsCallMethod } from '../json-rpc-tool-call'
+import {
+  isMcpToolsCallMethod,
+  parseMcpJsonRpcMethod,
+  parseMcpJsonRpcPayloadId,
+  parseMcpToolCallBody,
+} from '../json-rpc-tool-call'
+import { recordMcpRpcAnalytics } from '../observability/mcp-analytics'
 import { resolveConnectionForPrincipal } from '../tools/shared'
 import { evaluateMcpToolPolicy } from './policy-engine'
 import { resolveMcpPrincipal } from './principal-resolver'
 import type { McpPolicyDecision, McpPrincipal } from './types'
+
+const RPC_ANALYTICS_METHODS = new Set(['initialize', 'tools/list'])
 
 function buildCorrelationId(): string {
   return crypto.randomUUID()
@@ -85,6 +93,11 @@ export function createMcpPolicyMiddleware() {
       )
     }
     if (!toolCall) {
+      const mcpMethod = parseMcpJsonRpcMethod(body)
+      const rpcAnalyticsMethods = RPC_ANALYTICS_METHODS
+      if (mcpMethod && rpcAnalyticsMethods.has(mcpMethod)) {
+        recordMcpRpcAnalytics({ mcpMethod })
+      }
       return next()
     }
 
@@ -129,6 +142,7 @@ export function createMcpPolicyMiddleware() {
         correlationId: decision.correlationId,
         principalType: decision.principalType,
         principalId: decision.principalId,
+        userId: principal.type === 'delegated_user' ? principal.userId : null,
         organizationId: decision.organizationId,
         connectionId: decision.connectionId,
         toolName: decision.toolName,

--- a/apps/api/src/routes/telemetry-collect.test.ts
+++ b/apps/api/src/routes/telemetry-collect.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { env } from '@durabull/env'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
-import telemetryRoutes, { hashTelemetryIdentifier } from './telemetry'
+import { hashTelemetryIdentifier } from '@durabull/analytics/server'
+import { resetServerAnalyticsForTests } from '@durabull/analytics/server'
+import {
+  bootstrapServerAnalytics,
+  resetCachedAnonymousInstanceIdForTests,
+} from '../lib/configure-server-analytics'
+import telemetryRoutes from './telemetry'
 
 const INSTANCE_ID = '41111111-1111-4111-8111-111111111111'
 const SESSION_ID = 'ephemeral-session'
@@ -75,9 +81,12 @@ describe('telemetry collect route', () => {
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = HMAC_SECRET
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'https://us.i.posthog.com'
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = POSTHOG_KEY
+    bootstrapServerAnalytics()
   })
 
   afterEach(() => {
+    resetServerAnalyticsForTests()
+    resetCachedAnonymousInstanceIdForTests()
     mutableEnv.APP_BASE_URL = originalAppBaseUrl
     mutableEnv.BETTER_AUTH_SECRET = originalBetterAuthSecret
     mutableEnv.CI = originalCi
@@ -95,6 +104,7 @@ describe('telemetry collect route', () => {
     mutableEnv.POSTHOG_KEY = POSTHOG_KEY
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = undefined
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = undefined
+    bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
@@ -173,9 +183,27 @@ describe('telemetry collect route', () => {
     expect(properties.instance_key).not.toContain(INSTANCE_ID)
   })
 
+  it('returns not found when product telemetry is disabled', async () => {
+    mutableEnv.NODE_ENV = 'development'
+    bootstrapServerAnalytics()
+    const fetchMock = mock(async () => new Response(null, { status: 200 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await app.request('/collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: collectPayload(),
+    })
+
+    expect(response.status).toBe(404)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('rejects collect requests on non-Durabull API deployments', async () => {
     mutableEnv.APP_BASE_URL = 'https://self-hosted.example.com'
     mutableEnv.DURABULL_CLOUD = false
+    bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
@@ -234,6 +262,7 @@ describe('telemetry collect route', () => {
     mutableEnv.POSTHOG_KEY = undefined
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = undefined
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = undefined
+    bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
@@ -250,6 +279,7 @@ describe('telemetry collect route', () => {
 
   it('fails closed when the configured PostHog batch host is invalid', async () => {
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'http://[::1'
+    bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()

--- a/apps/api/src/routes/telemetry.test.ts
+++ b/apps/api/src/routes/telemetry.test.ts
@@ -6,6 +6,12 @@ import { closeDb } from '@durabull/dal'
 import { env } from '@durabull/env'
 import { Hono } from 'hono'
 
+import { resetServerAnalyticsForTests } from '@durabull/analytics/server'
+import {
+  bootstrapServerAnalytics,
+  resetCachedAnonymousInstanceIdForTests,
+} from '../lib/configure-server-analytics'
+
 const QUEUE_PAUSED_EVENT = 'queue_paused'
 
 const mutableEnv = env as {
@@ -38,6 +44,8 @@ describe('telemetry routes', () => {
 
   afterEach(async () => {
     await closeDb()
+    resetServerAnalyticsForTests()
+    resetCachedAnonymousInstanceIdForTests()
     mutableEnv.CI = originalCi
     mutableEnv.DATABASE_URL = originalDatabaseUrl
     mutableEnv.NODE_ENV = originalNodeEnv
@@ -82,10 +90,9 @@ describe('telemetry routes', () => {
     })
   })
 
-  it('accepts known events in production and forwards sanitized canonical events', async () => {
+  it('rejects forbidden properties on /events', async () => {
     mutableEnv.NODE_ENV = 'production'
-    const fetchMock = mock(async () => new Response(null, { status: 202 }))
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    bootstrapServerAnalytics()
     const app = await createTelemetryRouteApp()
 
     const response = await app.request('/events', {
@@ -98,12 +105,31 @@ describe('telemetry routes', () => {
           success: true,
         },
         sessionId: 'ephemeral-session',
+      }),
+    })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('accepts known events in production and forwards sanitized canonical events', async () => {
+    mutableEnv.NODE_ENV = 'production'
+    bootstrapServerAnalytics()
+    const fetchMock = mock(async () => new Response(null, { status: 202 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = await createTelemetryRouteApp()
+
+    const response = await app.request('/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: QUEUE_PAUSED_EVENT,
+        properties: { success: true },
+        sessionId: 'ephemeral-session',
         timestamp: '2026-04-28T12:00:00.000Z',
       }),
     })
 
     expect(response.status).toBe(202)
-    expect(await response.json()).toEqual({ accepted: true })
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
@@ -118,11 +144,11 @@ describe('telemetry routes', () => {
     )
     expect(body.events[0].event).toBe(QUEUE_PAUSED_EVENT)
     expect(body.events[0].properties.success).toBe(true)
-    expect(body.events[0].properties).not.toHaveProperty('queue_name')
   })
 
   it('rejects unknown events', async () => {
     mutableEnv.NODE_ENV = 'production'
+    bootstrapServerAnalytics()
     const app = await createTelemetryRouteApp()
 
     const response = await app.request('/events', {
@@ -140,6 +166,7 @@ describe('telemetry routes', () => {
 
   it('keeps local telemetry non-blocking when Durabull API forwarding fails', async () => {
     mutableEnv.NODE_ENV = 'production'
+    bootstrapServerAnalytics()
     const fetchMock = mock(async () => {
       throw new Error('Durabull API unavailable')
     })

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -1,26 +1,16 @@
-import { createHmac } from 'node:crypto'
 import {
-  isKnownDurabullTelemetryEvent,
-  sanitizeTelemetryEvent,
-} from '@durabull/analytics/sanitizer'
-import {
-  getDatabaseMode,
-  shouldUseEnvConnections,
-  telemetryInstallationRepository,
-} from '@durabull/dal'
-import { env } from '@durabull/env'
+  captureAnonymousServerEvent,
+  getTelemetryStatusFromOptions,
+  ingestTelemetryCollectBatch,
+  TELEMETRY_DISCLOSURE_URL,
+  tryGetServerAnalyticsOptions,
+  validateTelemetryPayload,
+} from '@durabull/analytics/server'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { isAuthlessMode } from '../lib/authless'
 
-// Self-hosted instances forward sanitized batches to the existing Durabull cloud API.
-// There is no separate event-ingestion app or alternate telemetry hostname to deploy.
-const DURABULL_CLOUD_API_HOST = 'app.durabull.io'
-const DURABULL_TELEMETRY_INGEST_ENDPOINT = `https://${DURABULL_CLOUD_API_HOST}/api/telemetry/collect`
-const DEFAULT_POSTHOG_BATCH_HOST = 'https://us.i.posthog.com'
 const MAX_COLLECT_EVENTS_PER_BATCH = 50
-export const TELEMETRY_DISCLOSURE_URL = 'https://durabull.io/privacy'
 
 const telemetryPayloadSchema = z.object({
   event: z.string().min(1).max(128),
@@ -42,120 +32,23 @@ const telemetryCollectPayloadSchema = z.object({
   events: z.array(telemetryCollectEventSchema).min(1).max(MAX_COLLECT_EVENTS_PER_BATCH),
 })
 
-interface TelemetryCollectConfig {
-  hmacSecret: string
-  posthogBatchUrl: string
-  posthogKey: string
-}
-
-export function isDurabullTelemetryEnabled(): boolean {
-  if (env.NODE_ENV === 'test' || env.CI === true) return false
-  return env.NODE_ENV === 'production'
-}
-
-export function isDurabullManagedPosthogProject(): boolean {
-  if (env.DURABULL_CLOUD === true) return true
-
-  try {
-    return new URL(env.APP_BASE_URL).hostname === DURABULL_CLOUD_API_HOST
-  } catch {
-    return false
+export function getTelemetryStatus() {
+  const options = tryGetServerAnalyticsOptions()
+  if (!options) {
+    return {
+      enabled: false,
+      collectionRequired: true as const,
+      dedupeIdentifiedPosthogEvents: false,
+      disclosureUrl: TELEMETRY_DISCLOSURE_URL,
+    }
   }
+
+  return getTelemetryStatusFromOptions(options)
 }
 
 export function isDurabullTelemetryCollectEnabled(): boolean {
-  return env.DURABULL_CLOUD === true || isDurabullManagedPosthogProject()
-}
-
-export function getTelemetryStatus() {
-  return {
-    enabled: isDurabullTelemetryEnabled(),
-    collectionRequired: true as const,
-    dedupeIdentifiedPosthogEvents: shouldDedupeIdentifiedPosthogEvents(),
-    disclosureUrl: TELEMETRY_DISCLOSURE_URL,
-  }
-}
-
-export function hashTelemetryIdentifier(value: string, secret: string): string {
-  return createHmac('sha256', secret).update(value).digest('hex')
-}
-
-function getDurabullTelemetryPosthogKey(): string | null {
-  return env.DURABULL_TELEMETRY_POSTHOG_KEY?.trim() || env.POSTHOG_KEY?.trim() || null
-}
-
-function shouldDedupeIdentifiedPosthogEvents(): boolean {
-  const appPosthogKey = env.POSTHOG_KEY?.trim()
-  if (!appPosthogKey || !isDurabullManagedPosthogProject()) return false
-
-  return getDurabullTelemetryPosthogKey() === appPosthogKey
-}
-
-function getPosthogBatchUrl(): string | null {
-  const rawHost = env.DURABULL_TELEMETRY_POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_BATCH_HOST
-  const hostWithProtocol = /^https?:\/\//i.test(rawHost) ? rawHost : `https://${rawHost}`
-
-  try {
-    const parsed = new URL(hostWithProtocol)
-    const basePath = parsed.pathname.replace(/\/$/, '')
-    const batchPath = basePath.endsWith('/batch') ? basePath : `${basePath}/batch`
-
-    return `${parsed.origin}${batchPath}/`
-  } catch {
-    return null
-  }
-}
-
-function getTelemetryCollectConfig(): TelemetryCollectConfig | null {
-  const posthogKey = getDurabullTelemetryPosthogKey()
-  const hmacSecret = env.DURABULL_TELEMETRY_HMAC_SECRET?.trim() || env.BETTER_AUTH_SECRET?.trim()
-  const posthogBatchUrl = getPosthogBatchUrl()
-
-  if (!posthogKey || !hmacSecret || !posthogBatchUrl) return null
-
-  return {
-    hmacSecret,
-    posthogBatchUrl,
-    posthogKey,
-  }
-}
-
-async function forwardTelemetryEvent(payload: {
-  anonymousInstanceId: string
-  event: string
-  properties: Record<string, unknown>
-  sessionId: string
-  timestamp: string
-}) {
-  try {
-    await fetch(DURABULL_TELEMETRY_INGEST_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        sentAt: new Date().toISOString(),
-        instanceId: payload.anonymousInstanceId,
-        events: [
-          {
-            event: payload.event,
-            properties: {
-              ...payload.properties,
-              authless: isAuthlessMode(),
-              env_connections: shouldUseEnvConnections(),
-              environment: env.NODE_ENV ?? 'development',
-              persistence: getDatabaseMode(),
-              stateless: getDatabaseMode() === 'pglite',
-            },
-            sessionId: payload.sessionId,
-            timestamp: payload.timestamp,
-          },
-        ],
-      }),
-    })
-  } catch {
-    // Telemetry collection must never affect the local product experience.
-  }
+  const options = tryGetServerAnalyticsOptions()
+  return (options?.collectEnabled && options.enabled) ?? false
 }
 
 const telemetryRoutes = new Hono()
@@ -165,60 +58,27 @@ const telemetryRoutes = new Hono()
       return c.json({ error: 'Not Found' }, 404)
     }
 
-    const config = getTelemetryCollectConfig()
-    if (!config) {
-      return c.json({ error: 'Telemetry collection is not configured' }, 503)
-    }
-
     const payload = c.req.valid('json')
-    const batch = []
+    const result = await ingestTelemetryCollectBatch({
+      instanceId: payload.instanceId,
+      sentAt: payload.sentAt,
+      events: payload.events,
+    })
 
-    for (const event of payload.events) {
-      if (!isKnownDurabullTelemetryEvent(event.event)) {
+    if (!result.ok) {
+      if (result.error === 'disabled' || result.error === 'not_configured') {
+        return c.json({ error: 'Telemetry collection is not configured' }, 503)
+      }
+      if (result.error === 'unknown_event') {
         return c.json({ error: 'Unknown telemetry event' }, 400)
       }
-
-      const sanitized = sanitizeTelemetryEvent(event.event, event.properties)
-      if (sanitized.droppedProperties.length > 0) {
+      if (result.error === 'invalid_properties') {
         return c.json({ error: 'Invalid telemetry properties' }, 400)
       }
-
-      const distinctId = hashTelemetryIdentifier(
-        `${payload.instanceId}:${event.sessionId}`,
-        config.hmacSecret
-      )
-      const instanceKey = hashTelemetryIdentifier(payload.instanceId, config.hmacSecret)
-
-      batch.push({
-        event: sanitized.event,
-        properties: {
-          ...sanitized.properties,
-          $geoip_disable: true,
-          $process_person_profile: false,
-          distinct_id: distinctId,
-          instance_key: instanceKey,
-        },
-        timestamp: event.timestamp ?? payload.sentAt ?? new Date().toISOString(),
-      })
-    }
-
-    try {
-      const posthogResponse = await fetch(config.posthogBatchUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          api_key: config.posthogKey,
-          batch,
-        }),
-      })
-
-      if (!posthogResponse.ok) {
-        return c.json({ error: 'Telemetry upstream rejected batch' }, 502)
+      if (result.error === 'upstream_unavailable') {
+        return c.json({ error: 'Telemetry upstream unavailable' }, 503)
       }
-    } catch {
-      return c.json({ error: 'Telemetry upstream unavailable' }, 502)
+      return c.json({ error: 'Telemetry upstream rejected batch' }, 502)
     }
 
     return c.json({ accepted: true }, 202)
@@ -230,20 +90,40 @@ const telemetryRoutes = new Hono()
     }
 
     const body = c.req.valid('json')
-    if (!isKnownDurabullTelemetryEvent(body.event)) {
-      return c.json({ error: 'Unknown telemetry event' }, 400)
+    const options = tryGetServerAnalyticsOptions()
+    if (!options) {
+      return c.json({ error: 'Telemetry is not configured' }, 503)
     }
 
-    const sanitized = sanitizeTelemetryEvent(body.event, body.properties ?? {})
-    const anonymousInstanceId =
-      await telemetryInstallationRepository.getOrCreateAnonymousInstanceId()
+    const validated = validateTelemetryPayload(
+      body.event,
+      body.properties ?? {},
+      options.getRuntimeContext()
+    )
+    if (!validated.ok) {
+      if (validated.error === 'unknown_event') {
+        return c.json({ error: 'Unknown telemetry event' }, 400)
+      }
+      return c.json({ error: 'Invalid telemetry properties' }, 400)
+    }
 
-    void forwardTelemetryEvent({
+    if (
+      options.collectEnabled &&
+      (!options.durabullTelemetryPosthogKey?.trim() || !options.hmacSecret?.trim())
+    ) {
+      return c.json({ error: 'Telemetry collection is not configured' }, 503)
+    }
+
+    const anonymousInstanceId = await options.resolveAnonymousInstanceId()
+
+    void captureAnonymousServerEvent({
       anonymousInstanceId,
-      event: sanitized.event,
-      properties: sanitized.properties,
+      event: validated.event,
+      properties: validated.properties,
       sessionId: body.sessionId,
       timestamp: body.timestamp ?? new Date().toISOString(),
+    }).catch(() => {
+      // Telemetry must never affect the local product experience.
     })
 
     return c.json({ accepted: true }, 202)

--- a/apps/web/src/routes/consent.tsx
+++ b/apps/web/src/routes/consent.tsx
@@ -1,3 +1,5 @@
+import { AnalyticsEvents } from '@durabull/analytics/events'
+import { trackEvent } from '@durabull/analytics/browser'
 import {
   labelConsentScopes,
   type McpOAuthConsentContext,
@@ -128,6 +130,10 @@ function ConsentPage() {
       const result = await submitOAuthConsent({
         accept,
         consentCode: search.consent_code,
+      })
+      trackEvent(accept ? AnalyticsEvents.MCP_CONSENT_GRANTED : AnalyticsEvents.MCP_CONSENT_DENIED, {
+        success: accept,
+        scope_count: context?.scopes.length ?? 0,
       })
       window.location.assign(result.redirectURI)
     } catch (error) {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -8,9 +8,25 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts"
     },
+    "./events": {
+      "types": "./src/events.ts",
+      "import": "./src/events.ts"
+    },
+    "./browser": {
+      "types": "./src/browser.ts",
+      "import": "./src/browser.ts"
+    },
+    "./react": {
+      "types": "./src/react.ts",
+      "import": "./src/react.ts"
+    },
     "./client": {
       "types": "./src/client.ts",
       "import": "./src/client.ts"
+    },
+    "./server": {
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts"
     },
     "./sanitizer": {
       "types": "./src/sanitizer.ts",

--- a/packages/analytics/src/browser.ts
+++ b/packages/analytics/src/browser.ts
@@ -1,0 +1,19 @@
+/**
+ * Browser / React analytics (PostHog JS SDK).
+ *
+ * Prefer `@durabull/analytics/browser` or `@durabull/analytics/react` in app code.
+ */
+export {
+  configureDurabullTelemetry,
+  getPostHog,
+  identifyOrganization,
+  identifyUser,
+  initAnalytics,
+  type OrganizationProperties,
+  resetIdentity,
+  trackEvent,
+  trackOrganizationCreated,
+  trackPageView,
+  trackUserCreated,
+  type UserProperties,
+} from './client'

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -108,6 +108,16 @@ export const AnalyticsEvents = {
 
   // App Lifecycle Events
   APP_UPDATE_CLICKED: 'app_update_clicked',
+
+  // MCP Events
+  MCP_RPC_REQUESTED: 'mcp_rpc_requested',
+  MCP_TOOL_CALLED: 'mcp_tool_called',
+  MCP_TOOL_DENIED: 'mcp_tool_denied',
+  MCP_AUTH_FAILED: 'mcp_auth_failed',
+  MCP_RATE_LIMITED: 'mcp_rate_limited',
+  MCP_CLIENT_REGISTERED: 'mcp_client_registered',
+  MCP_CONSENT_GRANTED: 'mcp_consent_granted',
+  MCP_CONSENT_DENIED: 'mcp_consent_denied',
 } as const
 
 /**
@@ -193,6 +203,15 @@ export const AnalyticsProperties = {
   TAB: 'tab',
   UPDATE_REASON: 'update_reason',
   VISIBLE: 'visible',
+
+  // MCP properties (sanitized — no raw IDs or connection names)
+  MCP_METHOD: 'mcp_method',
+  TOOL_NAME: 'tool_name',
+  PRINCIPAL_TYPE: 'principal_type',
+  RESPONSE_CLASS: 'response_class',
+  DENIAL_REASON_CATEGORY: 'denial_reason_category',
+  MCP_AUTH_FAILURE: 'mcp_auth_failure',
+  MCP_RATE_LIMIT_SCOPE: 'mcp_rate_limit_scope',
 } as const
 
 /**

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,70 +1,14 @@
 /**
- * @durabull/analytics
+ * @durabull/analytics — shared event schema and sanitization.
  *
- * Analytics package for PostHog integration
- * Provides user and organization identification, event tracking, and page view tracking
- *
- * Usage:
- * - Import from '@durabull/analytics/client' for client-side usage
- * - Initialize with initAnalytics() at app startup
- * - Call identifyUser() when a user signs up or logs in
- * - Call identifyOrganization() when a user creates or joins an organization
+ * Runtime SDKs:
+ * - `@durabull/analytics/browser` or `@durabull/analytics/react` — PostHog in the web app
+ * - `@durabull/analytics/server` — PostHog batch capture from the API
  */
 
-// Re-export all client functions and types
-export {
-  configureDurabullTelemetry,
-  getPostHog,
-  identifyOrganization,
-  identifyUser,
-  initAnalytics,
-  type OrganizationProperties,
-  resetIdentity,
-  trackEvent,
-  trackOrganizationCreated,
-  trackPageView,
-  trackUserCreated,
-  type UserProperties,
-} from './client'
-// Re-export all event constants and types
-export {
-  type AccountLinkEventProperties,
-  type AnalyticsEventName,
-  AnalyticsEvents,
-  AnalyticsProperties,
-  AuthMethod,
-  type AuthMethodType,
-  ConnectionEnvironment,
-  type ConnectionEventProperties,
-  type ConnectionSelectedProperties,
-  type ConnectionTestedProperties,
-  type DialogEventProperties,
-  DialogType,
-  type DialogTypeValue,
-  type InvitationEventProperties,
-  type JobLogsClearedProperties,
-  type JobStatusFilteredProperties,
-  type JobsOperationProperties,
-  JobTab,
-  type JobTabChangedProperties,
-  type JobViewedProperties,
-  type MemberInvitedProperties,
-  type MemberRemovedProperties,
-  MemberRole,
-  type MemberRoleUpdatedProperties,
-  type OrganizationSwitchedProperties,
-  type QueueCleanedProperties,
-  type QueueEventProperties,
-  QueueTab,
-  type RedisKeyEventProperties,
-  type RedisKeyFilterChangedProperties,
-  type ScheduledJobEventProperties,
-  type SignInEventProperties,
-  // Event property types
-  type SignUpEventProperties,
-  type ThemeChangedProperties,
-  ThemeValue,
-} from './events'
+/** @deprecated Prefer `@durabull/analytics/browser` in new code. */
+export * from './browser'
+export * from './events'
 export {
   categorizeErrorMessage,
   getForbiddenTelemetryPropertyKeys,

--- a/packages/analytics/src/react.ts
+++ b/packages/analytics/src/react.ts
@@ -1,0 +1,2 @@
+/** Alias for {@link ./browser.ts} — use in React apps. */
+export * from './browser'

--- a/packages/analytics/src/sanitizer.ts
+++ b/packages/analytics/src/sanitizer.ts
@@ -75,6 +75,7 @@ const ALLOWED_PROPERTY_KEYS = new Set([
   'error_category',
   'exclude_bull_keys',
   'filter_status',
+  'instance_key',
   'is_default',
   'job_count',
   'job_status',
@@ -100,6 +101,15 @@ const ALLOWED_PROPERTY_KEYS = new Set([
   'theme',
   'update_reason',
   'visible',
+  'denial_reason_category',
+  'mcp_auth_failure',
+  'mcp_method',
+  'mcp_rate_limit_scope',
+  'principal_type',
+  'response_class',
+  'redaction_count',
+  'scope_count',
+  'tool_name',
 ])
 
 const PUBLIC_TOP_LEVEL_ROUTES = new Set([
@@ -223,6 +233,10 @@ export function sanitizeTelemetryEvent(
 
     if (FORBIDDEN_PROPERTY_KEYS.has(key) || !ALLOWED_PROPERTY_KEYS.has(key)) {
       droppedProperties.push(key)
+      continue
+    }
+
+    if (value === undefined) {
       continue
     }
 

--- a/packages/analytics/src/server/capture.ts
+++ b/packages/analytics/src/server/capture.ts
@@ -1,0 +1,298 @@
+import {
+  getServerAnalyticsOptions,
+  tryGetServerAnalyticsOptions,
+  type ServerAnalyticsOptions,
+} from './config'
+import {
+  hashIdentifiedOrganizationDistinctId,
+  hashIdentifiedUserDistinctId,
+  hashTelemetryIdentifier,
+} from './identifiers'
+import {
+  resolvePosthogBatchUrl,
+  sendPosthogBatch,
+  type PosthogBatchCapture,
+  type PosthogBatchClientConfig,
+} from './posthog-batch'
+import { validateTelemetryPayload } from './validate'
+
+interface DurabullTelemetryCollectConfig extends PosthogBatchClientConfig {
+  hmacSecret: string
+}
+
+function getOptions(): ServerAnalyticsOptions | null {
+  return tryGetServerAnalyticsOptions()
+}
+
+function getDurabullTelemetryCollectConfig(
+  options: ServerAnalyticsOptions
+): DurabullTelemetryCollectConfig | null {
+  const posthogKey = options.durabullTelemetryPosthogKey
+  const hmacSecret = options.hmacSecret
+  const posthogBatchUrl = resolvePosthogBatchUrl(options.durabullTelemetryPosthogHost ?? undefined)
+
+  if (!posthogKey || !hmacSecret || !posthogBatchUrl) return null
+
+  return { hmacSecret, posthogBatchUrl, posthogKey }
+}
+
+function getIdentifiedPosthogConfig(options: ServerAnalyticsOptions): PosthogBatchClientConfig | null {
+  const posthogKey = options.appPosthogKey
+  if (!posthogKey) return null
+
+  const posthogBatchUrl = resolvePosthogBatchUrl(
+    options.appPosthogHost ?? options.durabullTelemetryPosthogHost ?? undefined
+  )
+  if (!posthogBatchUrl) return null
+
+  return { posthogBatchUrl, posthogKey }
+}
+
+function buildAnonymousCapture(input: {
+  anonymousInstanceId: string
+  sessionId: string
+  event: string
+  properties: Record<string, string | number | boolean | null>
+  timestamp: string
+  hmacSecret: string
+}): PosthogBatchCapture {
+  const distinctId = hashTelemetryIdentifier(
+    `${input.anonymousInstanceId}:${input.sessionId}`,
+    input.hmacSecret
+  )
+  const instanceKey = hashTelemetryIdentifier(input.anonymousInstanceId, input.hmacSecret)
+
+  return {
+    event: input.event,
+    properties: {
+      ...input.properties,
+      instance_key: instanceKey,
+    },
+    distinctId,
+    processPersonProfile: false,
+    timestamp: input.timestamp,
+  }
+}
+
+async function forwardAnonymousToCloudCollect(input: {
+  cloudCollectUrl: string
+  anonymousInstanceId: string
+  event: string
+  properties: Record<string, string | number | boolean | null>
+  sessionId: string
+  timestamp: string
+  runtimeContext: ReturnType<ServerAnalyticsOptions['getRuntimeContext']>
+}): Promise<void> {
+  const response = await fetch(input.cloudCollectUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sentAt: new Date().toISOString(),
+      instanceId: input.anonymousInstanceId,
+      events: [
+        {
+          event: input.event,
+          properties: {
+            ...input.runtimeContext,
+            ...input.properties,
+          },
+          sessionId: input.sessionId,
+          timestamp: input.timestamp,
+        },
+      ],
+    }),
+  })
+
+  if (!response.ok) {
+    console.warn(`[analytics] cloud collect forward failed with status ${response.status}`)
+  }
+}
+
+export async function captureAnonymousServerEvent(input: {
+  anonymousInstanceId: string
+  event: string
+  properties: Record<string, unknown>
+  sessionId: string
+  timestamp?: string
+}): Promise<void> {
+  const options = getOptions()
+  if (!options?.enabled) return
+
+  const runtimeContext = options.getRuntimeContext()
+  const validated = validateTelemetryPayload(input.event, input.properties, runtimeContext)
+  if (!validated.ok) return
+
+  const timestamp = input.timestamp ?? new Date().toISOString()
+
+  if (options.collectEnabled) {
+    const config = getDurabullTelemetryCollectConfig(options)
+    if (!config) return
+
+    await sendPosthogBatch(
+      config,
+      [
+        buildAnonymousCapture({
+          anonymousInstanceId: input.anonymousInstanceId,
+          sessionId: input.sessionId,
+          event: validated.event,
+          properties: validated.properties,
+          timestamp,
+          hmacSecret: config.hmacSecret,
+        }),
+      ],
+      { runtimeContext, mergeRuntime: true }
+    )
+    return
+  }
+
+  await forwardAnonymousToCloudCollect({
+    cloudCollectUrl: options.cloudCollectUrl,
+    anonymousInstanceId: input.anonymousInstanceId,
+    event: validated.event,
+    properties: validated.properties,
+    sessionId: input.sessionId,
+    timestamp,
+    runtimeContext,
+  })
+}
+
+export async function captureIdentifiedServerEvent(input: {
+  event: string
+  properties: Record<string, unknown>
+  distinctId: string
+  organizationId?: string | null
+  timestamp?: string
+}): Promise<void> {
+  const options = getOptions()
+  if (!options?.enabled) return
+
+  const runtimeContext = options.getRuntimeContext()
+  const validated = validateTelemetryPayload(input.event, input.properties, runtimeContext)
+  if (!validated.ok) return
+
+  const config = getIdentifiedPosthogConfig(options)
+  if (!config) return
+
+  const hmacSecret = options.hmacSecret
+  const organizationGroup =
+    input.organizationId && hmacSecret
+      ? hashIdentifiedOrganizationDistinctId(input.organizationId, hmacSecret)
+      : null
+
+  await sendPosthogBatch(
+    config,
+    [
+      {
+        event: validated.event,
+        properties: validated.properties,
+        distinctId: input.distinctId,
+        organizationId: organizationGroup,
+        processPersonProfile: true,
+        timestamp: input.timestamp,
+      },
+    ],
+    { runtimeContext, mergeRuntime: true }
+  )
+}
+
+export interface TelemetryCollectEventInput {
+  event: string
+  properties: Record<string, unknown>
+  sessionId: string
+  timestamp?: string
+}
+
+export type IngestCollectBatchResult =
+  | { ok: true }
+  | {
+      ok: false
+      error:
+        | 'disabled'
+        | 'not_configured'
+        | 'unknown_event'
+        | 'invalid_properties'
+        | 'upstream_rejected'
+        | 'upstream_unavailable'
+    }
+
+export async function ingestTelemetryCollectBatch(input: {
+  instanceId: string
+  sentAt?: string
+  events: TelemetryCollectEventInput[]
+}): Promise<IngestCollectBatchResult> {
+  const options = getOptions()
+  if (!options?.enabled) {
+    return { ok: false, error: 'disabled' }
+  }
+
+  const config = getDurabullTelemetryCollectConfig(options)
+  if (!config) {
+    return { ok: false, error: 'not_configured' }
+  }
+
+  const batch: PosthogBatchCapture[] = []
+
+  for (const event of input.events) {
+    const validated = validateTelemetryPayload(event.event, event.properties)
+    if (!validated.ok) {
+      return { ok: false, error: validated.error }
+    }
+
+    batch.push(
+      buildAnonymousCapture({
+        anonymousInstanceId: input.instanceId,
+        sessionId: event.sessionId,
+        event: validated.event,
+        properties: validated.properties,
+        timestamp: event.timestamp ?? input.sentAt ?? new Date().toISOString(),
+        hmacSecret: config.hmacSecret,
+      })
+    )
+  }
+
+  try {
+    const accepted = await sendPosthogBatch(config, batch, { mergeRuntime: false })
+    return accepted ? { ok: true } : { ok: false, error: 'upstream_rejected' }
+  } catch {
+    return { ok: false, error: 'upstream_unavailable' }
+  }
+}
+
+export function shouldDedupeIdentifiedPosthogEvents(): boolean {
+  return getOptions()?.dedupeIdentifiedPosthogEvents ?? false
+}
+
+export function resolveIdentifiedDistinctIds(input: {
+  userId?: string | null
+  organizationId?: string | null
+}): { distinctId: string | null; organizationGroup: string | null } {
+  const options = getOptions()
+  const secret = options?.hmacSecret
+  if (!secret) {
+    return { distinctId: null, organizationGroup: null }
+  }
+
+  if (input.userId) {
+    return {
+      distinctId: hashIdentifiedUserDistinctId(input.userId, secret),
+      organizationGroup: input.organizationId
+        ? hashIdentifiedOrganizationDistinctId(input.organizationId, secret)
+        : null,
+    }
+  }
+
+  if (input.organizationId) {
+    const organizationGroup = hashIdentifiedOrganizationDistinctId(input.organizationId, secret)
+    return {
+      distinctId: organizationGroup,
+      organizationGroup,
+    }
+  }
+
+  return { distinctId: null, organizationGroup: null }
+}
+
+/** @deprecated Use getServerAnalyticsOptions().hmacSecret */
+export function getTelemetryHmacSecret(): string | null {
+  return getOptions()?.hmacSecret ?? null
+}

--- a/packages/analytics/src/server/config.ts
+++ b/packages/analytics/src/server/config.ts
@@ -1,0 +1,71 @@
+export const TELEMETRY_DISCLOSURE_URL = 'https://durabull.io/privacy'
+export const DURABULL_CLOUD_API_HOST = 'app.durabull.io'
+export const DEFAULT_CLOUD_COLLECT_URL = `https://${DURABULL_CLOUD_API_HOST}/api/telemetry/collect`
+export const DEFAULT_POSTHOG_BATCH_HOST = 'https://us.i.posthog.com'
+
+export interface ServerAnalyticsRuntimeContext {
+  authless: boolean
+  env_connections: boolean
+  environment: string
+  persistence: string
+  stateless: boolean
+}
+
+export interface ServerAnalyticsOptions {
+  /** Production-only product analytics (false in test/CI/dev). */
+  enabled: boolean
+  /** Cloud or managed host: ingest directly to PostHog batch. */
+  collectEnabled: boolean
+  /** When app + Durabull telemetry share one PostHog project, skip duplicate anonymous events. */
+  dedupeIdentifiedPosthogEvents: boolean
+  disclosureUrl: string
+  hmacSecret: string | null
+  durabullTelemetryPosthogKey: string | null
+  durabullTelemetryPosthogHost: string | null
+  appPosthogKey: string | null
+  appPosthogHost: string | null
+  cloudCollectUrl: string
+  getRuntimeContext: () => ServerAnalyticsRuntimeContext
+  /** Cached anonymous installation id for server-origin events (avoids per-event DB writes). */
+  resolveAnonymousInstanceId: () => Promise<string>
+}
+
+let configuredOptions: ServerAnalyticsOptions | null = null
+
+export function configureServerAnalytics(options: ServerAnalyticsOptions): void {
+  configuredOptions = options
+}
+
+export function getServerAnalyticsOptions(): ServerAnalyticsOptions {
+  if (!configuredOptions) {
+    throw new Error(
+      'Server analytics is not configured. Call configureServerAnalytics() during API bootstrap.'
+    )
+  }
+  return configuredOptions
+}
+
+export function tryGetServerAnalyticsOptions(): ServerAnalyticsOptions | null {
+  return configuredOptions
+}
+
+/** Test-only: reset configured options between cases. */
+export function resetServerAnalyticsForTests(): void {
+  configuredOptions = null
+}
+
+export function getTelemetryStatusFromOptions(
+  options: ServerAnalyticsOptions
+): {
+  enabled: boolean
+  collectionRequired: true
+  dedupeIdentifiedPosthogEvents: boolean
+  disclosureUrl: string
+} {
+  return {
+    enabled: options.enabled,
+    collectionRequired: true as const,
+    dedupeIdentifiedPosthogEvents: options.dedupeIdentifiedPosthogEvents,
+    disclosureUrl: options.disclosureUrl,
+  }
+}

--- a/packages/analytics/src/server/identifiers.test.ts
+++ b/packages/analytics/src/server/identifiers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test'
+import { hashMcpAnalyticsSessionId, hashTelemetryIdentifier } from './identifiers'
+
+describe('server identifiers', () => {
+  it('hashes telemetry identifiers deterministically', () => {
+    const secret = 'test-secret'
+    expect(hashTelemetryIdentifier('instance:session', secret)).toBe(
+      hashTelemetryIdentifier('instance:session', secret)
+    )
+    expect(hashTelemetryIdentifier('instance:session', secret)).not.toContain('instance')
+  })
+
+  it('hashes MCP session keys without exposing principal ids', () => {
+    const hashed = hashMcpAnalyticsSessionId('principal-abc', 'test-secret')
+    expect(hashed).toHaveLength(32)
+    expect(hashed).not.toContain('principal')
+  })
+})

--- a/packages/analytics/src/server/identifiers.ts
+++ b/packages/analytics/src/server/identifiers.ts
@@ -1,0 +1,17 @@
+import { createHmac } from 'node:crypto'
+
+export function hashTelemetryIdentifier(value: string, secret: string): string {
+  return createHmac('sha256', secret).update(value).digest('hex')
+}
+
+export function hashMcpAnalyticsSessionId(principalId: string, secret: string): string {
+  return createHmac('sha256', secret).update(`mcp:${principalId}`).digest('hex').slice(0, 32)
+}
+
+export function hashIdentifiedUserDistinctId(userId: string, secret: string): string {
+  return hashTelemetryIdentifier(`user:${userId}`, secret)
+}
+
+export function hashIdentifiedOrganizationDistinctId(organizationId: string, secret: string): string {
+  return hashTelemetryIdentifier(`org:${organizationId}`, secret)
+}

--- a/packages/analytics/src/server/index.ts
+++ b/packages/analytics/src/server/index.ts
@@ -1,0 +1,35 @@
+export {
+  configureServerAnalytics,
+  DURABULL_CLOUD_API_HOST,
+  DEFAULT_CLOUD_COLLECT_URL,
+  getServerAnalyticsOptions,
+  getTelemetryStatusFromOptions,
+  resetServerAnalyticsForTests,
+  TELEMETRY_DISCLOSURE_URL,
+  tryGetServerAnalyticsOptions,
+  type ServerAnalyticsOptions,
+  type ServerAnalyticsRuntimeContext,
+} from './config'
+export {
+  captureAnonymousServerEvent,
+  captureIdentifiedServerEvent,
+  getTelemetryHmacSecret,
+  ingestTelemetryCollectBatch,
+  resolveIdentifiedDistinctIds,
+  shouldDedupeIdentifiedPosthogEvents,
+  type IngestCollectBatchResult,
+  type TelemetryCollectEventInput,
+} from './capture'
+export {
+  hashIdentifiedOrganizationDistinctId,
+  hashIdentifiedUserDistinctId,
+  hashMcpAnalyticsSessionId,
+  hashTelemetryIdentifier,
+} from './identifiers'
+export { validateTelemetryPayload, type TelemetryValidationResult } from './validate'
+export {
+  resolvePosthogBatchUrl,
+  sendPosthogBatch,
+  type PosthogBatchCapture,
+  type PosthogBatchClientConfig,
+} from './posthog-batch'

--- a/packages/analytics/src/server/posthog-batch.ts
+++ b/packages/analytics/src/server/posthog-batch.ts
@@ -1,0 +1,88 @@
+import type { ServerAnalyticsRuntimeContext } from './config'
+
+export interface PosthogBatchCapture {
+  event: string
+  /** Already sanitized properties; runtime is not re-merged when mergeRuntime is false. */
+  properties: Record<string, unknown>
+  timestamp?: string
+  distinctId: string
+  processPersonProfile: boolean
+  organizationId?: string | null
+}
+
+export interface PosthogBatchClientConfig {
+  posthogBatchUrl: string
+  posthogKey: string
+}
+
+export const DEFAULT_POSTHOG_BATCH_HOST = 'https://us.i.posthog.com'
+
+export function resolvePosthogBatchUrl(rawHost: string | undefined): string | null {
+  const hostWithProtocol = rawHost?.trim()
+    ? /^https?:\/\//i.test(rawHost)
+      ? rawHost
+      : `https://${rawHost}`
+    : DEFAULT_POSTHOG_BATCH_HOST
+
+  try {
+    const parsed = new URL(hostWithProtocol)
+    const basePath = parsed.pathname.replace(/\/$/, '')
+    const batchPath = basePath.endsWith('/batch') ? basePath : `${basePath}/batch`
+    return `${parsed.origin}${batchPath}/`
+  } catch {
+    return null
+  }
+}
+
+export async function sendPosthogBatch(
+  config: PosthogBatchClientConfig,
+  captures: PosthogBatchCapture[],
+  options: {
+    runtimeContext?: ServerAnalyticsRuntimeContext
+    mergeRuntime?: boolean
+  } = {}
+): Promise<boolean> {
+  if (captures.length === 0) return true
+
+  const mergeRuntime = options.mergeRuntime ?? true
+  const runtimeContext = options.runtimeContext ?? {
+    authless: false,
+    env_connections: false,
+    environment: 'unknown',
+    persistence: 'unknown',
+    stateless: false,
+  }
+
+  const batch = captures.map((capture) => {
+    const properties: Record<string, unknown> = {
+      ...(mergeRuntime ? runtimeContext : {}),
+      ...capture.properties,
+      $geoip_disable: true,
+      $process_person_profile: capture.processPersonProfile,
+      distinct_id: capture.distinctId,
+    }
+
+    if (capture.organizationId) {
+      properties.$groups = {
+        organization: capture.organizationId,
+      }
+    }
+
+    return {
+      event: capture.event,
+      properties,
+      timestamp: capture.timestamp ?? new Date().toISOString(),
+    }
+  })
+
+  const response = await fetch(config.posthogBatchUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: config.posthogKey,
+      batch,
+    }),
+  })
+
+  return response.ok
+}

--- a/packages/analytics/src/server/validate.test.ts
+++ b/packages/analytics/src/server/validate.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'bun:test'
 
 import { AnalyticsEvents, AnalyticsProperties } from '../events'
+import type { ServerAnalyticsRuntimeContext } from './config'
 import { validateTelemetryPayload } from './validate'
+
+const productionRuntime: ServerAnalyticsRuntimeContext = {
+  authless: false,
+  env_connections: true,
+  environment: 'production',
+  persistence: 'postgres',
+  stateless: false,
+}
 
 describe('validateTelemetryPayload', () => {
   it('accepts events when optional MCP properties are undefined', () => {
@@ -22,7 +31,7 @@ describe('validateTelemetryPayload', () => {
     const result = validateTelemetryPayload(
       AnalyticsEvents.QUEUE_PAUSED,
       { authless: true, success: true },
-      { authless: false, environment: 'production' }
+      productionRuntime
     )
 
     expect(result.ok).toBe(true)

--- a/packages/analytics/src/server/validate.test.ts
+++ b/packages/analytics/src/server/validate.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test'
+
+import { AnalyticsEvents, AnalyticsProperties } from '../events'
+import { validateTelemetryPayload } from './validate'
+
+describe('validateTelemetryPayload', () => {
+  it('accepts events when optional MCP properties are undefined', () => {
+    const result = validateTelemetryPayload(AnalyticsEvents.MCP_AUTH_FAILED, {
+      [AnalyticsProperties.MCP_AUTH_FAILURE]: 'unauthorized',
+      [AnalyticsProperties.SUCCESS]: false,
+      [AnalyticsProperties.PRINCIPAL_TYPE]: undefined,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.properties).not.toHaveProperty(AnalyticsProperties.PRINCIPAL_TYPE)
+      expect(result.properties[AnalyticsProperties.MCP_AUTH_FAILURE]).toBe('unauthorized')
+    }
+  })
+
+  it('lets server runtime context override client properties', () => {
+    const result = validateTelemetryPayload(
+      AnalyticsEvents.QUEUE_PAUSED,
+      { authless: true, success: true },
+      { authless: false, environment: 'production' }
+    )
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.properties.authless).toBe(false)
+      expect(result.properties.environment).toBe('production')
+    }
+  })
+})

--- a/packages/analytics/src/server/validate.ts
+++ b/packages/analytics/src/server/validate.ts
@@ -1,4 +1,5 @@
 import { isKnownDurabullTelemetryEvent, sanitizeTelemetryEvent } from '../sanitizer'
+import type { ServerAnalyticsRuntimeContext } from './config'
 
 export type TelemetryValidationResult =
   | {
@@ -11,16 +12,18 @@ export type TelemetryValidationResult =
 export function validateTelemetryPayload(
   eventName: string,
   properties: Record<string, unknown> = {},
-  runtimeContext: Record<string, unknown> = {}
+  runtimeContext?: ServerAnalyticsRuntimeContext
 ): TelemetryValidationResult {
   if (!isKnownDurabullTelemetryEvent(eventName)) {
     return { ok: false, error: 'unknown_event' }
   }
 
-  const sanitized = sanitizeTelemetryEvent(eventName, {
+  const mergedProperties: Record<string, unknown> = {
     ...properties,
-    ...runtimeContext,
-  })
+    ...(runtimeContext ?? {}),
+  }
+
+  const sanitized = sanitizeTelemetryEvent(eventName, mergedProperties)
 
   if (sanitized.droppedProperties.length > 0) {
     return { ok: false, error: 'invalid_properties' }

--- a/packages/analytics/src/server/validate.ts
+++ b/packages/analytics/src/server/validate.ts
@@ -1,0 +1,34 @@
+import { isKnownDurabullTelemetryEvent, sanitizeTelemetryEvent } from '../sanitizer'
+
+export type TelemetryValidationResult =
+  | {
+      ok: true
+      event: string
+      properties: Record<string, string | number | boolean | null>
+    }
+  | { ok: false; error: 'unknown_event' | 'invalid_properties' }
+
+export function validateTelemetryPayload(
+  eventName: string,
+  properties: Record<string, unknown> = {},
+  runtimeContext: Record<string, unknown> = {}
+): TelemetryValidationResult {
+  if (!isKnownDurabullTelemetryEvent(eventName)) {
+    return { ok: false, error: 'unknown_event' }
+  }
+
+  const sanitized = sanitizeTelemetryEvent(eventName, {
+    ...properties,
+    ...runtimeContext,
+  })
+
+  if (sanitized.droppedProperties.length > 0) {
+    return { ok: false, error: 'invalid_properties' }
+  }
+
+  return {
+    ok: true,
+    event: sanitized.event,
+    properties: sanitized.properties,
+  }
+}

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -10,7 +10,8 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/dal/src/repositories/telemetry-installation.ts
+++ b/packages/dal/src/repositories/telemetry-installation.ts
@@ -6,27 +6,25 @@ import { telemetryInstallation } from '../db/schemas/telemetry-installation/sche
 const DEFAULT_TELEMETRY_INSTALLATION_ID = 'default'
 
 export const telemetryInstallationRepository = {
-  async getOrCreateAnonymousInstanceId(): Promise<string> {
+  async readAnonymousInstanceId(): Promise<string | null> {
     const db = await getDb()
-    const now = new Date()
-
     const existing = await db
       .select({ anonymousInstanceId: telemetryInstallation.anonymousInstanceId })
       .from(telemetryInstallation)
       .where(eq(telemetryInstallation.id, DEFAULT_TELEMETRY_INSTALLATION_ID))
       .limit(1)
 
-    if (existing[0]) {
-      await db
-        .update(telemetryInstallation)
-        .set({
-          lastSeenAt: now,
-          updatedAt: now,
-        })
-        .where(eq(telemetryInstallation.id, DEFAULT_TELEMETRY_INSTALLATION_ID))
+    return existing[0]?.anonymousInstanceId ?? null
+  },
 
-      return existing[0].anonymousInstanceId
+  async getOrCreateAnonymousInstanceId(): Promise<string> {
+    const existingId = await this.readAnonymousInstanceId()
+    if (existingId) {
+      return existingId
     }
+
+    const db = await getDb()
+    const now = new Date()
 
     const [created] = await db
       .insert(telemetryInstallation)

--- a/packages/mcp/src/request-context.ts
+++ b/packages/mcp/src/request-context.ts
@@ -20,6 +20,7 @@ export interface McpToolInvocationAuditInput {
   arguments: Record<string, unknown>
   connectionId?: string | null
   responseClass: 'success' | 'tool_error'
+  redactionCount?: number
 }
 
 export interface McpRequestContext {

--- a/packages/mcp/src/tools/register-read-tools.ts
+++ b/packages/mcp/src/tools/register-read-tools.ts
@@ -467,6 +467,7 @@ function finalizeReadToolSuccess(
     arguments: args,
     connectionId: typeof args.connectionId === 'string' ? args.connectionId : null,
     responseClass: 'success' as const,
+    redactionCount: redactionCount > 0 ? redactionCount : undefined,
   }
   getMcpRequestContext()?.onToolInvocationComplete?.(auditInput)
 

--- a/tasks/handoff-analytics-mcp-telemetry.md
+++ b/tasks/handoff-analytics-mcp-telemetry.md
@@ -1,0 +1,283 @@
+# Handoff: Analytics package split + MCP product telemetry
+
+**Branch:** `main` (uncommitted local changes only — not pushed)  
+**Last verified:** 2026-05-28 — **23 tests pass** (see Verification)  
+**Original goal:** Track MCP usage in PostHog (anonymous + identified), consolidate server analytics into `packages/analytics`, fix review findings until no Critical/High correctness issues remain.
+
+---
+
+## 1. What this change set does
+
+### Product intent
+
+- **Before:** Browser telemetry via `@durabull/analytics` + relay `POST /api/telemetry/events` → cloud `/api/telemetry/collect`. MCP had **ops-only** signals (`mcp_telemetry` stdout + `mcp_audit_event` DB) — **no PostHog product events for MCP**.
+- **After:** Shared `@durabull/analytics/server` for capture/validate/HMAC; MCP maps telemetry signals → PostHog events (`mcp_tool_called`, `mcp_auth_failed`, etc.); consent page uses `/browser` + `/events` subpaths.
+
+### Architecture (high level)
+
+```
+Browser / self-hosted API          Durabull Cloud API
+─────────────────────────          ───────────────────
+trackEvent → POST /events    →     POST /collect → ingestTelemetryCollectBatch
+  (validate + runtime)               (validate per event, HMAC distinct_id)
+  → forward to cloud OR              → sendPosthogBatch (Durabull PostHog key)
+
+MCP request path
+────────────────
+policy/mount/auth → recordMcpTelemetry (ops) → recordMcpTelemetryAnalytics
+  → enqueueMcpAnalytics → processMcpAnalytics
+  → captureAnonymousServerEvent + captureIdentifiedServerEvent (parallel)
+```
+
+---
+
+## 2. File map (what to read first)
+
+| Path | Role |
+|------|------|
+| `packages/analytics/src/server/capture.ts` | Anonymous/identified capture, cloud forward, **`ingestTelemetryCollectBatch`** |
+| `packages/analytics/src/server/validate.ts` | `validateTelemetryPayload` — runtime merge: `{ ...properties, ...runtimeContext }` (server wins) |
+| `packages/analytics/src/sanitizer.ts` | Allow/deny lists; **`undefined` values skipped** (not dropped) |
+| `packages/analytics/src/server/config.ts` | `configureServerAnalytics`, `resetServerAnalyticsForTests` |
+| `packages/analytics/src/server/posthog-batch.ts` | `resolvePosthogBatchUrl`, `sendPosthogBatch` |
+| `packages/analytics/src/server/identifiers.ts` | HMAC distinct IDs, MCP session hash |
+| `packages/analytics/src/events.ts` | Event + property name constants |
+| `apps/api/src/lib/configure-server-analytics.ts` | Env → `configureServerAnalytics`, cached instance ID |
+| `apps/api/src/routes/telemetry.ts` | `/status`, `/collect`, `/events` |
+| `apps/api/src/mcp/observability/mcp-analytics.ts` | MCP → PostHog mapping |
+| `apps/api/src/mcp/observability/mcp-analytics-queue.ts` | Bounded async queue (512 depth, 8 in-flight) |
+| `apps/api/src/mcp/observability/mcp-telemetry.ts` | Ops signals + fan-out to analytics |
+| `apps/api/src/mcp/observability/mcp-telemetry-signals.ts` | Signal union type |
+| `packages/dal/src/repositories/telemetry-installation.ts` | `readAnonymousInstanceId`, `getOrCreateAnonymousInstanceId` (no per-event UPDATE) |
+
+**Deleted:** `apps/api/src/lib/posthog-server.ts` (logic moved to package).
+
+---
+
+## 3. Completed work (do not redo blindly)
+
+### Package structure
+
+- `packages/analytics` exports: `./server`, `./browser`, `./react` (alias), `./client` (legacy), `./events`, `./sanitizer`.
+- Removed **duplicate** `./events` block in `package.json` (was listed twice).
+- `packages/analytics/src/server/index.ts` exports `resetServerAnalyticsForTests`.
+
+### MCP product analytics
+
+- Events in `events.ts`: `mcp_rpc_requested`, `mcp_tool_called`, `mcp_tool_denied`, `mcp_auth_failed`, `mcp_rate_limited`, consent events, etc.
+- `mcp-analytics.ts` wired from auth middleware, policy (RPC: `initialize`, `tools/list` only), mount (tool success/error), audit (denials).
+- **No double `mcp_tool_called` for redaction** — `redaction_applied` / audit signals no-op in analytics switch; `redaction_count` on tool success only.
+- Uses `options.hmacSecret` (not deprecated `getTelemetryHmacSecret` in production path).
+- `Promise.all` for anonymous + identified when both run; dedupe skips anonymous when `shouldDedupeIdentifiedPosthogEvents()` && identified distinct id exists.
+
+### Server capture / routes
+
+- `/collect` returns 404 when `!collectEnabled || !enabled`.
+- `ingestTelemetryCollectBatch` returns `{ error: 'disabled' }` when `!options.enabled`.
+- Collect ingest uses `sendPosthogBatch(..., { mergeRuntime: false })` to avoid cloud host stamping OSS batches incorrectly.
+- `/events` returns **503** when `collectEnabled` but missing PostHog key or HMAC secret.
+- Strict validation on `/events` and `/collect` — unknown events / forbidden properties → **400**.
+- Identified distinct IDs hashed (`hashIdentifiedUserDistinctId`, `hashIdentifiedOrganizationDistinctId`).
+- Cached anonymous instance ID via `telemetryInstallationRepository.readAnonymousInstanceId()` + process cache in `configure-server-analytics.ts`.
+
+### Correctness fixes (verified)
+
+- Sanitizer skips `undefined` optional MCP properties (was causing silent drop of entire events).
+- `validateTelemetryPayload` merge order: server runtime overrides client on `/events`.
+- Telemetry tests split: forbidden props → 400; valid props → 202 + forward.
+- `packages/analytics/src/server/validate.test.ts` added.
+- Dead code removed: `principalToAnalyticsIdentity` in policy middleware; unused `telemetryInstallationRepository` import in `telemetry.ts`; route re-exports of `hashTelemetryIdentifier`.
+- `apps/web/src/routes/consent.tsx` imports `@durabull/analytics/events` + `@durabull/analytics/browser`.
+
+### Review loop status
+
+- **Two** full parallel-code-review cycles run (4× explore subagents each).
+- **Critical/High correctness:** addressed; re-review reported **none** for sanitizer/validate/telemetry/MCP paths after fixes.
+- **Not done:** Security/perf hardening items below (intentionally deferred).
+
+---
+
+## 4. Remaining work (prioritized for “perfection”)
+
+Use `/parallel-code-review` after each batch; fix **Critical/High** before claiming done. User wanted loop until no serious issues — interpret **serious** as Critical + High **correctness** and **High security** in this diff’s scope.
+
+### P0 — Trust & honest HTTP semantics (correctness + security)
+
+| # | Task | Files | Acceptance criteria |
+|---|------|-------|---------------------|
+| 1 | **Server runtime on `/collect` ingest** | `capture.ts` `ingestTelemetryCollectBatch` | Pass `options.getRuntimeContext()` into `validateTelemetryPayload` for each event (same merge as `/events`). Update `telemetry-collect.test.ts` if tests assumed client-only `authless`/`environment`. |
+| 2 | **Complete `/events` preflight** | `telemetry.ts`, optionally export helper from `capture.ts` | Return **503** when `collectEnabled` but `getDurabullTelemetryCollectConfig(options)` is null (includes **invalid PostHog host**). Today: key+HMAC checked but invalid URL → **202** + silent no-op in capture. Add test mirroring collect “invalid PostHog batch host”. |
+| 3 | **Fix self-hosted forward runtime merge** | `capture.ts` `forwardAnonymousToCloudCollect` ~95–98 | Use `...input.properties, ...input.runtimeContext` (match validate). Add unit or route test. |
+| 4 | **PostHog host allowlist** | `posthog-batch.ts`, align `app.ts` `getPosthogApiHost` | HTTPS only; allowlist `*.posthog.com` / `*.i.posthog.com`; reject private/link-local IPs. Test invalid host → 503 on collect and events. |
+
+### P1 — MCP hot path & cost (performance)
+
+| # | Task | Files | Notes |
+|---|------|-------|-------|
+| 5 | **Dedupe/coalesce PostHog** | `mcp-analytics.ts`, `capture.ts` | When same project/URL/key: one `sendPosthogBatch` per MCP event. Test: `dedupeIdentifiedPosthogEvents: true` → only identified capture called (`mcp-analytics.test.ts` currently mocks dedupe false). |
+| 6 | **Remove duplicate connection access DB query** | `policy-engine.ts`, `mcp-policy-middleware.ts`, `tools/shared.ts` | Policy already calls `canDelegatedUserAccessConnection`; middleware calls it again in `resolveConnectionForPrincipal`. Set `mcpResolvedConnection` once after grant. |
+| 7 | **Single-flight instance ID** | `configure-server-analytics.ts` | Prevent thundering herd on cold start; optional eager resolve in `app.ts` at bootstrap. |
+| 8 | **Async `/collect`** | `telemetry.ts`, `capture.ts` | Return 202 immediately; flush via bounded worker (pattern: `mcp-analytics-queue.ts`). |
+
+### P2 — Security hardening (separate PR acceptable)
+
+| # | Task | Notes |
+|---|------|-------|
+| 9 | Require `DURABULL_TELEMETRY_HMAC_SECRET` in production collect mode | Remove `BETTER_AUTH_SECRET` fallback in `configure-server-analytics.ts` |
+| 10 | Rate limit: trust `X-Forwarded-For` only when proxy trusted | `apps/api/src/middleware/rate-limit.ts` |
+| 11 | `/collect` authentication | Signed batches or install token — larger design |
+| 12 | Browser `client.ts` runtime merge | `...(properties), ...runtimeContext` before `/events` |
+| 13 | Clamp or ignore client `timestamp` on collect | `telemetry.ts`, `capture.ts` |
+
+### P3 — Maintainability (readability review)
+
+| # | Task |
+|---|------|
+| 14 | Root `packages/analytics/src/index.ts`: stop re-exporting full browser SDK; migrate web to `/browser` |
+| 15 | Unify `McpPrincipalType` from `@durabull/dal` in MCP modules |
+| 16 | Extract shared `createBoundedAsyncQueue` (audit + analytics) |
+| 17 | Remove dead `DEFAULT_POSTHOG_BATCH_HOST` from `server/config.ts`; dedupe with `posthog-batch.ts` |
+| 18 | Add `AnalyticsProperties.REDACTION_COUNT`; use in `mcp-analytics.ts` |
+| 19 | Remove deprecated `getTelemetryHmacSecret` from public `server/index.ts` exports; update test mocks |
+| 20 | Document which `McpTelemetrySignal` values are counter/log-only vs PostHog |
+
+### P4 — Test gaps to close
+
+- `/events` 503 when collect misconfigured (secrets) — **partially done**; extend for invalid host.
+- `/collect` 502 (`upstream_rejected`) and 503 (`upstream_unavailable`) — mock `fetch` failures.
+- MCP dedupe integration test (real `validateTelemetryPayload` path, not only mocks).
+- `capture.ts` / `posthog-batch.ts` unit tests (optional but valuable).
+- Forward path runtime merge test.
+
+---
+
+## 5. Verification commands
+
+```bash
+# Core regression suite (fast)
+bun test \
+  packages/analytics/src/server/validate.test.ts \
+  packages/analytics/src/server/identifiers.test.ts \
+  apps/api/src/routes/telemetry.test.ts \
+  apps/api/src/routes/telemetry-collect.test.ts \
+  apps/api/src/mcp/observability/mcp-analytics.test.ts
+
+# Broader API if touching app bootstrap / middleware
+bun test apps/api/src/app.test.ts
+
+# Typecheck analytics package
+cd packages/analytics && bun run check  # or monorepo equivalent
+```
+
+**Expected:** 23 pass in the core suite (as of handoff date).
+
+---
+
+## 6. Environment & configuration reference
+
+| Variable | Purpose |
+|----------|---------|
+| `DURABULL_TELEMETRY_POSTHOG_KEY` | Durabull product analytics PostHog key |
+| `DURABULL_TELEMETRY_POSTHOG_HOST` | Batch ingest host |
+| `DURABULL_TELEMETRY_HMAC_SECRET` | HMAC for distinct_id / instance_key (falls back to `BETTER_AUTH_SECRET` today — **change in P2**) |
+| `POSTHOG_KEY` / `POSTHOG_HOST` | App/customer PostHog (identified events) |
+| `DURABULL_CLOUD` / managed host | Enables `/collect` on cloud API |
+| `MCP_TELEMETRY_LOG` | Set `false` to disable sync stdout MCP telemetry |
+
+**Dedupe:** `dedupeIdentifiedPosthogEvents` in `configure-server-analytics.ts` when app and Durabull telemetry keys match (cloud).
+
+---
+
+## 7. Non-obvious behaviors (read before changing)
+
+1. **`validateTelemetryPayload` failure in capture** — `captureAnonymousServerEvent` / `captureIdentifiedServerEvent` return void on invalid input (no throw). Route-level validation is required for honest HTTP status codes.
+
+2. **`/collect` vs `/events` validation** — After P0 #1, both should merge server runtime. Until then, collect accepts client `authless`/`environment` (documented High security finding).
+
+3. **Double PostHog events** — When `dedupeIdentifiedPosthogEvents` is false, each identified MCP event sends **two** HTTP requests (anonymous + identified). Intentional for separate projects; bug if same project.
+
+4. **RPC analytics** — `recordMcpRpcAnalytics` from policy middleware **without** identity for `initialize` / `tools/list`; session id falls back to `'mcp-server'`. Product metrics are coarse unless you pass session/principal (P2/low).
+
+5. **MCP analytics queue** — Drops silently at depth 512; audit queue logs drops. Add metric if fixing P2.
+
+6. **Barrel exports** — Workspace rule: avoid new barrel files; prefer direct imports. Do not add new `index.ts` re-exports in app code.
+
+7. **Commits** — User rules: **only commit when explicitly asked**. This handoff is uncommitted work on `main`.
+
+8. **Linear** — Tie PR to Linear issue when creating PR (workspace rule).
+
+---
+
+## 8. Suggested workflow for next agent
+
+1. Read this file + skim `packages/analytics/src/server/capture.ts` and `apps/api/src/mcp/observability/mcp-analytics.ts`.
+2. Implement **P0 items 1–4** in order; run verification commands after each.
+3. Run **`/parallel-code-review`** (four explore subagents) on full file list from `git diff --name-only` + untracked list in §9.
+4. Fix remaining **Critical/High**; repeat review until clean or only accepted architectural deferrals documented in PR.
+5. Implement **P1** if time; otherwise list in PR “Follow-up”.
+6. Update `tasks/todo.md` with checkboxes; add `tasks/lessons.md` entry if user corrects anything.
+
+### Parallel review file list (copy-paste)
+
+```
+apps/api/src/app.ts
+apps/api/src/lib/configure-server-analytics.ts
+apps/api/src/mcp/audit/mcp-audit.ts
+apps/api/src/mcp/auth/mcp-session-middleware.ts
+apps/api/src/mcp/json-rpc-tool-call.ts
+apps/api/src/mcp/mount.ts
+apps/api/src/mcp/observability/mcp-analytics-queue.ts
+apps/api/src/mcp/observability/mcp-analytics.ts
+apps/api/src/mcp/observability/mcp-analytics.test.ts
+apps/api/src/mcp/observability/mcp-telemetry-signals.ts
+apps/api/src/mcp/observability/mcp-telemetry.ts
+apps/api/src/mcp/policy/mcp-policy-middleware.ts
+apps/api/src/routes/telemetry-collect.test.ts
+apps/api/src/routes/telemetry.test.ts
+apps/api/src/routes/telemetry.ts
+apps/web/src/routes/consent.tsx
+packages/analytics/package.json
+packages/analytics/src/browser.ts
+packages/analytics/src/events.ts
+packages/analytics/src/index.ts
+packages/analytics/src/react.ts
+packages/analytics/src/sanitizer.ts
+packages/analytics/src/server/capture.ts
+packages/analytics/src/server/config.ts
+packages/analytics/src/server/identifiers.ts
+packages/analytics/src/server/index.ts
+packages/analytics/src/server/posthog-batch.ts
+packages/analytics/src/server/validate.ts
+packages/analytics/src/server/validate.test.ts
+packages/dal/src/repositories/telemetry-installation.ts
+packages/mcp/src/request-context.ts
+packages/mcp/src/tools/register-read-tools.ts
+```
+
+---
+
+## 9. PR description starter
+
+**Title:** feat(analytics): server capture package + MCP PostHog product telemetry
+
+**Summary:**
+- Add `@durabull/analytics/server` for validated, HMAC-scoped PostHog capture and cloud collect ingest.
+- Emit MCP product events (`mcp_tool_called`, auth failures, rate limits, etc.) with bounded async queue.
+- Harden `/events` validation and fail-closed when collect is misconfigured.
+
+**Test plan:**
+- [ ] `bun test` on telemetry + mcp-analytics + server validate/identifiers
+- [ ] Manual: MCP tool call on dev stack → events in PostHog (anonymous + identified as configured)
+- [ ] `/collect` rejects spoofed forbidden keys; server runtime applied after P0
+- [ ] Invalid PostHog host returns 503 on `/events` and `/collect` after P0
+
+**Known follow-ups:** P1–P3 table above; `/collect` signing not in scope unless P2 #11 done.
+
+---
+
+## 10. Conversation context
+
+- Prior transcript: `.cursor/projects/Users-gregg-dev-durabull/agent-transcripts/d7d60e35-aacc-4edb-aaa8-52f8e3463c64/` (analytics consolidation + review-fix loop).
+- User attached skills: `loop` (monitored shell for recurring review), `parallel-code-review` (4× explore Task tool).
+
+**Definition of done (perfection):** P0 complete + parallel review shows no Critical/High correctness or High security findings in changed files + all tests green + PR description documents accepted deferrals.


### PR DESCRIPTION
## Summary

- Add `@durabull/analytics/server` for validated, HMAC-scoped PostHog capture and cloud `/collect` ingest.
- Emit MCP product analytics (`mcp_tool_called`, auth failures, rate limits, RPC) through a bounded async queue.
- Harden telemetry routes: strict property validation, server runtime precedence on `/events`, and fail-closed when collect is misconfigured.

## Test plan

- [x] `bun test packages/analytics/src/server apps/api/src/routes/telemetry.test.ts apps/api/src/routes/telemetry-collect.test.ts apps/api/src/mcp/observability/mcp-analytics.test.ts` (23 pass)
- [ ] Manual: MCP tool call on dev stack → events visible in PostHog (anonymous + identified as configured)
- [ ] Verify `/events` returns 400 for forbidden properties and 503 when collect secrets missing

## Follow-ups

See `tasks/handoff-analytics-mcp-telemetry.md` for P0 hardening (collect runtime merge, PostHog host allowlist, complete `/events` preflight) and parallel review backlog.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics tracking for MCP operations, including request metrics, tool usage, and authentication events.
  * Improved audit logging with additional context for MCP operations.
  * Analytics recording for MCP consent decisions.

* **Documentation**
  * Reorganized analytics package exports for improved accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->