### PR TITLE
fix(analytics): correct MCP org grouping and harden telemetry robustness

### DIFF
--- a/apps/api/src/lib/configure-server-analytics.ts
+++ b/apps/api/src/lib/configure-server-analytics.ts
@@ -4,7 +4,11 @@ import {
   DEFAULT_CLOUD_COLLECT_URL,
   TELEMETRY_DISCLOSURE_URL,
 } from '@durabull/analytics/server'
-import { getDatabaseMode, shouldUseEnvConnections, telemetryInstallationRepository } from '@durabull/dal'
+import {
+  getDatabaseMode,
+  shouldUseEnvConnections,
+  telemetryInstallationRepository,
+} from '@durabull/dal'
 import { env } from '@durabull/env'
 
 import { isAuthlessMode } from './authless'
@@ -24,6 +28,34 @@ function getDurabullTelemetryPosthogKey(): string | null {
 }
 
 let cachedAnonymousInstanceId: string | null = null
+let inFlightAnonymousInstanceId: Promise<string> | null = null
+
+/**
+ * Resolve the anonymous installation id with a process cache and single-flight guard so
+ * concurrent cold-start callers share one DB round-trip instead of stampeding the repository.
+ */
+async function resolveAnonymousInstanceId(): Promise<string> {
+  if (cachedAnonymousInstanceId) {
+    return cachedAnonymousInstanceId
+  }
+
+  if (inFlightAnonymousInstanceId) {
+    return inFlightAnonymousInstanceId
+  }
+
+  inFlightAnonymousInstanceId = (async () => {
+    try {
+      // getOrCreateAnonymousInstanceId reads first, so this avoids a redundant SELECT.
+      const id = await telemetryInstallationRepository.getOrCreateAnonymousInstanceId()
+      cachedAnonymousInstanceId = id
+      return id
+    } finally {
+      inFlightAnonymousInstanceId = null
+    }
+  })()
+
+  return inFlightAnonymousInstanceId
+}
 
 export function bootstrapServerAnalytics(): void {
   const appPosthogKey = env.POSTHOG_KEY?.trim() || null
@@ -51,20 +83,18 @@ export function bootstrapServerAnalytics(): void {
       persistence: getDatabaseMode(),
       stateless: getDatabaseMode() === 'pglite',
     }),
-    resolveAnonymousInstanceId: async () => {
-      if (cachedAnonymousInstanceId) {
-        return cachedAnonymousInstanceId
-      }
-
-      const existing = await telemetryInstallationRepository.readAnonymousInstanceId()
-      cachedAnonymousInstanceId =
-        existing ?? (await telemetryInstallationRepository.getOrCreateAnonymousInstanceId())
-      return cachedAnonymousInstanceId
-    },
+    resolveAnonymousInstanceId,
   })
+
+  // Eagerly warm the installation id so request paths (/events, MCP analytics)
+  // never block on a cold DB read. Telemetry must never affect product runtime.
+  if (env.NODE_ENV === 'production' && env.CI !== true) {
+    void resolveAnonymousInstanceId().catch(() => {})
+  }
 }
 
 /** Test-only: clear cached installation id when re-bootstrapping. */
 export function resetCachedAnonymousInstanceIdForTests(): void {
   cachedAnonymousInstanceId = null
+  inFlightAnonymousInstanceId = null
 }

--- a/apps/api/src/mcp/observability/mcp-analytics.test.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics.test.ts
@@ -3,9 +3,7 @@ import { AnalyticsEvents } from '@durabull/analytics/events'
 import { configureServerAnalytics, resetServerAnalyticsForTests } from '@durabull/analytics/server'
 import { env } from '@durabull/env'
 
-import {
-  resetCachedAnonymousInstanceIdForTests,
-} from '../../lib/configure-server-analytics'
+import { resetCachedAnonymousInstanceIdForTests } from '../../lib/configure-server-analytics'
 
 const captureAnonymousServerEvent = mock(async () => {})
 const captureIdentifiedServerEvent = mock(async () => {})
@@ -15,13 +13,21 @@ mock.module('@durabull/analytics/server', () => ({
   captureIdentifiedServerEvent,
   hashMcpAnalyticsSessionId: (value: string) => `session-${value}`,
   shouldDedupeIdentifiedPosthogEvents: () => false,
-  getTelemetryHmacSecret: () => 'test-secret',
-  resolveIdentifiedDistinctIds: ({ userId, organizationId }: { userId?: string; organizationId?: string }) => {
+  resolveIdentifiedDistinctIds: ({
+    userId,
+    organizationId,
+  }: {
+    userId?: string
+    organizationId?: string
+  }) => {
     if (userId) {
       return { distinctId: `hashed-user:${userId}`, organizationGroup: null }
     }
     if (organizationId) {
-      return { distinctId: `hashed-org:${organizationId}`, organizationGroup: `hashed-org:${organizationId}` }
+      return {
+        distinctId: `hashed-org:${organizationId}`,
+        organizationGroup: `hashed-org:${organizationId}`,
+      }
     }
     return { distinctId: null, organizationGroup: null }
   },
@@ -144,7 +150,8 @@ describe('mcp analytics', () => {
     expect(captureIdentifiedServerEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         distinctId: 'hashed-org:org-1',
-        organizationId: 'hashed-org:org-1',
+        // Raw org id is forwarded so capture hashes it exactly once (no double-hash).
+        organizationId: 'org-1',
       })
     )
   })

--- a/apps/api/src/mcp/observability/mcp-analytics.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics.ts
@@ -8,11 +8,11 @@ import {
   tryGetServerAnalyticsOptions,
 } from '@durabull/analytics/server'
 
+import type { McpPrincipalType } from '@durabull/dal'
+
 import { APP_VERSION } from '../../lib/build-info'
 import { enqueueMcpAnalytics } from './mcp-analytics-queue'
 import type { McpTelemetrySignal } from './mcp-telemetry-signals'
-
-export type McpPrincipalType = 'delegated_user' | 'service_account'
 
 export interface McpAnalyticsIdentity {
   principalType: McpPrincipalType
@@ -38,9 +38,7 @@ function categorizeDenialReason(reason: string | null | undefined): string {
   return 'policy'
 }
 
-function buildBaseProperties(
-  properties: Record<string, unknown> = {}
-): Record<string, unknown> {
+function buildBaseProperties(properties: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     [AnalyticsProperties.SERVER_VERSION]: APP_VERSION,
     ...properties,
@@ -69,9 +67,7 @@ async function processMcpAnalytics(input: McpAnalyticsInput): Promise<void> {
     const secret = options.hmacSecret
     const sessionId =
       input.sessionKey ??
-      (identity && secret
-        ? hashMcpAnalyticsSessionId(identity.principalId, secret)
-        : 'mcp-server')
+      (identity && secret ? hashMcpAnalyticsSessionId(identity.principalId, secret) : 'mcp-server')
 
     tasks.push(
       captureAnonymousServerEvent({
@@ -89,7 +85,10 @@ async function processMcpAnalytics(input: McpAnalyticsInput): Promise<void> {
         event: input.event,
         properties,
         distinctId: identified.distinctId,
-        organizationId: identified.organizationGroup,
+        // Pass the raw org id; captureIdentifiedServerEvent hashes it once for
+        // the PostHog group. Passing identified.organizationGroup (already
+        // hashed) would double-hash and break org correlation.
+        organizationId: identity?.organizationId ?? null,
       })
     )
   }
@@ -132,7 +131,7 @@ export function recordMcpToolAnalytics(input: {
       [AnalyticsProperties.PRINCIPAL_TYPE]: input.principalType,
       [AnalyticsProperties.SUCCESS]: input.responseClass === 'success',
       ...(input.redactionCount && input.redactionCount > 0
-        ? { redaction_count: input.redactionCount }
+        ? { [AnalyticsProperties.REDACTION_COUNT]: input.redactionCount }
         : {}),
     },
     identity: input.identity,

--- a/apps/api/src/mcp/observability/mcp-telemetry.ts
+++ b/apps/api/src/mcp/observability/mcp-telemetry.ts
@@ -1,4 +1,4 @@
-import type { McpPrincipalType } from './mcp-analytics'
+import type { McpPrincipalType } from '@durabull/dal'
 import { recordMcpTelemetryAnalytics } from './mcp-analytics'
 import type { McpTelemetrySignal } from './mcp-telemetry-signals'
 

--- a/apps/api/src/routes/telemetry-collect.test.ts
+++ b/apps/api/src/routes/telemetry-collect.test.ts
@@ -14,6 +14,9 @@ const INSTANCE_ID = '41111111-1111-4111-8111-111111111111'
 const SESSION_ID = 'ephemeral-session'
 const HMAC_SECRET = 'test-telemetry-collect-hmac-secret'
 const POSTHOG_KEY = 'phc_test_project_key'
+// Within the collect timestamp skew window so the value is forwarded unchanged.
+const RECENT_EVENT_TIMESTAMP = new Date(Date.now() - 60_000).toISOString()
+const RECENT_SENT_AT = new Date(Date.now() - 30_000).toISOString()
 
 const mutableEnv = env as {
   APP_BASE_URL?: string
@@ -58,13 +61,13 @@ function createTelemetryRouteApp(options: { bodyLimit?: boolean } = {}) {
 function collectPayload(properties: Record<string, unknown> = { success: true }) {
   return JSON.stringify({
     instanceId: INSTANCE_ID,
-    sentAt: '2026-04-28T12:00:00.000Z',
+    sentAt: RECENT_SENT_AT,
     events: [
       {
         event: 'queue_paused',
         properties,
         sessionId: SESSION_ID,
-        timestamp: '2026-04-28T12:00:01.000Z',
+        timestamp: RECENT_EVENT_TIMESTAMP,
       },
     ],
   })
@@ -170,7 +173,7 @@ describe('telemetry collect route', () => {
 
     expect(body.api_key).toBe(POSTHOG_KEY)
     expect(body.batch[0].event).toBe('queue_paused')
-    expect(body.batch[0].timestamp).toBe('2026-04-28T12:00:01.000Z')
+    expect(body.batch[0].timestamp).toBe(RECENT_EVENT_TIMESTAMP)
     expect(properties.success).toBe(true)
     expect(properties.authless).toBe(false)
     expect(properties.environment).toBe('production')

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -112,7 +112,12 @@ const telemetryRoutes = new Hono()
       return c.json({ error: 'Telemetry collection is not configured' }, 503)
     }
 
-    const anonymousInstanceId = await options.resolveAnonymousInstanceId()
+    let anonymousInstanceId: string
+    try {
+      anonymousInstanceId = await options.resolveAnonymousInstanceId()
+    } catch {
+      return c.json({ error: 'Telemetry is temporarily unavailable' }, 503)
+    }
 
     void captureAnonymousServerEvent({
       anonymousInstanceId,

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -212,6 +212,7 @@ export const AnalyticsProperties = {
   DENIAL_REASON_CATEGORY: 'denial_reason_category',
   MCP_AUTH_FAILURE: 'mcp_auth_failure',
   MCP_RATE_LIMIT_SCOPE: 'mcp_rate_limit_scope',
+  REDACTION_COUNT: 'redaction_count',
 } as const
 
 /**

--- a/packages/analytics/src/server/capture.test.ts
+++ b/packages/analytics/src/server/capture.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { AnalyticsEvents } from '../events'
+import { captureIdentifiedServerEvent, ingestTelemetryCollectBatch } from './capture'
+import {
+  configureServerAnalytics,
+  resetServerAnalyticsForTests,
+  type ServerAnalyticsOptions,
+} from './config'
+import { hashIdentifiedOrganizationDistinctId } from './identifiers'
+
+const HMAC_SECRET = 'test-hmac-secret'
+
+const baseRuntime = {
+  authless: false,
+  env_connections: false,
+  environment: 'production',
+  persistence: 'postgres',
+  stateless: false,
+} as const
+
+function configure(overrides: Partial<ServerAnalyticsOptions> = {}): void {
+  configureServerAnalytics({
+    enabled: true,
+    collectEnabled: true,
+    dedupeIdentifiedPosthogEvents: false,
+    disclosureUrl: 'https://durabull.io/privacy',
+    hmacSecret: HMAC_SECRET,
+    durabullTelemetryPosthogKey: 'phc_durabull',
+    durabullTelemetryPosthogHost: 'https://us.i.posthog.com',
+    appPosthogKey: 'phc_app',
+    appPosthogHost: 'https://us.i.posthog.com',
+    cloudCollectUrl: 'https://app.durabull.io/api/telemetry/collect',
+    getRuntimeContext: () => ({ ...baseRuntime }),
+    resolveAnonymousInstanceId: async () => 'anon-instance-id',
+    ...overrides,
+  })
+}
+
+const originalFetch = globalThis.fetch
+
+function captureFetchBodies(): { bodies: unknown[]; restore: () => void } {
+  const bodies: unknown[] = []
+  globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    bodies.push(JSON.parse(String(init?.body ?? '{}')))
+    return new Response(null, { status: 200 })
+  }) as typeof fetch
+  return {
+    bodies,
+    restore: () => {
+      globalThis.fetch = originalFetch
+    },
+  }
+}
+
+describe('captureIdentifiedServerEvent', () => {
+  beforeEach(() => {
+    resetServerAnalyticsForTests()
+    configure()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    resetServerAnalyticsForTests()
+  })
+
+  it('hashes the organization group exactly once for $groups', async () => {
+    const { bodies, restore } = captureFetchBodies()
+
+    await captureIdentifiedServerEvent({
+      event: AnalyticsEvents.MCP_TOOL_CALLED,
+      properties: { tool_name: 'list_jobs', response_class: 'success' },
+      distinctId: 'already-hashed-user',
+      organizationId: 'org-1',
+    })
+
+    restore()
+
+    expect(bodies).toHaveLength(1)
+    const batch = (bodies[0] as { batch: Array<{ properties: Record<string, unknown> }> }).batch
+    expect(batch).toHaveLength(1)
+    expect(batch[0].properties.$groups).toEqual({
+      organization: hashIdentifiedOrganizationDistinctId('org-1', HMAC_SECRET),
+    })
+  })
+})
+
+describe('ingestTelemetryCollectBatch timestamp clamping', () => {
+  beforeEach(() => {
+    resetServerAnalyticsForTests()
+    configure()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    resetServerAnalyticsForTests()
+  })
+
+  it('clamps client timestamps far outside the accepted skew window', async () => {
+    const { bodies, restore } = captureFetchBodies()
+    const before = Date.now()
+
+    const result = await ingestTelemetryCollectBatch({
+      instanceId: 'instance-1234567890',
+      events: [
+        {
+          event: AnalyticsEvents.MCP_TOOL_CALLED,
+          properties: { tool_name: 'list_jobs', response_class: 'success' },
+          sessionId: 'session-1',
+          timestamp: '2000-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+
+    restore()
+    const after = Date.now()
+
+    expect(result.ok).toBe(true)
+    const batch = (bodies[0] as { batch: Array<{ timestamp: string }> }).batch
+    const stamped = new Date(batch[0].timestamp).getTime()
+    expect(stamped).toBeGreaterThanOrEqual(before)
+    expect(stamped).toBeLessThanOrEqual(after)
+  })
+
+  it('preserves recent client timestamps within the skew window', async () => {
+    const { bodies, restore } = captureFetchBodies()
+    const recent = new Date(Date.now() - 60_000).toISOString()
+
+    await ingestTelemetryCollectBatch({
+      instanceId: 'instance-1234567890',
+      events: [
+        {
+          event: AnalyticsEvents.MCP_TOOL_CALLED,
+          properties: { tool_name: 'list_jobs', response_class: 'success' },
+          sessionId: 'session-1',
+          timestamp: recent,
+        },
+      ],
+    })
+
+    restore()
+
+    const batch = (bodies[0] as { batch: Array<{ timestamp: string }> }).batch
+    expect(batch[0].timestamp).toBe(recent)
+  })
+})

--- a/packages/analytics/src/server/capture.ts
+++ b/packages/analytics/src/server/capture.ts
@@ -1,20 +1,37 @@
-import {
-  getServerAnalyticsOptions,
-  tryGetServerAnalyticsOptions,
-  type ServerAnalyticsOptions,
-} from './config'
+import { tryGetServerAnalyticsOptions, type ServerAnalyticsOptions } from './config'
 import {
   hashIdentifiedOrganizationDistinctId,
   hashIdentifiedUserDistinctId,
   hashTelemetryIdentifier,
 } from './identifiers'
 import {
+  POSTHOG_FETCH_TIMEOUT_MS,
   resolvePosthogBatchUrl,
   sendPosthogBatch,
   type PosthogBatchCapture,
   type PosthogBatchClientConfig,
 } from './posthog-batch'
 import { validateTelemetryPayload } from './validate'
+
+/**
+ * Maximum drift (past or future) allowed for client-supplied event timestamps on
+ * the public `/collect` ingest path. Untrusted clients can otherwise backdate or
+ * future-date events to pollute analytics time series.
+ */
+const MAX_COLLECT_TIMESTAMP_SKEW_MS = 24 * 60 * 60 * 1000
+
+/** Clamp a client-supplied timestamp to server time when it is missing or outside the skew window. */
+function resolveCollectTimestamp(clientTimestamp: string | undefined, nowMs: number): string {
+  if (!clientTimestamp) return new Date(nowMs).toISOString()
+
+  const parsed = Date.parse(clientTimestamp)
+  if (Number.isNaN(parsed)) return new Date(nowMs).toISOString()
+  if (Math.abs(parsed - nowMs) > MAX_COLLECT_TIMESTAMP_SKEW_MS) {
+    return new Date(nowMs).toISOString()
+  }
+
+  return clientTimestamp
+}
 
 interface DurabullTelemetryCollectConfig extends PosthogBatchClientConfig {
   hmacSecret: string
@@ -24,9 +41,7 @@ function getOptions(): ServerAnalyticsOptions | null {
   return tryGetServerAnalyticsOptions()
 }
 
-export function isDurabullTelemetryCollectConfigured(
-  options: ServerAnalyticsOptions
-): boolean {
+export function isDurabullTelemetryCollectConfigured(options: ServerAnalyticsOptions): boolean {
   return getDurabullTelemetryCollectConfig(options) !== null
 }
 
@@ -42,7 +57,9 @@ function getDurabullTelemetryCollectConfig(
   return { hmacSecret, posthogBatchUrl, posthogKey }
 }
 
-function getIdentifiedPosthogConfig(options: ServerAnalyticsOptions): PosthogBatchClientConfig | null {
+function getIdentifiedPosthogConfig(
+  options: ServerAnalyticsOptions
+): PosthogBatchClientConfig | null {
   const posthogKey = options.appPosthogKey
   if (!posthogKey) return null
 
@@ -107,6 +124,8 @@ async function forwardAnonymousToCloudCollect(input: {
         },
       ],
     }),
+    redirect: 'manual',
+    signal: AbortSignal.timeout(POSTHOG_FETCH_TIMEOUT_MS),
   })
 
   if (!response.ok) {
@@ -237,6 +256,7 @@ export async function ingestTelemetryCollectBatch(input: {
   }
 
   const runtimeContext = options.getRuntimeContext()
+  const nowMs = Date.now()
   const batch: PosthogBatchCapture[] = []
 
   for (const event of input.events) {
@@ -251,7 +271,7 @@ export async function ingestTelemetryCollectBatch(input: {
         sessionId: event.sessionId,
         event: validated.event,
         properties: validated.properties,
-        timestamp: event.timestamp ?? input.sentAt ?? new Date().toISOString(),
+        timestamp: resolveCollectTimestamp(event.timestamp ?? input.sentAt, nowMs),
         hmacSecret: config.hmacSecret,
       })
     )
@@ -297,9 +317,4 @@ export function resolveIdentifiedDistinctIds(input: {
   }
 
   return { distinctId: null, organizationGroup: null }
-}
-
-/** @deprecated Use getServerAnalyticsOptions().hmacSecret */
-export function getTelemetryHmacSecret(): string | null {
-  return getOptions()?.hmacSecret ?? null
 }

--- a/packages/analytics/src/server/config.ts
+++ b/packages/analytics/src/server/config.ts
@@ -1,7 +1,6 @@
 export const TELEMETRY_DISCLOSURE_URL = 'https://durabull.io/privacy'
 export const DURABULL_CLOUD_API_HOST = 'app.durabull.io'
 export const DEFAULT_CLOUD_COLLECT_URL = `https://${DURABULL_CLOUD_API_HOST}/api/telemetry/collect`
-export const DEFAULT_POSTHOG_BATCH_HOST = 'https://us.i.posthog.com'
 
 export interface ServerAnalyticsRuntimeContext {
   authless: boolean

--- a/packages/analytics/src/server/index.ts
+++ b/packages/analytics/src/server/index.ts
@@ -13,7 +13,6 @@ export {
 export {
   captureAnonymousServerEvent,
   captureIdentifiedServerEvent,
-  getTelemetryHmacSecret,
   ingestTelemetryCollectBatch,
   isDurabullTelemetryCollectConfigured,
   resolveIdentifiedDistinctIds,

--- a/packages/analytics/src/server/posthog-batch.ts
+++ b/packages/analytics/src/server/posthog-batch.ts
@@ -17,6 +17,9 @@ export interface PosthogBatchClientConfig {
 
 export const DEFAULT_POSTHOG_BATCH_HOST = 'https://us.i.posthog.com'
 
+/** Upper bound on a single PostHog ingest round-trip; prevents hung sockets from tying up workers. */
+export const POSTHOG_FETCH_TIMEOUT_MS = 5_000
+
 function isPrivateOrLinkLocalIpv4(hostname: string): boolean {
   const match = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/.exec(hostname)
   if (!match) return false
@@ -117,6 +120,7 @@ export async function sendPosthogBatch(
       batch,
     }),
     redirect: 'manual',
+    signal: AbortSignal.timeout(POSTHOG_FETCH_TIMEOUT_MS),
   })
 
   if (response.status >= 300 && response.status < 400) return false

--- a/tasks/handoff-analytics-mcp-telemetry.md
+++ b/tasks/handoff-analytics-mcp-telemetry.md
@@ -1,8 +1,18 @@
 # Handoff: Analytics package split + MCP product telemetry
 
-**Branch:** `main` (uncommitted local changes only — not pushed)  
-**Last verified:** 2026-05-28 — **23 tests pass** (see Verification)  
-**Original goal:** Track MCP usage in PostHog (anonymous + identified), consolidate server analytics into `packages/analytics`, fix review findings until no Critical/High correctness issues remain.
+**Last verified:** 2026-05-28 — **40 tests pass** in the core suite (see §5 Verification)
+**Goal:** Track MCP usage in PostHog (anonymous + identified), consolidate server analytics into `packages/analytics`, and keep telemetry bullet-proof across client + server until no Critical/High correctness or High-security findings remain in changed scope.
+
+## Status timeline (read this first)
+
+| Stage | What shipped | State |
+|-------|--------------|-------|
+| **PR #107** | Initial server capture package + MCP PostHog telemetry | Merged |
+| **PR #108** (`fix(analytics): harden telemetry collect/events preflight and PostHog host trust`) | **All P0**: server runtime on `/collect` ingest, fail-closed `/events` preflight incl. invalid PostHog host, forward merge order, HTTPS-only PostHog host allowlist + private-IP rejection + `redirect: 'manual'` | Merged into `main` |
+| **PR #109** (`fix(analytics): correct MCP org grouping and harden telemetry robustness`) | Found via 4-lens parallel review of merged `main`. Fixes **MCP org `$groups` double-hash** (real bug), fetch timeouts + forward `redirect: 'manual'`, single-flight/eager instance id, `/collect` timestamp clamp, `/events` 503 guard, hygiene cleanups | Branch `cursor/telemetry-bulletproof-followups`, **open** |
+
+**Current branch for in-flight work:** `cursor/telemetry-bulletproof-followups` (PR #109).
+**Next agent:** branch fresh from `origin/main` (after #109 merges) for the deferred items in §4.
 
 ---
 
@@ -89,87 +99,101 @@ policy/mount/auth → recordMcpTelemetry (ops) → recordMcpTelemetryAnalytics
 - Dead code removed: `principalToAnalyticsIdentity` in policy middleware; unused `telemetryInstallationRepository` import in `telemetry.ts`; route re-exports of `hashTelemetryIdentifier`.
 - `apps/web/src/routes/consent.tsx` imports `@durabull/analytics/events` + `@durabull/analytics/browser`.
 
+### Correctness/robustness fixes in PR #109 (open)
+
+- **MCP org `$groups` double-hash fixed.** `resolveIdentifiedDistinctIds()` returns an already-HMAC-hashed `organizationGroup`; `mcp-analytics.ts` previously passed it into `captureIdentifiedServerEvent({ organizationId })`, which hashed it **again** → `hash(hash(orgId))`. Now passes **raw** `identity.organizationId`; capture hashes once. New `packages/analytics/src/server/capture.test.ts` asserts `$groups.organization === hashIdentifiedOrganizationDistinctId(orgId, secret)` exactly once.
+- **Fetch timeouts** (`POSTHOG_FETCH_TIMEOUT_MS = 5_000`, `AbortSignal.timeout`) on `sendPosthogBatch` and `forwardAnonymousToCloudCollect`; **`redirect: 'manual'`** added to the cloud forward (SSRF parity).
+- **Single-flight + eager bootstrap** of anonymous instance id in `configure-server-analytics.ts` (no thundering herd; removed redundant cold-start `SELECT`; `/events` no longer blocks on cold DB).
+- **`/collect` timestamp clamp** to server time ±24h (`resolveCollectTimestamp` in `capture.ts`) — stops back/future-dated client events polluting time series.
+- **`/events` 503 guard** around `resolveAnonymousInstanceId` (was an unhandled 500 on DB failure).
+- **Hygiene:** removed dead `DEFAULT_POSTHOG_BATCH_HOST` (config.ts) and deprecated `getTelemetryHmacSecret` export; added `AnalyticsProperties.REDACTION_COUNT`; unified `McpPrincipalType` import from `@durabull/dal`.
+
 ### Review loop status
 
-- **Two** full parallel-code-review cycles run (4× explore subagents each).
-- **Critical/High correctness:** addressed; re-review reported **none** for sanitizer/validate/telemetry/MCP paths after fixes.
-- **Not done:** Security/perf hardening items below (intentionally deferred).
+- Three full parallel-code-review cycles run (4× explore subagents each); the third was over **merged `main`** post-#108.
+- **Critical:** none in telemetry scope. **High correctness:** the org double-hash — fixed in #109.
+- **Still open (deferred):** see §4 — `/collect` auth (subsumes OSS-forward fidelity), XFF trust, dedicated HMAC secret, async `/collect`, dedupe/coalesce, queue-drop metric, barrel migration.
 
 ---
 
-## 4. Remaining work (prioritized for “perfection”)
+## 4. Remaining work (for the next agent)
 
-Use `/parallel-code-review` after each batch; fix **Critical/High** before claiming done. User wanted loop until no serious issues — interpret **serious** as Critical + High **correctness** and **High security** in this diff’s scope.
+Everything in **P0 is merged (#108)**. The contained correctness/robustness/hygiene items are in **#109 (open)**. What remains below is genuinely larger-design or cross-cutting — each is worth its own PR. Use `/parallel-code-review` after each batch; fix **Critical/High** before claiming done.
 
-### P0 — Trust & honest HTTP semantics (correctness + security)
+### ✅ Already done (do NOT redo)
+
+| Item | Where |
+|------|-------|
+| Server runtime on `/collect` ingest; `/events` invalid-host preflight; forward merge order; PostHog HTTPS allowlist + private-IP reject + `redirect: 'manual'` | **#108** |
+| MCP org `$groups` double-hash; fetch timeouts + forward `redirect: 'manual'`; single-flight + eager instance id; `/collect` timestamp clamp; `/events` 503 guard | **#109** |
+| Browser `client.ts` runtime merge (server still authoritative via re-validate) | already in `client.ts` `sendDurabullTelemetry`/`withRuntimeContext` |
+| Hygiene: dead `DEFAULT_POSTHOG_BATCH_HOST`, deprecated `getTelemetryHmacSecret`, `AnalyticsProperties.REDACTION_COUNT`, unify `McpPrincipalType` | **#109** |
+
+### P0 (deferred) — Trust & honest semantics
 
 | # | Task | Files | Acceptance criteria |
 |---|------|-------|---------------------|
-| 1 | **Server runtime on `/collect` ingest** | `capture.ts` `ingestTelemetryCollectBatch` | Pass `options.getRuntimeContext()` into `validateTelemetryPayload` for each event (same merge as `/events`). Update `telemetry-collect.test.ts` if tests assumed client-only `authless`/`environment`. |
-| 2 | **Complete `/events` preflight** | `telemetry.ts`, optionally export helper from `capture.ts` | Return **503** when `collectEnabled` but `getDurabullTelemetryCollectConfig(options)` is null (includes **invalid PostHog host**). Today: key+HMAC checked but invalid URL → **202** + silent no-op in capture. Add test mirroring collect “invalid PostHog batch host”. |
-| 3 | **Fix self-hosted forward runtime merge** | `capture.ts` `forwardAnonymousToCloudCollect` ~95–98 | Use `...input.properties, ...input.runtimeContext` (match validate). Add unit or route test. |
-| 4 | **PostHog host allowlist** | `posthog-batch.ts`, align `app.ts` `getPosthogApiHost` | HTTPS only; allowlist `*.posthog.com` / `*.i.posthog.com`; reject private/link-local IPs. Test invalid host → 503 on collect and events. |
+| A | **`/collect` authentication / signed batches** | `telemetry.ts`, `capture.ts`, `configure-server-analytics.ts`, new verify util | Distinguish **trusted OSS forwards** from **untrusted public posts**. Signed/HMAC'd batch or install token. **This also fixes the OSS→cloud runtime re-stamp** (see Known issue below). AC: verified forwards keep their originating runtime; unverified posts still get server-runtime override (anti-spoof); unauthenticated/invalid signature → 401/403; tests for both paths. |
+| B | **Rate-limit `X-Forwarded-For` trust** | `apps/api/src/middleware/rate-limit.ts` | Only trust XFF behind a configured trusted proxy (use rightmost trusted hop or `cf-connecting-ip`/`x-real-ip`). MCP ingress already avoids XFF — mirror it. Cross-cutting: affects all `/api/*` limiters, so test broadly. **High security.** |
 
-### P1 — MCP hot path & cost (performance)
+**Known issue resolved-by-A:** cloud `/collect` re-stamps OSS-forwarded runtime with the cloud node's `getRuntimeContext()` because `validateTelemetryPayload` merges server runtime over event properties (intended anti-spoof for public posts). For legit OSS forwards this clobbers `authless`/`persistence`/`stateless`/`env_connections`, mis-attributing self-hosted deployments. Do **not** "fix" by trusting client runtime on `/collect` — that reopens the spoofing hole #108 closed. Fix via the signed/auth channel in A.
+
+### P1 — Performance
 
 | # | Task | Files | Notes |
 |---|------|-------|-------|
-| 5 | **Dedupe/coalesce PostHog** | `mcp-analytics.ts`, `capture.ts` | When same project/URL/key: one `sendPosthogBatch` per MCP event. Test: `dedupeIdentifiedPosthogEvents: true` → only identified capture called (`mcp-analytics.test.ts` currently mocks dedupe false). |
-| 6 | **Remove duplicate connection access DB query** | `policy-engine.ts`, `mcp-policy-middleware.ts`, `tools/shared.ts` | Policy already calls `canDelegatedUserAccessConnection`; middleware calls it again in `resolveConnectionForPrincipal`. Set `mcpResolvedConnection` once after grant. |
-| 7 | **Single-flight instance ID** | `configure-server-analytics.ts` | Prevent thundering herd on cold start; optional eager resolve in `app.ts` at bootstrap. |
-| 8 | **Async `/collect`** | `telemetry.ts`, `capture.ts` | Return 202 immediately; flush via bounded worker (pattern: `mcp-analytics-queue.ts`). |
+| 5 | **Dedupe/coalesce PostHog** | `mcp-analytics.ts`, `capture.ts` | When anonymous + identified share the same `{posthogBatchUrl, posthogKey}`, emit **one** `sendPosthogBatch` (two captures) instead of 2 HTTP calls. Add integration test with `dedupeIdentifiedPosthogEvents: true` (currently mocked false). |
+| 6 | **Remove duplicate connection-access DB query** (not telemetry, but on MCP hot path) | `policy-engine.ts`, `mcp-policy-middleware.ts`, `tools/shared.ts` | Policy already calls `canDelegatedUserAccessConnection`; middleware re-checks in `resolveConnectionForPrincipal`. Resolve once after grant. |
+| 8 | **Async `/collect`** | `telemetry.ts`, `capture.ts` | Return 202 immediately, flush via bounded worker (pattern: `mcp-analytics-queue.ts`). The #109 fetch timeout mitigates the worst hang. |
 
-### P2 — Security hardening (separate PR acceptable)
+### P2 — Security hardening
 
 | # | Task | Notes |
 |---|------|-------|
-| 9 | Require `DURABULL_TELEMETRY_HMAC_SECRET` in production collect mode | Remove `BETTER_AUTH_SECRET` fallback in `configure-server-analytics.ts` |
-| 10 | Rate limit: trust `X-Forwarded-For` only when proxy trusted | `apps/api/src/middleware/rate-limit.ts` |
-| 11 | `/collect` authentication | Signed batches or install token — larger design |
-| 12 | Browser `client.ts` runtime merge | `...(properties), ...runtimeContext` before `/events` |
-| 13 | Clamp or ignore client `timestamp` on collect | `telemetry.ts`, `capture.ts` |
+| 9 | Require dedicated `DURABULL_TELEMETRY_HMAC_SECRET` in prod collect mode | Remove `BETTER_AUTH_SECRET` fallback in `configure-server-analytics.ts:~bootstrap`; fail collect bootstrap (or 503) if missing. Coordinate env across cloud + self-host docs. |
 
-### P3 — Maintainability (readability review)
+### P3 — Maintainability
 
 | # | Task |
 |---|------|
-| 14 | Root `packages/analytics/src/index.ts`: stop re-exporting full browser SDK; migrate web to `/browser` |
-| 15 | Unify `McpPrincipalType` from `@durabull/dal` in MCP modules |
-| 16 | Extract shared `createBoundedAsyncQueue` (audit + analytics) |
-| 17 | Remove dead `DEFAULT_POSTHOG_BATCH_HOST` from `server/config.ts`; dedupe with `posthog-batch.ts` |
-| 18 | Add `AnalyticsProperties.REDACTION_COUNT`; use in `mcp-analytics.ts` |
-| 19 | Remove deprecated `getTelemetryHmacSecret` from public `server/index.ts` exports; update test mocks |
-| 20 | Document which `McpTelemetrySignal` values are counter/log-only vs PostHog |
+| 14 | Root `packages/analytics/src/index.ts`: stop re-exporting full browser SDK (barrel); migrate ~31 web call sites to `@durabull/analytics/browser` + `/events`. |
+| 16 | Extract shared `createBoundedAsyncQueue` (audit `mcp-audit.ts` + analytics `mcp-analytics-queue.ts`). |
+| 20 | Document which `McpTelemetrySignal` values are counter/log-only vs PostHog. |
+| 21 | Analytics queue drops silently at depth 512 — add a drop counter/structured log (audit queue already logs drops). Optional `scope_count` constant (consent.tsx uses a raw literal). |
 
-### P4 — Test gaps to close
+### P4 — Test gaps still worth closing
 
-- `/events` 503 when collect misconfigured (secrets) — **partially done**; extend for invalid host.
-- `/collect` 502 (`upstream_rejected`) and 503 (`upstream_unavailable`) — mock `fetch` failures.
-- MCP dedupe integration test (real `validateTelemetryPayload` path, not only mocks).
-- `capture.ts` / `posthog-batch.ts` unit tests (optional but valuable).
-- Forward path runtime merge test.
+- MCP dedupe integration test (real `shouldDedupeIdentifiedPosthogEvents: true` path, not mocked).
+- `/collect` `502` (`upstream_rejected`) + `503` (`upstream_unavailable`) already covered in `telemetry-collect.test.ts`; extend if A changes status mapping.
+- Concurrent `resolveAnonymousInstanceId` single-flight test (one create, same id).
+- `forwardAnonymousToCloudCollect` runtime-merge + new timeout behavior.
 
 ---
 
 ## 5. Verification commands
 
 ```bash
-# Core regression suite (fast)
+# Core regression suite (fast) — 40 pass as of #109
 bun test \
   packages/analytics/src/server/validate.test.ts \
   packages/analytics/src/server/identifiers.test.ts \
+  packages/analytics/src/server/posthog-batch.test.ts \
+  packages/analytics/src/server/capture.test.ts \
   apps/api/src/routes/telemetry.test.ts \
   apps/api/src/routes/telemetry-collect.test.ts \
   apps/api/src/mcp/observability/mcp-analytics.test.ts
 
-# Broader API if touching app bootstrap / middleware
-bun test apps/api/src/app.test.ts
+# Lint changed files with the repo-pinned Biome (NOT `bunx biome` — wrong version)
+./node_modules/.bin/biome lint <changed paths>
+./node_modules/.bin/biome format <changed paths>   # check; add --write to fix
 
-# Typecheck analytics package
-cd packages/analytics && bun run check  # or monorepo equivalent
+# Typecheck (test files error on `bun:test` import — PRE-EXISTING/environmental, ignore)
+cd apps/api && bun run typecheck
 ```
 
-**Expected:** 23 pass in the core suite (as of handoff date).
+**Expected:** 40 pass in the core suite (as of #109).
+
+**Sandbox gotcha:** `apps/api/src/app.test.ts` "api app config" cases fail in the agent sandbox shell — it has `CI=true` and no `MCP_AUTHLESS_BEARER_TOKEN`, so `createApiApp` throws in MCP auth assertion and the `enabled` env gate flips. These are **environmental, not caused by telemetry changes**. To run them: `MCP_AUTHLESS_BEARER_TOKEN=test-token CI= bun test apps/api/src/app.test.ts`.
 
 ---
 
@@ -210,12 +234,13 @@ cd packages/analytics && bun run check  # or monorepo equivalent
 
 ## 8. Suggested workflow for next agent
 
-1. Read this file + skim `packages/analytics/src/server/capture.ts` and `apps/api/src/mcp/observability/mcp-analytics.ts`.
-2. Implement **P0 items 1–4** in order; run verification commands after each.
-3. Run **`/parallel-code-review`** (four explore subagents) on full file list from `git diff --name-only` + untracked list in §9.
-4. Fix remaining **Critical/High**; repeat review until clean or only accepted architectural deferrals documented in PR.
-5. Implement **P1** if time; otherwise list in PR “Follow-up”.
-6. Update `tasks/todo.md` with checkboxes; add `tasks/lessons.md` entry if user corrects anything.
+1. Read this file (esp. §0 status timeline + §4) and skim `packages/analytics/src/server/capture.ts` and `apps/api/src/mcp/observability/mcp-analytics.ts`.
+2. After **#109 merges**, branch fresh from `origin/main` (workspace rule: follow-up PRs branch from latest primary).
+3. Pick **one** §4 item per PR. Recommended order: **P0-A (`/collect` auth — unlocks the OSS-forward fidelity fix)** → **P0-B (XFF trust)** → P1 dedupe/coalesce → P2 HMAC secret → P3 cleanups.
+4. Run **`/parallel-code-review`** (four explore subagents) on the changed file list; fix Critical/High before claiming done.
+5. Update `tasks/todo.md` checkboxes; add `tasks/lessons.md` if the user corrects anything; tie the PR to a Linear issue (workspace rule — needed for release-note automation).
+
+**Lesson captured this round:** never use `git stash`/`stash pop` to "peek" at clean state while you have uncommitted work — a failed pop silently strips your edits (it happened; recovered from `stash@{0}`). Use a throwaway `git worktree` or commit a WIP first instead.
 
 ### Parallel review file list (copy-paste)
 
@@ -243,6 +268,7 @@ packages/analytics/src/index.ts
 packages/analytics/src/react.ts
 packages/analytics/src/sanitizer.ts
 packages/analytics/src/server/capture.ts
+packages/analytics/src/server/capture.test.ts
 packages/analytics/src/server/config.ts
 packages/analytics/src/server/identifiers.ts
 packages/analytics/src/server/index.ts
@@ -277,7 +303,9 @@ packages/mcp/src/tools/register-read-tools.ts
 
 ## 10. Conversation context
 
-- Prior transcript: `.cursor/projects/Users-gregg-dev-durabull/agent-transcripts/d7d60e35-aacc-4edb-aaa8-52f8e3463c64/` (analytics consolidation + review-fix loop).
-- User attached skills: `loop` (monitored shell for recurring review), `parallel-code-review` (4× explore Task tool).
+- Analytics consolidation + first review-fix loop: PR #107.
+- P0 hardening: PR #108 (merged).
+- Post-#108 review + fixes: PR #109 (`cursor/telemetry-bulletproof-followups`, open) — found via a 4-lens `/parallel-code-review` over merged `main`.
+- Skills in play: `parallel-code-review` (4× explore Task tool), `loop` (monitored shell for recurring review).
 
-**Definition of done (perfection):** P0 complete + parallel review shows no Critical/High correctness or High security findings in changed files + all tests green + PR description documents accepted deferrals.
+**Definition of done (perfection):** P0 complete (#108 ✅) + no Critical/High correctness or High-security findings in changed scope (org double-hash fixed in #109 ✅; remaining High-security = XFF trust, deferred to P0-B) + all tests green + each PR documents accepted deferrals and links a Linear issue.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -148,3 +148,28 @@
 - [ ] Use `tasks/mcp-implementation-master-plan.md` as the technical source of truth for implementation details.
 - [ ] Ensure each PR links to a Linear issue and includes complete verification evidence before merge.
 - [ ] Keep the running history ledger in `tasks/mcp-pr-execution-playbook.md` updated as each agent completes handoff.
+
+## Current Task
+
+Post-#108 telemetry/analytics follow-ups (see `tasks/handoff-analytics-mcp-telemetry.md`). PR #108 landed all P0 hardening; a four-lens parallel review of merged `main` surfaced one real correctness bug plus robustness/hygiene gaps.
+
+- [x] Fix MCP identified-event organization `$groups` double-hash (pass raw org id; capture hashes once).
+- [x] Add 5s fetch timeout to PostHog batch + cloud forward; `redirect: 'manual'` on cloud forward (SSRF parity).
+- [x] Single-flight + eager-bootstrap anonymous instance id; drop redundant cold-start SELECT.
+- [x] Clamp client-supplied `/collect` timestamps to server time ±24h (anti-pollution).
+- [x] `try/catch` `resolveAnonymousInstanceId` in `/events` → 503 instead of unhandled 500.
+- [x] Hygiene: drop dead `DEFAULT_POSTHOG_BATCH_HOST` in `config.ts`; remove deprecated `getTelemetryHmacSecret` export; add `AnalyticsProperties.REDACTION_COUNT`; unify `McpPrincipalType` from `@durabull/dal`.
+- [x] Tests: new `capture.test.ts` (single-hash `$groups`, timestamp clamp pass/clamp); updated mcp-analytics + collect tests.
+
+## Result
+
+- Verified suite green: 40 pass across the prescribed telemetry files (`validate`, `identifiers`, `posthog-batch`, `capture`, `telemetry`, `telemetry-collect`, `mcp-analytics`).
+- Telemetry/MCP source typechecks clean; Biome lint clean on changed files (formatting normalized to repo style).
+- Note: `apps/api/src/app.test.ts` "api app config" cases fail only in this sandbox shell (missing `MCP_AUTHLESS_BEARER_TOKEN`, `CI=true`) — unrelated to this diff (failures originate in MCP auth assertion / `enabled` env gate, not telemetry).
+
+### Deferred to dedicated follow-up PRs (documented, not hacked)
+
+- `/collect` authentication / signed batches — also resolves OSS→cloud forwarded-runtime re-stamping fidelity loss and unauthenticated abuse.
+- Rate-limit `X-Forwarded-For` trust (High security; cross-cutting `rate-limit.ts`, needs trusted-proxy config).
+- Require dedicated `DURABULL_TELEMETRY_HMAC_SECRET` in prod (remove `BETTER_AUTH_SECRET` fallback; env coordination).
+- Async `/collect` (202 + bounded worker) and single-batch PostHog coalesce; extract shared `createBoundedAsyncQueue`; queue-drop metric; root barrel migration to `/browser`.


### PR DESCRIPTION
## Summary

Follow-up to #108. After #108 landed all the P0 hardening, a four-lens parallel review (security / correctness / performance / readability) of merged `main` surfaced **one real correctness bug** plus several robustness and hygiene gaps. This PR closes the contained items; larger architectural work is split into tracked follow-ups (below).

### Correctness (the bug)
- **MCP identified events double-hashed the organization `$groups` key.** `resolveIdentifiedDistinctIds()` already returns an HMAC-hashed `organizationGroup`, but `mcp-analytics` passed it into `captureIdentifiedServerEvent()` which hashed it **again** → `hash(hash(orgId))`, breaking org correlation for every identified MCP event. Now the raw org id is forwarded and hashed exactly once.

### Robustness
- 5s timeout on PostHog batch + cloud-forward fetches; `redirect: 'manual'` on the cloud forward (SSRF parity with `sendPosthogBatch`) — hung upstreams can no longer tie up `/collect` workers or the MCP analytics queue.
- Single-flight + eager-bootstrap of the anonymous installation id; removed the redundant cold-start `SELECT`. `/events` no longer blocks on a cold DB read.
- Clamp client-supplied `/collect` timestamps to server time ±24h (stops back/future-dated events polluting time series).
- `/events` now returns **503** (not an unhandled 500) if `resolveAnonymousInstanceId` throws.

### Hygiene
- Removed dead `DEFAULT_POSTHOG_BATCH_HOST` (config.ts) and the deprecated `getTelemetryHmacSecret` export.
- Added `AnalyticsProperties.REDACTION_COUNT` (replaces a raw string literal).
- Unified `McpPrincipalType` to import from `@durabull/dal`.

### Tests
- New `packages/analytics/src/server/capture.test.ts`: asserts single-hash `$groups` end-to-end (capture → batch → fetch body) and timestamp clamp (stale clamped / recent preserved).
- Updated `mcp-analytics.test.ts` (encoded the old double-hash) and `telemetry-collect.test.ts` (recent timestamps).

## Test plan

- [x] `bun test` on `validate`, `identifiers`, `posthog-batch`, `capture`, `telemetry`, `telemetry-collect`, `mcp-analytics` → **40 pass**
- [x] Telemetry/MCP source typecheck clean; Biome lint clean on changed files
- [ ] CI green

> Note: `apps/api/src/app.test.ts` "api app config" cases fail only in a sandbox shell lacking `MCP_AUTHLESS_BEARER_TOKEN` / with `CI=true`; failures originate in the MCP auth assertion and the `enabled` env gate, unrelated to this diff.

## Follow-ups (deferred, documented in `tasks/handoff-analytics-mcp-telemetry.md`)

- **`/collect` authentication / signed batches** — also resolves OSS→cloud forwarded-runtime re-stamping (self-hosted deployment-attribution fidelity) and unauthenticated abuse.
- **Rate-limit `X-Forwarded-For` trust** (High security; cross-cutting `rate-limit.ts`, needs trusted-proxy config).
- **Require dedicated `DURABULL_TELEMETRY_HMAC_SECRET`** in prod (remove `BETTER_AUTH_SECRET` fallback).
- **Async `/collect`** (202 + bounded worker) + single-batch PostHog coalesce; extract shared `createBoundedAsyncQueue`; queue-drop metric; root barrel migration to `/browser`.

Made with [Cursor](https://cursor.com)