### PR TITLE
fix(analytics): harden telemetry collect/events preflight and PostHog host trust

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,3 +1,4 @@
+import { isAllowedPosthogHostname } from '@durabull/analytics/server'
 import { getDatabaseMode, getDb, shouldUseEnvConnections, user } from '@durabull/dal'
 import { env } from '@durabull/env'
 import { eq } from 'drizzle-orm'
@@ -71,6 +72,13 @@ function getPosthogApiHost(): string {
     if (pointsToAppHost || pointsToProxyPath) {
       console.warn(
         `[PostHog] POSTHOG_HOST "${rawHost}" points to this app/proxy. Falling back to ${DEFAULT_POSTHOG_API_HOST}`
+      )
+      return DEFAULT_POSTHOG_API_HOST
+    }
+
+    if (parsedHost.protocol !== 'https:' || !isAllowedPosthogHostname(parsedHost.hostname)) {
+      console.warn(
+        `[PostHog] POSTHOG_HOST "${rawHost}" is not an allowed PostHog host. Falling back to ${DEFAULT_POSTHOG_API_HOST}`
       )
       return DEFAULT_POSTHOG_API_HOST
     }

--- a/apps/api/src/routes/telemetry-collect.test.ts
+++ b/apps/api/src/routes/telemetry-collect.test.ts
@@ -172,6 +172,8 @@ describe('telemetry collect route', () => {
     expect(body.batch[0].event).toBe('queue_paused')
     expect(body.batch[0].timestamp).toBe('2026-04-28T12:00:01.000Z')
     expect(properties.success).toBe(true)
+    expect(properties.authless).toBe(false)
+    expect(properties.environment).toBe('production')
     expect(properties.$process_person_profile).toBe(false)
     expect(properties.$geoip_disable).toBe(true)
     expect(properties.distinct_id).toBe(
@@ -181,6 +183,88 @@ describe('telemetry collect route', () => {
     expect(properties.distinct_id).not.toContain(INSTANCE_ID)
     expect(properties.distinct_id).not.toContain(SESSION_ID)
     expect(properties.instance_key).not.toContain(INSTANCE_ID)
+  })
+
+  it('applies server runtime over client-spoofed collect properties', async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 200 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await app.request('/collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: collectPayload({
+        authless: true,
+        environment: 'development',
+        persistence: 'pglite',
+        stateless: true,
+        success: true,
+      }),
+    })
+
+    expect(response.status).toBe(202)
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    const body = JSON.parse(String(init.body)) as {
+      batch: Array<{ properties: Record<string, unknown> }>
+    }
+    const properties = body.batch[0].properties
+
+    expect(properties.authless).toBe(false)
+    expect(properties.environment).toBe('production')
+  })
+
+  it('returns 502 when PostHog rejects the batch', async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 400 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await app.request('/collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: collectPayload(),
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({ error: 'Telemetry upstream rejected batch' })
+  })
+
+  it('returns 502 when PostHog responds with a redirect', async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: 'https://evil.example.com/batch/' },
+        })
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await app.request('/collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: collectPayload(),
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({ error: 'Telemetry upstream rejected batch' })
+  })
+
+  it('returns 503 when PostHog is unreachable', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('PostHog unavailable')
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await app.request('/collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: collectPayload(),
+    })
+
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({ error: 'Telemetry upstream unavailable' })
   })
 
   it('returns not found when product telemetry is disabled', async () => {
@@ -279,6 +363,40 @@ describe('telemetry collect route', () => {
 
   it('fails closed when the configured PostHog batch host is invalid', async () => {
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'http://[::1'
+    bootstrapServerAnalytics()
+    const fetchMock = mock(async () => new Response(null, { status: 200 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await app.request('/collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: collectPayload(),
+    })
+
+    expect(response.status).toBe(503)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the configured PostHog batch host is not HTTPS', async () => {
+    mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'http://us.i.posthog.com'
+    bootstrapServerAnalytics()
+    const fetchMock = mock(async () => new Response(null, { status: 200 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await app.request('/collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: collectPayload(),
+    })
+
+    expect(response.status).toBe(503)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the configured PostHog batch host is not allowlisted', async () => {
+    mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'https://evil.example.com'
     bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch

--- a/apps/api/src/routes/telemetry.test.ts
+++ b/apps/api/src/routes/telemetry.test.ts
@@ -15,14 +15,28 @@ import {
 const QUEUE_PAUSED_EVENT = 'queue_paused'
 
 const mutableEnv = env as {
+  APP_BASE_URL?: string
+  BETTER_AUTH_SECRET?: string
   CI?: boolean
   DATABASE_URL?: string
+  DURABULL_CLOUD?: boolean
+  DURABULL_TELEMETRY_HMAC_SECRET?: string
+  DURABULL_TELEMETRY_POSTHOG_HOST?: string
+  DURABULL_TELEMETRY_POSTHOG_KEY?: string
   NODE_ENV?: 'development' | 'test' | 'production'
+  POSTHOG_KEY?: string
 }
 
+const originalAppBaseUrl = mutableEnv.APP_BASE_URL
+const originalBetterAuthSecret = mutableEnv.BETTER_AUTH_SECRET
 const originalCi = mutableEnv.CI
 const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalDurabullCloud = mutableEnv.DURABULL_CLOUD
+const originalHmacSecret = mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET
 const originalNodeEnv = mutableEnv.NODE_ENV
+const originalPosthogHost = mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST
+const originalPosthogKey = mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY
+const originalPublicPosthogKey = mutableEnv.POSTHOG_KEY
 const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
 const originalFetch = globalThis.fetch
 
@@ -46,9 +60,16 @@ describe('telemetry routes', () => {
     await closeDb()
     resetServerAnalyticsForTests()
     resetCachedAnonymousInstanceIdForTests()
+    mutableEnv.APP_BASE_URL = originalAppBaseUrl
+    mutableEnv.BETTER_AUTH_SECRET = originalBetterAuthSecret
     mutableEnv.CI = originalCi
+    mutableEnv.DURABULL_CLOUD = originalDurabullCloud
+    mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = originalHmacSecret
+    mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = originalPosthogHost
+    mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = originalPosthogKey
     mutableEnv.DATABASE_URL = originalDatabaseUrl
     mutableEnv.NODE_ENV = originalNodeEnv
+    mutableEnv.POSTHOG_KEY = originalPublicPosthogKey
     globalThis.fetch = originalFetch
 
     if (originalPgliteDir) {
@@ -162,6 +183,61 @@ describe('telemetry routes', () => {
     })
 
     expect(response.status).toBe(400)
+  })
+
+  it('lets server runtime override client properties when forwarding to cloud collect', async () => {
+    mutableEnv.NODE_ENV = 'production'
+    bootstrapServerAnalytics()
+    const fetchMock = mock(async () => new Response(null, { status: 202 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = await createTelemetryRouteApp()
+
+    const response = await app.request('/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: QUEUE_PAUSED_EVENT,
+        properties: { authless: true, success: true },
+        sessionId: 'ephemeral-session',
+      }),
+    })
+
+    expect(response.status).toBe(202)
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    const body = JSON.parse(String(init.body)) as {
+      events: Array<{ properties: Record<string, unknown> }>
+    }
+
+    expect(body.events[0].properties.authless).toBe(false)
+    expect(body.events[0].properties.environment).toBe('production')
+  })
+
+  it('returns 503 on /events when collect mode has an invalid PostHog batch host', async () => {
+    mutableEnv.APP_BASE_URL = 'https://app.durabull.io'
+    mutableEnv.BETTER_AUTH_SECRET = 'test-events-hmac-secret'
+    mutableEnv.DURABULL_CLOUD = true
+    mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = 'test-events-hmac-secret'
+    mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'https://evil.example.com'
+    mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = 'phc_test_project_key'
+    mutableEnv.NODE_ENV = 'production'
+    bootstrapServerAnalytics()
+    const fetchMock = mock(async () => new Response(null, { status: 202 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = await createTelemetryRouteApp()
+
+    const response = await app.request('/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: QUEUE_PAUSED_EVENT,
+        properties: { success: true },
+        sessionId: 'ephemeral-session',
+      }),
+    })
+
+    expect(response.status).toBe(503)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('keeps local telemetry non-blocking when Durabull API forwarding fails', async () => {

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -2,6 +2,7 @@ import {
   captureAnonymousServerEvent,
   getTelemetryStatusFromOptions,
   ingestTelemetryCollectBatch,
+  isDurabullTelemetryCollectConfigured,
   TELEMETRY_DISCLOSURE_URL,
   tryGetServerAnalyticsOptions,
   validateTelemetryPayload,
@@ -107,10 +108,7 @@ const telemetryRoutes = new Hono()
       return c.json({ error: 'Invalid telemetry properties' }, 400)
     }
 
-    if (
-      options.collectEnabled &&
-      (!options.durabullTelemetryPosthogKey?.trim() || !options.hmacSecret?.trim())
-    ) {
+    if (options.collectEnabled && !isDurabullTelemetryCollectConfigured(options)) {
       return c.json({ error: 'Telemetry collection is not configured' }, 503)
     }
 

--- a/packages/analytics/src/server/capture.ts
+++ b/packages/analytics/src/server/capture.ts
@@ -24,6 +24,12 @@ function getOptions(): ServerAnalyticsOptions | null {
   return tryGetServerAnalyticsOptions()
 }
 
+export function isDurabullTelemetryCollectConfigured(
+  options: ServerAnalyticsOptions
+): boolean {
+  return getDurabullTelemetryCollectConfig(options) !== null
+}
+
 function getDurabullTelemetryCollectConfig(
   options: ServerAnalyticsOptions
 ): DurabullTelemetryCollectConfig | null {
@@ -93,8 +99,8 @@ async function forwardAnonymousToCloudCollect(input: {
         {
           event: input.event,
           properties: {
-            ...input.runtimeContext,
             ...input.properties,
+            ...input.runtimeContext,
           },
           sessionId: input.sessionId,
           timestamp: input.timestamp,
@@ -230,10 +236,11 @@ export async function ingestTelemetryCollectBatch(input: {
     return { ok: false, error: 'not_configured' }
   }
 
+  const runtimeContext = options.getRuntimeContext()
   const batch: PosthogBatchCapture[] = []
 
   for (const event of input.events) {
-    const validated = validateTelemetryPayload(event.event, event.properties)
+    const validated = validateTelemetryPayload(event.event, event.properties, runtimeContext)
     if (!validated.ok) {
       return { ok: false, error: validated.error }
     }

--- a/packages/analytics/src/server/index.ts
+++ b/packages/analytics/src/server/index.ts
@@ -15,6 +15,7 @@ export {
   captureIdentifiedServerEvent,
   getTelemetryHmacSecret,
   ingestTelemetryCollectBatch,
+  isDurabullTelemetryCollectConfigured,
   resolveIdentifiedDistinctIds,
   shouldDedupeIdentifiedPosthogEvents,
   type IngestCollectBatchResult,
@@ -28,6 +29,7 @@ export {
 } from './identifiers'
 export { validateTelemetryPayload, type TelemetryValidationResult } from './validate'
 export {
+  isAllowedPosthogHostname,
   resolvePosthogBatchUrl,
   sendPosthogBatch,
   type PosthogBatchCapture,

--- a/packages/analytics/src/server/posthog-batch.test.ts
+++ b/packages/analytics/src/server/posthog-batch.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test'
+
+import { isAllowedPosthogHostname, resolvePosthogBatchUrl } from './posthog-batch'
+
+describe('isAllowedPosthogHostname', () => {
+  it('allows official PostHog ingest hosts', () => {
+    expect(isAllowedPosthogHostname('us.i.posthog.com')).toBe(true)
+    expect(isAllowedPosthogHostname('eu.i.posthog.com')).toBe(true)
+    expect(isAllowedPosthogHostname('us.posthog.com')).toBe(true)
+  })
+
+  it('rejects non-PostHog and private hosts', () => {
+    expect(isAllowedPosthogHostname('evil.example.com')).toBe(false)
+    expect(isAllowedPosthogHostname('127.0.0.1')).toBe(false)
+    expect(isAllowedPosthogHostname('10.0.0.1')).toBe(false)
+    expect(isAllowedPosthogHostname('169.254.169.254')).toBe(false)
+    expect(isAllowedPosthogHostname('::1')).toBe(false)
+  })
+})
+
+describe('resolvePosthogBatchUrl', () => {
+  it('resolves default US batch endpoint', () => {
+    expect(resolvePosthogBatchUrl(undefined)).toBe('https://us.i.posthog.com/batch/')
+  })
+
+  it('rejects non-HTTPS hosts', () => {
+    expect(resolvePosthogBatchUrl('http://us.i.posthog.com')).toBeNull()
+  })
+
+  it('rejects disallowed hostnames', () => {
+    expect(resolvePosthogBatchUrl('https://127.0.0.1')).toBeNull()
+    expect(resolvePosthogBatchUrl('https://evil.example.com')).toBeNull()
+  })
+
+  it('rejects malformed URLs', () => {
+    expect(resolvePosthogBatchUrl('http://[::1')).toBeNull()
+  })
+})

--- a/packages/analytics/src/server/posthog-batch.ts
+++ b/packages/analytics/src/server/posthog-batch.ts
@@ -17,6 +17,37 @@ export interface PosthogBatchClientConfig {
 
 export const DEFAULT_POSTHOG_BATCH_HOST = 'https://us.i.posthog.com'
 
+function isPrivateOrLinkLocalIpv4(hostname: string): boolean {
+  const match = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/.exec(hostname)
+  if (!match) return false
+
+  const octets = match.slice(1).map(Number)
+  if (octets[0] === 127) return true
+  if (octets[0] === 10) return true
+  if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) return true
+  if (octets[0] === 192 && octets[1] === 168) return true
+  if (octets[0] === 169 && octets[1] === 254) return true
+  return false
+}
+
+function isPrivateOrLinkLocalIpv6(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  if (normalized === '::1') return true
+  if (normalized.startsWith('fe80:')) return true
+  if (/^f[cd][0-9a-f]{2}:/i.test(normalized)) return true
+  return false
+}
+
+/** HTTPS-only PostHog hostnames (*.posthog.com); rejects private/link-local IPs. */
+export function isAllowedPosthogHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  if (isPrivateOrLinkLocalIpv4(normalized) || isPrivateOrLinkLocalIpv6(normalized)) {
+    return false
+  }
+
+  return normalized === 'posthog.com' || normalized.endsWith('.posthog.com')
+}
+
 export function resolvePosthogBatchUrl(rawHost: string | undefined): string | null {
   const hostWithProtocol = rawHost?.trim()
     ? /^https?:\/\//i.test(rawHost)
@@ -26,6 +57,9 @@ export function resolvePosthogBatchUrl(rawHost: string | undefined): string | nu
 
   try {
     const parsed = new URL(hostWithProtocol)
+    if (parsed.protocol !== 'https:') return null
+    if (!isAllowedPosthogHostname(parsed.hostname)) return null
+
     const basePath = parsed.pathname.replace(/\/$/, '')
     const batchPath = basePath.endsWith('/batch') ? basePath : `${basePath}/batch`
     return `${parsed.origin}${batchPath}/`
@@ -82,7 +116,10 @@ export async function sendPosthogBatch(
       api_key: config.posthogKey,
       batch,
     }),
+    redirect: 'manual',
   })
+
+  if (response.status >= 300 && response.status < 400) return false
 
   return response.ok
 }


### PR DESCRIPTION
## Summary

- Apply server runtime context on `/collect` ingest so clients cannot spoof deployment metadata (`authless`, `environment`, etc.)
- Fail closed on `/events` when collect mode is misconfigured, including invalid PostHog batch hosts (503 instead of 202 + silent no-op)
- Fix self-hosted forward merge order so server runtime wins when relaying to cloud collect
- Restrict PostHog batch/proxy hosts to HTTPS `*.posthog.com` and reject private/link-local targets; disable fetch redirects to block redirect SSRF

## Test plan

- [x] `bun test` on telemetry + posthog-batch + mcp-analytics suites (37 pass)
- [ ] Invalid `DURABULL_TELEMETRY_POSTHOG_HOST` returns 503 on `/events` and `/collect`
- [ ] Spoofed `authless: true` on collect is overridden by server runtime in PostHog batch

## Follow-ups (deferred to PR2+)

- `/collect` authentication / signed batches
- PostHog dedupe/coalesce for MCP events
- XFF trust for rate limiting
- Browser client runtime merge alignment


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added validation to ensure telemetry is only forwarded to official PostHog hosts over HTTPS, rejecting private/non-allowed hostnames.

* **Bug Fixes**
  * Improved error handling for upstream PostHog failures with appropriate HTTP status codes.
  * Fixed server-side telemetry properties to prevent client spoofing.

* **Reliability**
  * Enhanced fallback behavior when PostHog host configuration is invalid or unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->