### PR TITLE
fix(analytics): #109 signed /collect auth and proxy-trusted rate limits

### DIFF
--- a/apps/api/src/lib/configure-server-analytics.ts
+++ b/apps/api/src/lib/configure-server-analytics.ts
@@ -24,6 +24,22 @@ function getDurabullTelemetryPosthogKey(): string | null {
 }
 
 let cachedAnonymousInstanceId: string | null = null
+let anonymousInstanceIdInflight: Promise<string> | null = null
+
+async function resolveAnonymousInstanceIdSingleFlight(): Promise<string> {
+  if (cachedAnonymousInstanceId) {
+    return cachedAnonymousInstanceId
+  }
+
+  anonymousInstanceIdInflight ??= (async () => {
+    const existing = await telemetryInstallationRepository.readAnonymousInstanceId()
+    const id = existing ?? (await telemetryInstallationRepository.getOrCreateAnonymousInstanceId())
+    cachedAnonymousInstanceId = id
+    return id
+  })()
+
+  return anonymousInstanceIdInflight
+}
 
 export function bootstrapServerAnalytics(): void {
   const appPosthogKey = env.POSTHOG_KEY?.trim() || null
@@ -37,6 +53,7 @@ export function bootstrapServerAnalytics(): void {
       isDurabullManagedPosthogProject() &&
       durabullTelemetryPosthogKey === appPosthogKey,
     disclosureUrl: TELEMETRY_DISCLOSURE_URL,
+    collectSigningSecret: env.DURABULL_TELEMETRY_COLLECT_SECRET?.trim() || null,
     hmacSecret:
       env.DURABULL_TELEMETRY_HMAC_SECRET?.trim() || env.BETTER_AUTH_SECRET?.trim() || null,
     durabullTelemetryPosthogKey,
@@ -51,20 +68,18 @@ export function bootstrapServerAnalytics(): void {
       persistence: getDatabaseMode(),
       stateless: getDatabaseMode() === 'pglite',
     }),
-    resolveAnonymousInstanceId: async () => {
-      if (cachedAnonymousInstanceId) {
-        return cachedAnonymousInstanceId
-      }
-
-      const existing = await telemetryInstallationRepository.readAnonymousInstanceId()
-      cachedAnonymousInstanceId =
-        existing ?? (await telemetryInstallationRepository.getOrCreateAnonymousInstanceId())
-      return cachedAnonymousInstanceId
-    },
+    resolveAnonymousInstanceId: resolveAnonymousInstanceIdSingleFlight,
   })
+
+  if (env.NODE_ENV === 'production' && env.CI !== true) {
+    void resolveAnonymousInstanceIdSingleFlight().catch(() => {
+      // Warm cache at bootstrap; telemetry must never block API startup.
+    })
+  }
 }
 
 /** Test-only: clear cached installation id when re-bootstrapping. */
 export function resetCachedAnonymousInstanceIdForTests(): void {
   cachedAnonymousInstanceId = null
+  anonymousInstanceIdInflight = null
 }

--- a/apps/api/src/lib/configure-server-analytics.ts
+++ b/apps/api/src/lib/configure-server-analytics.ts
@@ -32,10 +32,15 @@ async function resolveAnonymousInstanceIdSingleFlight(): Promise<string> {
   }
 
   anonymousInstanceIdInflight ??= (async () => {
-    const existing = await telemetryInstallationRepository.readAnonymousInstanceId()
-    const id = existing ?? (await telemetryInstallationRepository.getOrCreateAnonymousInstanceId())
-    cachedAnonymousInstanceId = id
-    return id
+    try {
+      const existing = await telemetryInstallationRepository.readAnonymousInstanceId()
+      const id = existing ?? (await telemetryInstallationRepository.getOrCreateAnonymousInstanceId())
+      cachedAnonymousInstanceId = id
+      return id
+    } catch (error) {
+      anonymousInstanceIdInflight = null
+      throw error
+    }
   })()
 
   return anonymousInstanceIdInflight

--- a/apps/api/src/mcp/observability/mcp-analytics.test.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics.test.ts
@@ -59,6 +59,7 @@ describe('mcp analytics', () => {
       collectEnabled: true,
       dedupeIdentifiedPosthogEvents: false,
       disclosureUrl: 'https://durabull.io/privacy',
+      collectSigningSecret: 'test-collect-secret',
       hmacSecret: 'test-secret',
       durabullTelemetryPosthogKey: 'phc_test',
       durabullTelemetryPosthogHost: 'https://us.i.posthog.com',

--- a/apps/api/src/middleware/rate-limit.test.ts
+++ b/apps/api/src/middleware/rate-limit.test.ts
@@ -6,30 +6,44 @@ import { apiRateLimiter } from './rate-limit'
 const mutableEnv = env as {
   CI?: boolean
   DISABLE_RATE_LIMIT?: boolean
+  DURABULL_CLOUD?: boolean
   NODE_ENV?: 'development' | 'test' | 'production'
+  TRUST_PROXY?: boolean
 }
 
 const originalCi = mutableEnv.CI
 const originalDisableRateLimit = mutableEnv.DISABLE_RATE_LIMIT
+const originalDurabullCloud = mutableEnv.DURABULL_CLOUD
 const originalNodeEnv = mutableEnv.NODE_ENV
+const originalTrustProxy = mutableEnv.TRUST_PROXY
+
+function createPingApp() {
+  const app = new Hono()
+  app.use('/api/*', apiRateLimiter)
+  app.get('/api/ping', (c) => c.json({ ok: true }))
+  return app
+}
 
 describe('apiRateLimiter', () => {
   beforeEach(() => {
     mutableEnv.CI = false
     mutableEnv.DISABLE_RATE_LIMIT = false
+    mutableEnv.DURABULL_CLOUD = false
     mutableEnv.NODE_ENV = 'production'
+    mutableEnv.TRUST_PROXY = undefined
   })
 
   afterEach(() => {
     mutableEnv.CI = originalCi
     mutableEnv.DISABLE_RATE_LIMIT = originalDisableRateLimit
+    mutableEnv.DURABULL_CLOUD = originalDurabullCloud
     mutableEnv.NODE_ENV = originalNodeEnv
+    mutableEnv.TRUST_PROXY = originalTrustProxy
   })
 
-  it('allows a normal multi-tab app startup burst from one client', async () => {
-    const app = new Hono()
-    app.use('/api/*', apiRateLimiter)
-    app.get('/api/ping', (c) => c.json({ ok: true }))
+  it('allows a normal multi-tab app startup burst from one client behind trusted proxy', async () => {
+    mutableEnv.DURABULL_CLOUD = true
+    const app = createPingApp()
 
     const responses = await Promise.all(
       Array.from({ length: 150 }, () =>
@@ -41,5 +55,35 @@ describe('apiRateLimiter', () => {
 
     expect(responses.every((response) => response.status === 200)).toBe(true)
     expect(responses[0]?.headers.get('X-RateLimit-Limit')).toBe('600')
+  })
+
+  it('does not treat spoofed x-forwarded-for values as separate clients when proxy is untrusted', async () => {
+    const app = createPingApp()
+
+    const responses = await Promise.all(
+      Array.from({ length: 601 }, (_, index) =>
+        app.request('/api/ping', {
+          headers: { 'x-forwarded-for': `203.0.113.${index % 250}` },
+        })
+      )
+    )
+
+    expect(responses.some((response) => response.status === 429)).toBe(true)
+    expect(responses.filter((response) => response.status === 429).length).toBeGreaterThan(0)
+  })
+
+  it('honors x-forwarded-for when TRUST_PROXY is enabled', async () => {
+    mutableEnv.TRUST_PROXY = true
+    const app = createPingApp()
+
+    const responses = await Promise.all(
+      Array.from({ length: 601 }, (_, index) =>
+        app.request('/api/ping', {
+          headers: { 'x-forwarded-for': `198.51.100.${index % 250}` },
+        })
+      )
+    )
+
+    expect(responses.every((response) => response.status === 200)).toBe(true)
   })
 })

--- a/apps/api/src/middleware/rate-limit.test.ts
+++ b/apps/api/src/middleware/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { env } from '@durabull/env'
 import { Hono } from 'hono'
-import { apiRateLimiter } from './rate-limit'
+import { apiRateLimiter, resetRateLimitStoreForTests } from './rate-limit'
 
 const mutableEnv = env as {
   CI?: boolean
@@ -26,6 +26,7 @@ function createPingApp() {
 
 describe('apiRateLimiter', () => {
   beforeEach(() => {
+    resetRateLimitStoreForTests()
     mutableEnv.CI = false
     mutableEnv.DISABLE_RATE_LIMIT = false
     mutableEnv.DURABULL_CLOUD = false
@@ -70,6 +71,24 @@ describe('apiRateLimiter', () => {
 
     expect(responses.some((response) => response.status === 429)).toBe(true)
     expect(responses.filter((response) => response.status === 429).length).toBeGreaterThan(0)
+  })
+
+  it('does not treat spoofed x-forwarded-for leftmost hops as separate clients when proxy is trusted', async () => {
+    mutableEnv.TRUST_PROXY = true
+    const app = createPingApp()
+
+    const responses = await Promise.all(
+      Array.from({ length: 601 }, (_, index) =>
+        app.request('/api/ping', {
+          headers: {
+            'cf-connecting-ip': '198.51.100.42',
+            'x-forwarded-for': `${index}.0.0.1, 198.51.100.42`,
+          },
+        })
+      )
+    )
+
+    expect(responses.some((response) => response.status === 429)).toBe(true)
   })
 
   it('honors x-forwarded-for when TRUST_PROXY is enabled', async () => {

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -220,7 +220,7 @@ export const apiRateLimiter = rateLimiter({
         error: 'Too Many Requests',
         code: 'RATE_LIMITED',
         message: 'Rate limit exceeded. Please slow down.',
-        retryAfter: 10,
+        retryAfter: Math.ceil(GENERAL_API_RATE_LIMIT_WINDOW_MS / 1000),
       },
       429
     ),

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -19,6 +19,11 @@ interface RateLimitEntry {
 // In-memory store for rate limiting
 const rateLimitStore = new Map<string, RateLimitEntry>()
 
+/** Test-only: clear in-memory counters between cases. */
+export function resetRateLimitStoreForTests(): void {
+  rateLimitStore.clear()
+}
+
 const GENERAL_API_RATE_LIMIT_WINDOW_MS = 60 * 1000
 const GENERAL_API_RATE_LIMIT_MAX_REQUESTS = 600
 
@@ -63,16 +68,21 @@ function isTrustedProxyEnvironment(): boolean {
 function getTrustedClientIp(c: Parameters<ReturnType<typeof createMiddleware>>[0]): string | null {
   if (!isTrustedProxyEnvironment()) return null
 
-  const forwarded = c.req.header('x-forwarded-for')
-  if (forwarded) {
-    return forwarded.split(',')[0]?.trim() || null
-  }
-
   const cfIp = c.req.header('cf-connecting-ip')?.trim()
   if (cfIp) return cfIp
 
   const realIp = c.req.header('x-real-ip')?.trim()
   if (realIp) return realIp
+
+  const forwarded = c.req.header('x-forwarded-for')
+  if (forwarded) {
+    const ips = forwarded
+      .split(',')
+      .map((ip) => ip.trim())
+      .filter(Boolean)
+    // Use the rightmost hop (appended by the trusted proxy), not the client-spoofable leftmost entry.
+    return ips.at(-1) ?? null
+  }
 
   return null
 }

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -50,27 +50,38 @@ interface RateLimitOptions {
   ) => Response | Promise<Response>
 }
 
+function isTrustedProxyEnvironment(): boolean {
+  if (env.TRUST_PROXY === true) return true
+  if (env.DURABULL_CLOUD === true) return true
+  return false
+}
+
 /**
- * Get client identifier for rate limiting.
- * Uses X-Forwarded-For header (from reverse proxy) or falls back to a default.
+ * Resolve a client IP from forwarding headers when the deployment sits behind a trusted proxy.
+ * Ignores spoofable headers on direct or untrusted ingress so they cannot mint fresh rate-limit keys.
  */
-function getClientKey(c: Parameters<ReturnType<typeof createMiddleware>>[0]): string {
-  // In production behind a reverse proxy, use X-Forwarded-For
+function getTrustedClientIp(c: Parameters<ReturnType<typeof createMiddleware>>[0]): string | null {
+  if (!isTrustedProxyEnvironment()) return null
+
   const forwarded = c.req.header('x-forwarded-for')
   if (forwarded) {
-    // Take the first IP (original client)
-    return forwarded.split(',')[0].trim()
+    return forwarded.split(',')[0]?.trim() || null
   }
 
-  // Fall back to CF-Connecting-IP (Cloudflare) or X-Real-IP
-  const cfIp = c.req.header('cf-connecting-ip')
+  const cfIp = c.req.header('cf-connecting-ip')?.trim()
   if (cfIp) return cfIp
 
-  const realIp = c.req.header('x-real-ip')
+  const realIp = c.req.header('x-real-ip')?.trim()
   if (realIp) return realIp
 
-  // Last resort - this won't work well behind proxies
-  return 'unknown-client'
+  return null
+}
+
+/**
+ * Get client identifier for rate limiting.
+ */
+function getClientKey(c: Parameters<ReturnType<typeof createMiddleware>>[0]): string {
+  return getTrustedClientIp(c) ?? 'unknown-client'
 }
 
 /**
@@ -104,15 +115,6 @@ function shouldSkipRateLimiting(): boolean {
 }
 
 /**
- * Check if the client key indicates local/test traffic that shouldn't be rate limited.
- * This handles cases where environment variables aren't properly set.
- */
-function isLocalClient(clientKey: string): boolean {
-  // "unknown-client" means no forwarding headers - local development/testing
-  return clientKey === 'unknown-client'
-}
-
-/**
  * Creates a rate limiting middleware for Hono.
  */
 export function rateLimiter(options: RateLimitOptions) {
@@ -125,11 +127,6 @@ export function rateLimiter(options: RateLimitOptions) {
     }
 
     const clientKey = keyGenerator(c)
-
-    // Skip rate limiting for local clients (no forwarding headers = local dev/test)
-    if (isLocalClient(clientKey)) {
-      return next()
-    }
     const key = `${keyPrefix}:${clientKey}`
     const now = Date.now()
 
@@ -258,11 +255,7 @@ function mcpIngressRateLimitKey(c: Parameters<ReturnType<typeof createMiddleware
     return `bearer:${createHash('sha256').update(bearerToken).digest('hex').slice(0, 24)}`
   }
 
-  const cfIp = c.req.header('cf-connecting-ip')
-  if (cfIp) return cfIp
-  const realIp = c.req.header('x-real-ip')
-  if (realIp) return realIp
-  return 'mcp-anonymous'
+  return getTrustedClientIp(c) ?? 'mcp-anonymous'
 }
 
 /** Stricter limit for dynamic MCP OAuth client registration. */

--- a/apps/api/src/routes/telemetry-collect.test.ts
+++ b/apps/api/src/routes/telemetry-collect.test.ts
@@ -2,8 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { env } from '@durabull/env'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
-import { hashTelemetryIdentifier } from '@durabull/analytics/server'
-import { resetServerAnalyticsForTests } from '@durabull/analytics/server'
+import {
+  hashTelemetryIdentifier,
+  resetServerAnalyticsForTests,
+  signTelemetryCollectBody,
+  TELEMETRY_COLLECT_SIGNATURE_HEADER,
+  TELEMETRY_COLLECT_TIMESTAMP_HEADER,
+} from '@durabull/analytics/server'
 import {
   bootstrapServerAnalytics,
   resetCachedAnonymousInstanceIdForTests,
@@ -13,13 +18,23 @@ import telemetryRoutes from './telemetry'
 const INSTANCE_ID = '41111111-1111-4111-8111-111111111111'
 const SESSION_ID = 'ephemeral-session'
 const HMAC_SECRET = 'test-telemetry-collect-hmac-secret'
+const COLLECT_SECRET = 'test-telemetry-collect-signing-secret'
 const POSTHOG_KEY = 'phc_test_project_key'
+
+const DEFAULT_RUNTIME = {
+  authless: false,
+  env_connections: false,
+  environment: 'production',
+  persistence: 'postgres',
+  stateless: false,
+} as const
 
 const mutableEnv = env as {
   APP_BASE_URL?: string
   BETTER_AUTH_SECRET?: string
   CI?: boolean
   DURABULL_CLOUD?: boolean
+  DURABULL_TELEMETRY_COLLECT_SECRET?: string
   DURABULL_TELEMETRY_HMAC_SECRET?: string
   DURABULL_TELEMETRY_POSTHOG_HOST?: string
   DURABULL_TELEMETRY_POSTHOG_KEY?: string
@@ -30,6 +45,7 @@ const mutableEnv = env as {
 const originalAppBaseUrl = mutableEnv.APP_BASE_URL
 const originalBetterAuthSecret = mutableEnv.BETTER_AUTH_SECRET
 const originalCi = mutableEnv.CI
+const originalCollectSecret = mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET
 const originalDurabullCloud = mutableEnv.DURABULL_CLOUD
 const originalHmacSecret = mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET
 const originalNodeEnv = mutableEnv.NODE_ENV
@@ -55,10 +71,14 @@ function createTelemetryRouteApp(options: { bodyLimit?: boolean } = {}) {
   return app.route('/', telemetryRoutes)
 }
 
-function collectPayload(properties: Record<string, unknown> = { success: true }) {
+function collectPayload(
+  properties: Record<string, unknown> = { success: true },
+  runtime: Record<string, unknown> = DEFAULT_RUNTIME
+) {
   return JSON.stringify({
     instanceId: INSTANCE_ID,
     sentAt: '2026-04-28T12:00:00.000Z',
+    runtime,
     events: [
       {
         event: 'queue_paused',
@@ -67,6 +87,35 @@ function collectPayload(properties: Record<string, unknown> = { success: true })
         timestamp: '2026-04-28T12:00:01.000Z',
       },
     ],
+  })
+}
+
+function signedCollectRequest(
+  body: string,
+  secret: string = COLLECT_SECRET,
+  timestampSec: number = Math.floor(Date.now() / 1000)
+) {
+  const { signature, timestamp } = signTelemetryCollectBody(secret, timestampSec, body)
+  return {
+    method: 'POST' as const,
+    headers: {
+      'Content-Type': 'application/json',
+      [TELEMETRY_COLLECT_TIMESTAMP_HEADER]: timestamp,
+      [TELEMETRY_COLLECT_SIGNATURE_HEADER]: signature,
+    },
+    body,
+  }
+}
+
+async function postCollect(
+  app: ReturnType<typeof createTelemetryRouteApp>,
+  body: string,
+  extraHeaders: Record<string, string> = {}
+) {
+  const signed = signedCollectRequest(body)
+  return app.request('/collect', {
+    ...signed,
+    headers: { ...signed.headers, ...extraHeaders },
   })
 }
 
@@ -79,6 +128,7 @@ describe('telemetry collect route', () => {
     mutableEnv.NODE_ENV = 'production'
     mutableEnv.POSTHOG_KEY = undefined
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = HMAC_SECRET
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = COLLECT_SECRET
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'https://us.i.posthog.com'
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = POSTHOG_KEY
     bootstrapServerAnalytics()
@@ -94,6 +144,7 @@ describe('telemetry collect route', () => {
     mutableEnv.NODE_ENV = originalNodeEnv
     mutableEnv.POSTHOG_KEY = originalPublicPosthogKey
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = originalHmacSecret
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = originalCollectSecret
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = originalPosthogHost
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = originalPosthogKey
     globalThis.fetch = originalFetch
@@ -109,11 +160,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(202)
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
@@ -133,23 +180,22 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer should-not-forward',
-        Cookie: 'session=should-not-forward',
-        'X-Forwarded-For': '203.0.113.10',
-        'User-Agent': 'should-not-forward',
-      },
-      body: collectPayload({
+    const response = await postCollect(
+      app,
+      collectPayload({
         authless: true,
         environment: 'production',
         persistence: 'pglite',
         stateless: true,
         success: true,
       }),
-    })
+      {
+        Authorization: 'Bearer should-not-forward',
+        Cookie: 'session=should-not-forward',
+        'X-Forwarded-For': '203.0.113.10',
+        'User-Agent': 'should-not-forward',
+      }
+    )
 
     expect(response.status).toBe(202)
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -185,22 +231,30 @@ describe('telemetry collect route', () => {
     expect(properties.instance_key).not.toContain(INSTANCE_ID)
   })
 
-  it('applies server runtime over client-spoofed collect properties', async () => {
+  it('uses authenticated client runtime instead of cloud server runtime', async () => {
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload({
-        authless: true,
-        environment: 'development',
-        persistence: 'pglite',
-        stateless: true,
-        success: true,
-      }),
-    })
+    const response = await postCollect(
+      app,
+      collectPayload(
+        {
+          authless: false,
+          environment: 'development',
+          persistence: 'postgres',
+          stateless: false,
+          success: true,
+        },
+        {
+          authless: true,
+          env_connections: false,
+          environment: 'production',
+          persistence: 'pglite',
+          stateless: true,
+        }
+      )
+    )
 
     expect(response.status).toBe(202)
 
@@ -210,12 +264,14 @@ describe('telemetry collect route', () => {
     }
     const properties = body.batch[0].properties
 
-    expect(properties.authless).toBe(false)
+    expect(properties.authless).toBe(true)
     expect(properties.environment).toBe('production')
+    expect(properties.persistence).toBe('pglite')
+    expect(properties.stateless).toBe(true)
   })
 
-  it('returns 502 when PostHog rejects the batch', async () => {
-    const fetchMock = mock(async () => new Response(null, { status: 400 }))
+  it('rejects unsigned collect requests', async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
@@ -224,6 +280,31 @@ describe('telemetry collect route', () => {
       headers: { 'Content-Type': 'application/json' },
       body: collectPayload(),
     })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized telemetry collect request' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects collect requests with invalid signatures', async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 200 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+    const body = collectPayload()
+    const signed = signedCollectRequest(body, 'wrong-secret')
+
+    const response = await app.request('/collect', signed)
+
+    expect(response.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 502 when PostHog rejects the batch', async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 400 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(502)
     expect(await response.json()).toEqual({ error: 'Telemetry upstream rejected batch' })
@@ -240,11 +321,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(502)
     expect(await response.json()).toEqual({ error: 'Telemetry upstream rejected batch' })
@@ -257,11 +334,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(503)
     expect(await response.json()).toEqual({ error: 'Telemetry upstream unavailable' })
@@ -274,11 +347,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(404)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -292,11 +361,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(404)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -307,11 +372,10 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload({ queue_name: 'billing-production', success: true }),
-    })
+    const response = await postCollect(
+      app,
+      collectPayload({ queue_name: 'billing-production', success: true })
+    )
 
     expect(response.status).toBe(400)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -322,20 +386,19 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        instanceId: INSTANCE_ID,
-        events: [
-          {
-            event: 'oss_queue_paused',
-            properties: {},
-            sessionId: SESSION_ID,
-          },
-        ],
-      }),
+    const body = JSON.stringify({
+      instanceId: INSTANCE_ID,
+      runtime: DEFAULT_RUNTIME,
+      events: [
+        {
+          event: 'oss_queue_paused',
+          properties: {},
+          sessionId: SESSION_ID,
+        },
+      ],
     })
+
+    const response = await postCollect(app, body)
 
     expect(response.status).toBe(400)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -345,17 +408,14 @@ describe('telemetry collect route', () => {
     mutableEnv.BETTER_AUTH_SECRET = undefined
     mutableEnv.POSTHOG_KEY = undefined
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = undefined
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = undefined
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = undefined
     bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(503)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -368,11 +428,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(503)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -385,11 +441,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(503)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -402,11 +454,7 @@ describe('telemetry collect route', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
-    const response = await app.request('/collect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: collectPayload(),
-    })
+    const response = await postCollect(app, collectPayload())
 
     expect(response.status).toBe(503)
     expect(fetchMock).not.toHaveBeenCalled()

--- a/apps/api/src/routes/telemetry.test.ts
+++ b/apps/api/src/routes/telemetry.test.ts
@@ -20,6 +20,7 @@ const mutableEnv = env as {
   CI?: boolean
   DATABASE_URL?: string
   DURABULL_CLOUD?: boolean
+  DURABULL_TELEMETRY_COLLECT_SECRET?: string
   DURABULL_TELEMETRY_HMAC_SECRET?: string
   DURABULL_TELEMETRY_POSTHOG_HOST?: string
   DURABULL_TELEMETRY_POSTHOG_KEY?: string
@@ -27,11 +28,14 @@ const mutableEnv = env as {
   POSTHOG_KEY?: string
 }
 
+const COLLECT_SECRET = 'test-events-collect-secret'
+
 const originalAppBaseUrl = mutableEnv.APP_BASE_URL
 const originalBetterAuthSecret = mutableEnv.BETTER_AUTH_SECRET
 const originalCi = mutableEnv.CI
 const originalDatabaseUrl = mutableEnv.DATABASE_URL
 const originalDurabullCloud = mutableEnv.DURABULL_CLOUD
+const originalCollectSecret = mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET
 const originalHmacSecret = mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET
 const originalNodeEnv = mutableEnv.NODE_ENV
 const originalPosthogHost = mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST
@@ -64,6 +68,7 @@ describe('telemetry routes', () => {
     mutableEnv.BETTER_AUTH_SECRET = originalBetterAuthSecret
     mutableEnv.CI = originalCi
     mutableEnv.DURABULL_CLOUD = originalDurabullCloud
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = originalCollectSecret
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = originalHmacSecret
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = originalPosthogHost
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = originalPosthogKey
@@ -134,6 +139,7 @@ describe('telemetry routes', () => {
 
   it('accepts known events in production and forwards sanitized canonical events', async () => {
     mutableEnv.NODE_ENV = 'production'
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = COLLECT_SECRET
     bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 202 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
@@ -157,9 +163,14 @@ describe('telemetry routes', () => {
     const body = JSON.parse(String(init.body)) as {
       events: Array<{ event: string; properties: Record<string, unknown> }>
       instanceId: string
+      runtime: Record<string, unknown>
     }
 
     expect(url).toBe('https://app.durabull.io/api/telemetry/collect')
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+    })
+    expect((init.headers as Record<string, string>)['X-Durabull-Telemetry-Signature']).toBeDefined()
     expect(body.instanceId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
     )
@@ -185,8 +196,9 @@ describe('telemetry routes', () => {
     expect(response.status).toBe(400)
   })
 
-  it('lets server runtime override client properties when forwarding to cloud collect', async () => {
+  it('forwards trusted OSS runtime to cloud collect', async () => {
     mutableEnv.NODE_ENV = 'production'
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = COLLECT_SECRET
     bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 202 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
@@ -207,16 +219,20 @@ describe('telemetry routes', () => {
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
     const body = JSON.parse(String(init.body)) as {
       events: Array<{ properties: Record<string, unknown> }>
+      runtime: Record<string, unknown>
     }
 
+    expect(body.runtime.authless).toBe(false)
+    expect(body.runtime.environment).toBe('production')
     expect(body.events[0].properties.authless).toBe(false)
-    expect(body.events[0].properties.environment).toBe('production')
+    expect(body.events[0].properties.success).toBe(true)
   })
 
   it('returns 503 on /events when collect mode has an invalid PostHog batch host', async () => {
     mutableEnv.APP_BASE_URL = 'https://app.durabull.io'
     mutableEnv.BETTER_AUTH_SECRET = 'test-events-hmac-secret'
     mutableEnv.DURABULL_CLOUD = true
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = COLLECT_SECRET
     mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = 'test-events-hmac-secret'
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_HOST = 'https://evil.example.com'
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = 'phc_test_project_key'
@@ -242,6 +258,7 @@ describe('telemetry routes', () => {
 
   it('keeps local telemetry non-blocking when Durabull API forwarding fails', async () => {
     mutableEnv.NODE_ENV = 'production'
+    mutableEnv.DURABULL_TELEMETRY_COLLECT_SECRET = COLLECT_SECRET
     bootstrapServerAnalytics()
     const fetchMock = mock(async () => {
       throw new Error('Durabull API unavailable')

--- a/apps/api/src/routes/telemetry.test.ts
+++ b/apps/api/src/routes/telemetry.test.ts
@@ -46,6 +46,18 @@ const originalFetch = globalThis.fetch
 
 let tempPgliteDir = ''
 
+async function waitForFetchMock(
+  fetchMock: ReturnType<typeof mock>,
+  expectedCalls = 1,
+  timeoutMs = 5000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (fetchMock.mock.calls.length >= expectedCalls) return
+    await new Promise<void>((resolve) => setTimeout(resolve, 25))
+  }
+}
+
 async function createTelemetryRouteApp() {
   const { default: telemetryRoutes } = await import('./telemetry')
   return new Hono().route('/', telemetryRoutes)
@@ -157,6 +169,7 @@ describe('telemetry routes', () => {
     })
 
     expect(response.status).toBe(202)
+    await waitForFetchMock(fetchMock)
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
@@ -215,6 +228,8 @@ describe('telemetry routes', () => {
     })
 
     expect(response.status).toBe(202)
+
+    await waitForFetchMock(fetchMock)
 
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
     const body = JSON.parse(String(init.body)) as {
@@ -278,6 +293,7 @@ describe('telemetry routes', () => {
 
     expect(response.status).toBe(202)
     expect(await response.json()).toEqual({ accepted: true })
+    await waitForFetchMock(fetchMock)
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -155,17 +155,20 @@ const telemetryRoutes = new Hono()
       return c.json({ error: 'Telemetry collection is not configured' }, 503)
     }
 
-    const anonymousInstanceId = await options.resolveAnonymousInstanceId()
-
-    void captureAnonymousServerEvent({
-      anonymousInstanceId,
-      event: validated.event,
-      properties: validated.properties,
-      sessionId: body.sessionId,
-      timestamp: body.timestamp ?? new Date().toISOString(),
-    }).catch(() => {
-      // Telemetry must never affect the local product experience.
-    })
+    void (async () => {
+      try {
+        const anonymousInstanceId = await options.resolveAnonymousInstanceId()
+        await captureAnonymousServerEvent({
+          anonymousInstanceId,
+          event: validated.event,
+          properties: validated.properties,
+          sessionId: body.sessionId,
+          timestamp: body.timestamp ?? new Date().toISOString(),
+        })
+      } catch {
+        // Telemetry must never affect the local product experience.
+      }
+    })()
 
     return c.json({ accepted: true }, 202)
   })

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -3,9 +3,12 @@ import {
   getTelemetryStatusFromOptions,
   ingestTelemetryCollectBatch,
   isDurabullTelemetryCollectConfigured,
+  TELEMETRY_COLLECT_SIGNATURE_HEADER,
+  TELEMETRY_COLLECT_TIMESTAMP_HEADER,
   TELEMETRY_DISCLOSURE_URL,
   tryGetServerAnalyticsOptions,
   validateTelemetryPayload,
+  verifyTelemetryCollectSignature,
 } from '@durabull/analytics/server'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
@@ -27,9 +30,18 @@ const telemetryCollectEventSchema = z.object({
   timestamp: z.string().datetime().optional(),
 })
 
+const telemetryCollectRuntimeSchema = z.object({
+  authless: z.boolean(),
+  env_connections: z.boolean(),
+  environment: z.string().min(1).max(64),
+  persistence: z.string().min(1).max(64),
+  stateless: z.boolean(),
+})
+
 const telemetryCollectPayloadSchema = z.object({
   sentAt: z.string().datetime().optional(),
   instanceId: z.string().min(16).max(128),
+  runtime: telemetryCollectRuntimeSchema,
   events: z.array(telemetryCollectEventSchema).min(1).max(MAX_COLLECT_EVENTS_PER_BATCH),
 })
 
@@ -54,16 +66,47 @@ export function isDurabullTelemetryCollectEnabled(): boolean {
 
 const telemetryRoutes = new Hono()
   .get('/status', (c) => c.json(getTelemetryStatus()))
-  .post('/collect', zValidator('json', telemetryCollectPayloadSchema), async (c) => {
+  .post('/collect', async (c) => {
     if (!isDurabullTelemetryCollectEnabled()) {
       return c.json({ error: 'Not Found' }, 404)
     }
 
-    const payload = c.req.valid('json')
+    const options = tryGetServerAnalyticsOptions()
+    const collectSigningSecret = options?.collectSigningSecret
+    if (!collectSigningSecret) {
+      return c.json({ error: 'Telemetry collection is not configured' }, 503)
+    }
+
+    const rawBody = await c.req.text()
+    const verification = verifyTelemetryCollectSignature({
+      secret: collectSigningSecret,
+      timestampHeader: c.req.header(TELEMETRY_COLLECT_TIMESTAMP_HEADER),
+      signatureHeader: c.req.header(TELEMETRY_COLLECT_SIGNATURE_HEADER),
+      rawBody,
+    })
+
+    if (!verification.ok) {
+      return c.json({ error: 'Unauthorized telemetry collect request' }, 401)
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(rawBody)
+    } catch {
+      return c.json({ error: 'Invalid telemetry collect payload' }, 400)
+    }
+
+    const payloadResult = telemetryCollectPayloadSchema.safeParse(parsed)
+    if (!payloadResult.success) {
+      return c.json({ error: 'Invalid telemetry collect payload' }, 400)
+    }
+
+    const payload = payloadResult.data
     const result = await ingestTelemetryCollectBatch({
       instanceId: payload.instanceId,
       sentAt: payload.sentAt,
       events: payload.events,
+      clientRuntime: payload.runtime,
     })
 
     if (!result.ok) {

--- a/apps/docs/content/documentation/operations/security-and-hardening.mdx
+++ b/apps/docs/content/documentation/operations/security-and-hardening.mdx
@@ -40,12 +40,13 @@ Built-in controls include:
 - CORS policy
 - request body size limit (`1MB`)
 - in-memory rate limiting when `NODE_ENV=production`
+- set `TRUST_PROXY=true` when the API sits behind a reverse proxy that sets forwarding headers; Durabull Cloud enables this automatically via `DURABULL_CLOUD`
 
 ### MCP (`/mcp`)
 
 Durabull's hosted MCP endpoint adds layered read protections (enforced when `NODE_ENV=production`):
 
-- **Ingress rate limit:** 120 HTTP requests/minute per bearer token, or per `cf-connecting-ip` / `x-real-ip` when unauthenticated (not `X-Forwarded-For`) on all `/mcp` traffic
+- **Ingress rate limit:** 120 HTTP requests/minute per bearer token, or per trusted `cf-connecting-ip` / `x-real-ip` / `x-forwarded-for` when unauthenticated on all `/mcp` traffic (`TRUST_PROXY` / `DURABULL_CLOUD` required for forwarding headers)
 - **Per-tool rate limit:** 60 calls/minute per tool name by default; 30/minute for `get_job_logs`, `get_job_stacktraces`, `get_failure_events`, `get_queue_metrics`, `explain_job_failure`
 - **Output redaction:** central sanitizer removes Redis URLs, credential-like keys, and bearer tokens from tool payloads
 - **Audit events:** every MCP tool call records principal, tool, input hash, and outcome in `mcp_audit_event`

--- a/packages/analytics/src/server/capture.ts
+++ b/packages/analytics/src/server/capture.ts
@@ -22,8 +22,7 @@ import {
 } from './posthog-batch'
 import { validateTelemetryPayload } from './validate'
 
-interface DurabullTelemetryCollectConfig extends PosthogBatchClientConfig {
-  collectSigningSecret: string
+interface DurabullPosthogIngestConfig extends PosthogBatchClientConfig {
   hmacSecret: string
 }
 
@@ -34,20 +33,19 @@ function getOptions(): ServerAnalyticsOptions | null {
 export function isDurabullTelemetryCollectConfigured(
   options: ServerAnalyticsOptions
 ): boolean {
-  return getDurabullTelemetryCollectConfig(options) !== null
+  return getDurabullPosthogIngestConfig(options) !== null
 }
 
-function getDurabullTelemetryCollectConfig(
+function getDurabullPosthogIngestConfig(
   options: ServerAnalyticsOptions
-): DurabullTelemetryCollectConfig | null {
+): DurabullPosthogIngestConfig | null {
   const posthogKey = options.durabullTelemetryPosthogKey
   const hmacSecret = options.hmacSecret
-  const collectSigningSecret = options.collectSigningSecret
   const posthogBatchUrl = resolvePosthogBatchUrl(options.durabullTelemetryPosthogHost ?? undefined)
 
-  if (!posthogKey || !hmacSecret || !collectSigningSecret || !posthogBatchUrl) return null
+  if (!posthogKey || !hmacSecret || !posthogBatchUrl) return null
 
-  return { collectSigningSecret, hmacSecret, posthogBatchUrl, posthogKey }
+  return { hmacSecret, posthogBatchUrl, posthogKey }
 }
 
 function getIdentifiedPosthogConfig(options: ServerAnalyticsOptions): PosthogBatchClientConfig | null {
@@ -133,6 +131,8 @@ async function forwardAnonymousToCloudCollect(input: {
   if (!response.ok) {
     console.warn(`[analytics] cloud collect forward failed with status ${response.status}`)
   }
+
+  await response.body?.cancel()
 }
 
 export async function captureAnonymousServerEvent(input: {
@@ -152,7 +152,7 @@ export async function captureAnonymousServerEvent(input: {
   const timestamp = input.timestamp ?? new Date().toISOString()
 
   if (options.collectEnabled) {
-    const config = getDurabullTelemetryCollectConfig(options)
+    const config = getDurabullPosthogIngestConfig(options)
     if (!config) return
 
     await sendPosthogBatch(
@@ -259,7 +259,7 @@ export async function ingestTelemetryCollectBatch(input: {
     return { ok: false, error: 'disabled' }
   }
 
-  const config = getDurabullTelemetryCollectConfig(options)
+  const config = getDurabullPosthogIngestConfig(options)
   if (!config) {
     return { ok: false, error: 'not_configured' }
   }

--- a/packages/analytics/src/server/capture.ts
+++ b/packages/analytics/src/server/capture.ts
@@ -2,7 +2,13 @@ import {
   getServerAnalyticsOptions,
   tryGetServerAnalyticsOptions,
   type ServerAnalyticsOptions,
+  type ServerAnalyticsRuntimeContext,
 } from './config'
+import {
+  signTelemetryCollectBody,
+  TELEMETRY_COLLECT_SIGNATURE_HEADER,
+  TELEMETRY_COLLECT_TIMESTAMP_HEADER,
+} from './collect-auth'
 import {
   hashIdentifiedOrganizationDistinctId,
   hashIdentifiedUserDistinctId,
@@ -17,6 +23,7 @@ import {
 import { validateTelemetryPayload } from './validate'
 
 interface DurabullTelemetryCollectConfig extends PosthogBatchClientConfig {
+  collectSigningSecret: string
   hmacSecret: string
 }
 
@@ -35,11 +42,12 @@ function getDurabullTelemetryCollectConfig(
 ): DurabullTelemetryCollectConfig | null {
   const posthogKey = options.durabullTelemetryPosthogKey
   const hmacSecret = options.hmacSecret
+  const collectSigningSecret = options.collectSigningSecret
   const posthogBatchUrl = resolvePosthogBatchUrl(options.durabullTelemetryPosthogHost ?? undefined)
 
-  if (!posthogKey || !hmacSecret || !posthogBatchUrl) return null
+  if (!posthogKey || !hmacSecret || !collectSigningSecret || !posthogBatchUrl) return null
 
-  return { hmacSecret, posthogBatchUrl, posthogKey }
+  return { collectSigningSecret, hmacSecret, posthogBatchUrl, posthogKey }
 }
 
 function getIdentifiedPosthogConfig(options: ServerAnalyticsOptions): PosthogBatchClientConfig | null {
@@ -82,31 +90,44 @@ function buildAnonymousCapture(input: {
 
 async function forwardAnonymousToCloudCollect(input: {
   cloudCollectUrl: string
+  collectSigningSecret: string
   anonymousInstanceId: string
   event: string
   properties: Record<string, string | number | boolean | null>
   sessionId: string
   timestamp: string
-  runtimeContext: ReturnType<ServerAnalyticsOptions['getRuntimeContext']>
+  runtimeContext: ServerAnalyticsRuntimeContext
 }): Promise<void> {
+  const sentAt = new Date().toISOString()
+  const rawBody = JSON.stringify({
+    sentAt,
+    instanceId: input.anonymousInstanceId,
+    runtime: input.runtimeContext,
+    events: [
+      {
+        event: input.event,
+        properties: input.properties,
+        sessionId: input.sessionId,
+        timestamp: input.timestamp,
+      },
+    ],
+  })
+  const signedAt = Math.floor(Date.now() / 1000)
+  const { signature, timestamp } = signTelemetryCollectBody(
+    input.collectSigningSecret,
+    signedAt,
+    rawBody
+  )
+
   const response = await fetch(input.cloudCollectUrl, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      sentAt: new Date().toISOString(),
-      instanceId: input.anonymousInstanceId,
-      events: [
-        {
-          event: input.event,
-          properties: {
-            ...input.properties,
-            ...input.runtimeContext,
-          },
-          sessionId: input.sessionId,
-          timestamp: input.timestamp,
-        },
-      ],
-    }),
+    headers: {
+      'Content-Type': 'application/json',
+      [TELEMETRY_COLLECT_TIMESTAMP_HEADER]: timestamp,
+      [TELEMETRY_COLLECT_SIGNATURE_HEADER]: signature,
+    },
+    body: rawBody,
+    redirect: 'manual',
   })
 
   if (!response.ok) {
@@ -151,8 +172,14 @@ export async function captureAnonymousServerEvent(input: {
     return
   }
 
+  if (!options.collectSigningSecret) {
+    console.warn('[analytics] cloud collect forward skipped: missing collect signing secret')
+    return
+  }
+
   await forwardAnonymousToCloudCollect({
     cloudCollectUrl: options.cloudCollectUrl,
+    collectSigningSecret: options.collectSigningSecret,
     anonymousInstanceId: input.anonymousInstanceId,
     event: validated.event,
     properties: validated.properties,
@@ -225,6 +252,7 @@ export async function ingestTelemetryCollectBatch(input: {
   instanceId: string
   sentAt?: string
   events: TelemetryCollectEventInput[]
+  clientRuntime?: ServerAnalyticsRuntimeContext
 }): Promise<IngestCollectBatchResult> {
   const options = getOptions()
   if (!options?.enabled) {
@@ -236,7 +264,7 @@ export async function ingestTelemetryCollectBatch(input: {
     return { ok: false, error: 'not_configured' }
   }
 
-  const runtimeContext = options.getRuntimeContext()
+  const runtimeContext = input.clientRuntime ?? options.getRuntimeContext()
   const batch: PosthogBatchCapture[] = []
 
   for (const event of input.events) {

--- a/packages/analytics/src/server/collect-auth.test.ts
+++ b/packages/analytics/src/server/collect-auth.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  signTelemetryCollectBody,
+  TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC,
+  verifyTelemetryCollectSignature,
+} from './collect-auth'
+
+const SECRET = 'test-collect-signing-secret'
+const RAW_BODY = JSON.stringify({
+  instanceId: '41111111-1111-4111-8111-111111111111',
+  events: [{ event: 'queue_paused', properties: {}, sessionId: 'session' }],
+})
+
+describe('telemetry collect auth', () => {
+  it('signs and verifies collect payloads', () => {
+    const timestamp = 1_700_000_000
+    const { signature, timestamp: timestampHeader } = signTelemetryCollectBody(
+      SECRET,
+      timestamp,
+      RAW_BODY
+    )
+
+    expect(
+      verifyTelemetryCollectSignature({
+        secret: SECRET,
+        timestampHeader,
+        signatureHeader: signature,
+        rawBody: RAW_BODY,
+        nowSec: timestamp,
+      })
+    ).toEqual({ ok: true })
+  })
+
+  it('rejects missing signature headers', () => {
+    expect(
+      verifyTelemetryCollectSignature({
+        secret: SECRET,
+        timestampHeader: undefined,
+        signatureHeader: undefined,
+        rawBody: RAW_BODY,
+      })
+    ).toEqual({ ok: false, error: 'missing' })
+  })
+
+  it('rejects expired signatures', () => {
+    const timestamp = 1_700_000_000
+    const { signature, timestamp: timestampHeader } = signTelemetryCollectBody(
+      SECRET,
+      timestamp,
+      RAW_BODY
+    )
+
+    expect(
+      verifyTelemetryCollectSignature({
+        secret: SECRET,
+        timestampHeader,
+        signatureHeader: signature,
+        rawBody: RAW_BODY,
+        nowSec: timestamp + TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC + 1,
+      })
+    ).toEqual({ ok: false, error: 'expired' })
+  })
+
+  it('rejects tampered bodies', () => {
+    const timestamp = 1_700_000_000
+    const { signature, timestamp: timestampHeader } = signTelemetryCollectBody(
+      SECRET,
+      timestamp,
+      RAW_BODY
+    )
+
+    expect(
+      verifyTelemetryCollectSignature({
+        secret: SECRET,
+        timestampHeader,
+        signatureHeader: signature,
+        rawBody: `${RAW_BODY} `,
+        nowSec: timestamp,
+      })
+    ).toEqual({ ok: false, error: 'invalid' })
+  })
+})

--- a/packages/analytics/src/server/collect-auth.ts
+++ b/packages/analytics/src/server/collect-auth.ts
@@ -32,8 +32,8 @@ export function verifyTelemetryCollectSignature(input: {
     return { ok: false, error: 'missing' }
   }
 
-  const timestampSec = Number.parseInt(timestampHeader, 10)
-  if (!Number.isFinite(timestampSec)) {
+  const timestampSec = Number(timestampHeader.trim())
+  if (!Number.isFinite(timestampSec) || !/^\d+$/.test(timestampHeader.trim())) {
     return { ok: false, error: 'invalid' }
   }
 

--- a/packages/analytics/src/server/collect-auth.ts
+++ b/packages/analytics/src/server/collect-auth.ts
@@ -1,0 +1,62 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+export const TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC = 300
+export const TELEMETRY_COLLECT_TIMESTAMP_HEADER = 'X-Durabull-Telemetry-Timestamp'
+export const TELEMETRY_COLLECT_SIGNATURE_HEADER = 'X-Durabull-Telemetry-Signature'
+
+export function signTelemetryCollectBody(
+  secret: string,
+  timestamp: number,
+  rawBody: string
+): { signature: string; timestamp: string } {
+  const timestampValue = String(timestamp)
+  const digest = createHmac('sha256', secret)
+    .update(`${timestampValue}.${rawBody}`)
+    .digest('hex')
+
+  return {
+    signature: `sha256=${digest}`,
+    timestamp: timestampValue,
+  }
+}
+
+export function verifyTelemetryCollectSignature(input: {
+  secret: string
+  timestampHeader: string | undefined
+  signatureHeader: string | undefined
+  rawBody: string
+  nowSec?: number
+}): { ok: true } | { ok: false; error: 'missing' | 'invalid' | 'expired' } {
+  const { secret, timestampHeader, signatureHeader, rawBody } = input
+  if (!timestampHeader?.trim() || !signatureHeader?.trim()) {
+    return { ok: false, error: 'missing' }
+  }
+
+  const timestampSec = Number.parseInt(timestampHeader, 10)
+  if (!Number.isFinite(timestampSec)) {
+    return { ok: false, error: 'invalid' }
+  }
+
+  const nowSec = input.nowSec ?? Math.floor(Date.now() / 1000)
+  if (Math.abs(nowSec - timestampSec) > TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC) {
+    return { ok: false, error: 'expired' }
+  }
+
+  const expected = signTelemetryCollectBody(secret, timestampSec, rawBody).signature
+  const provided = signatureHeader.trim()
+
+  try {
+    const expectedBuffer = Buffer.from(expected)
+    const providedBuffer = Buffer.from(provided)
+    if (
+      expectedBuffer.length !== providedBuffer.length ||
+      !timingSafeEqual(expectedBuffer, providedBuffer)
+    ) {
+      return { ok: false, error: 'invalid' }
+    }
+  } catch {
+    return { ok: false, error: 'invalid' }
+  }
+
+  return { ok: true }
+}

--- a/packages/analytics/src/server/config.ts
+++ b/packages/analytics/src/server/config.ts
@@ -19,6 +19,8 @@ export interface ServerAnalyticsOptions {
   /** When app + Durabull telemetry share one PostHog project, skip duplicate anonymous events. */
   dedupeIdentifiedPosthogEvents: boolean
   disclosureUrl: string
+  /** Shared secret for HMAC-signed `/collect` batches (OSS forward + cloud ingest). */
+  collectSigningSecret: string | null
   hmacSecret: string | null
   durabullTelemetryPosthogKey: string | null
   durabullTelemetryPosthogHost: string | null

--- a/packages/analytics/src/server/index.ts
+++ b/packages/analytics/src/server/index.ts
@@ -11,6 +11,13 @@ export {
   type ServerAnalyticsRuntimeContext,
 } from './config'
 export {
+  signTelemetryCollectBody,
+  TELEMETRY_COLLECT_SIGNATURE_HEADER,
+  TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC,
+  TELEMETRY_COLLECT_TIMESTAMP_HEADER,
+  verifyTelemetryCollectSignature,
+} from './collect-auth'
+export {
   captureAnonymousServerEvent,
   captureIdentifiedServerEvent,
   getTelemetryHmacSecret,

--- a/tasks/handoff-analytics-mcp-telemetry.md
+++ b/tasks/handoff-analytics-mcp-telemetry.md
@@ -1,7 +1,7 @@
 # Handoff: Analytics package split + MCP product telemetry
 
 **Branch:** `cursor/analytics-collect-auth`  
-**Last verified:** 2026-05-28 — **46 tests pass** in telemetry + rate-limit suite (see Verification)  
+**Last verified:** 2026-05-28 — **48 tests pass** after parallel review loop (2 review rounds, all Critical/High fixed)  
 **Timeline:** #107 (merged) → #108 P0 hardening (merged) → **#109 open** (this branch)
 
 ---
@@ -48,6 +48,20 @@
 - `resolveAnonymousInstanceId` deduplicates concurrent DB reads via in-flight promise.
 - Eager warm at `bootstrapServerAnalytics()` in production (non-blocking).
 
+### Parallel review loop (complete)
+
+Two `/parallel-code-review` rounds. Fixed Critical/High findings:
+
+| Finding | Fix |
+|---------|-----|
+| Single-flight promise poisoned on DB error | Clear `anonymousInstanceIdInflight` in catch |
+| XFF leftmost spoof when proxy trusted | CF-Connecting-IP → X-Real-IP → rightmost XFF |
+| `collectSigningSecret` blocked cloud `/events` ingest | Decouple from PostHog ingest config |
+| `/events` awaited instance ID (500 on DB blip) | Fire-and-forget async capture |
+| `apiRateLimiter` JSON `retryAfter: 10` vs 60s window | Use window seconds |
+
+**Accepted deferrals (Medium/Low):** per-process rate limit store, `BETTER_AUTH_SECRET` HMAC fallback (P2), shared collect secret, 5m signature replay window.
+
 ---
 
 ## Remaining work (one PR each recommended)
@@ -89,7 +103,7 @@ bun test \
   apps/api/src/middleware/rate-limit.test.ts
 ```
 
-**Expected:** 46 pass.
+**Expected:** 48 pass.
 
 **Gotcha:** `apps/api/src/app.test.ts` may fail locally with `CI=true` or missing `MCP_AUTHLESS_BEARER_TOKEN` — not a telemetry regression.
 

--- a/tasks/handoff-analytics-mcp-telemetry.md
+++ b/tasks/handoff-analytics-mcp-telemetry.md
@@ -1,283 +1,119 @@
 # Handoff: Analytics package split + MCP product telemetry
 
-**Branch:** `main` (uncommitted local changes only — not pushed)  
-**Last verified:** 2026-05-28 — **23 tests pass** (see Verification)  
-**Original goal:** Track MCP usage in PostHog (anonymous + identified), consolidate server analytics into `packages/analytics`, fix review findings until no Critical/High correctness issues remain.
+**Branch:** `cursor/analytics-collect-auth`  
+**Last verified:** 2026-05-28 — **46 tests pass** in telemetry + rate-limit suite (see Verification)  
+**Timeline:** #107 (merged) → #108 P0 hardening (merged) → **#109 open** (this branch)
 
 ---
 
-## 1. What this change set does
+## Status
 
-### Product intent
+| Phase | State |
+|-------|--------|
+| #107 MCP PostHog + server capture package | ✅ merged |
+| #108 P0 runtime merge, /events 503, PostHog host allowlist | ✅ merged |
+| **#109 P0-A `/collect` HMAC auth + trusted OSS runtime** | ✅ **this branch** |
+| **#109 P0-B XFF trust for rate limiting** | ✅ **this branch** |
+| P1 single-flight instance ID + eager bootstrap | ✅ **this branch** |
+| P1 dedupe/coalesce, dup connection query, async collect | ⏳ deferred |
+| P2 dedicated HMAC secret (no BETTER_AUTH fallback) | ⏳ deferred |
+| P3 maintainability cleanups | ⏳ deferred |
 
-- **Before:** Browser telemetry via `@durabull/analytics` + relay `POST /api/telemetry/events` → cloud `/api/telemetry/collect`. MCP had **ops-only** signals (`mcp_telemetry` stdout + `mcp_audit_event` DB) — **no PostHog product events for MCP**.
-- **After:** Shared `@durabull/analytics/server` for capture/validate/HMAC; MCP maps telemetry signals → PostHog events (`mcp_tool_called`, `mcp_auth_failed`, etc.); consent page uses `/browser` + `/events` subpaths.
-
-### Architecture (high level)
-
-```
-Browser / self-hosted API          Durabull Cloud API
-─────────────────────────          ───────────────────
-trackEvent → POST /events    →     POST /collect → ingestTelemetryCollectBatch
-  (validate + runtime)               (validate per event, HMAC distinct_id)
-  → forward to cloud OR              → sendPosthogBatch (Durabull PostHog key)
-
-MCP request path
-────────────────
-policy/mount/auth → recordMcpTelemetry (ops) → recordMcpTelemetryAnalytics
-  → enqueueMcpAnalytics → processMcpAnalytics
-  → captureAnonymousServerEvent + captureIdentifiedServerEvent (parallel)
-```
+**Start new work from:** `git fetch origin && git checkout -b <branch> origin/main`
 
 ---
 
-## 2. File map (what to read first)
+## Completed on this branch
 
-| Path | Role |
-|------|------|
-| `packages/analytics/src/server/capture.ts` | Anonymous/identified capture, cloud forward, **`ingestTelemetryCollectBatch`** |
-| `packages/analytics/src/server/validate.ts` | `validateTelemetryPayload` — runtime merge: `{ ...properties, ...runtimeContext }` (server wins) |
-| `packages/analytics/src/sanitizer.ts` | Allow/deny lists; **`undefined` values skipped** (not dropped) |
-| `packages/analytics/src/server/config.ts` | `configureServerAnalytics`, `resetServerAnalyticsForTests` |
-| `packages/analytics/src/server/posthog-batch.ts` | `resolvePosthogBatchUrl`, `sendPosthogBatch` |
-| `packages/analytics/src/server/identifiers.ts` | HMAC distinct IDs, MCP session hash |
-| `packages/analytics/src/events.ts` | Event + property name constants |
-| `apps/api/src/lib/configure-server-analytics.ts` | Env → `configureServerAnalytics`, cached instance ID |
-| `apps/api/src/routes/telemetry.ts` | `/status`, `/collect`, `/events` |
-| `apps/api/src/mcp/observability/mcp-analytics.ts` | MCP → PostHog mapping |
-| `apps/api/src/mcp/observability/mcp-analytics-queue.ts` | Bounded async queue (512 depth, 8 in-flight) |
-| `apps/api/src/mcp/observability/mcp-telemetry.ts` | Ops signals + fan-out to analytics |
-| `apps/api/src/mcp/observability/mcp-telemetry-signals.ts` | Signal union type |
-| `packages/dal/src/repositories/telemetry-installation.ts` | `readAnonymousInstanceId`, `getOrCreateAnonymousInstanceId` (no per-event UPDATE) |
+### P0-A — `/collect` authentication
 
-**Deleted:** `apps/api/src/lib/posthog-server.ts` (logic moved to package).
+- New env: `DURABULL_TELEMETRY_COLLECT_SECRET` — shared HMAC signing secret for OSS → cloud `/collect`.
+- `packages/analytics/src/server/collect-auth.ts` — webhook-style `sha256=` signatures with 5-minute tolerance.
+- `/collect` requires valid signature headers; unsigned → **401**.
+- Collect payload includes top-level `runtime` (required). Cloud ingest uses **authenticated client runtime**, not cloud server runtime.
+- OSS forward signs batches and sends `runtime` separately from event properties.
 
----
+**Deploy note:** Cloud and self-hosted installs need matching `DURABULL_TELEMETRY_COLLECT_SECRET` before ship, or OSS→cloud forwarding stops (console warning).
 
-## 3. Completed work (do not redo blindly)
+### P0-B — XFF trust (rate limiting)
 
-### Package structure
+- New env: `TRUST_PROXY` (optional). Auto-enabled when `DURABULL_CLOUD=true`.
+- `getClientKey` / MCP ingress keys ignore `X-Forwarded-For`, `X-Real-IP`, and `CF-Connecting-IP` unless proxy is trusted.
+- Removed production bypass for `unknown-client` — untrusted ingress shares one bucket instead of skipping limits or minting per-spoofed-IP keys.
+- Tests: `apps/api/src/middleware/rate-limit.test.ts` (3 cases).
+- Docs: `security-and-hardening.mdx` updated.
 
-- `packages/analytics` exports: `./server`, `./browser`, `./react` (alias), `./client` (legacy), `./events`, `./sanitizer`.
-- Removed **duplicate** `./events` block in `package.json` (was listed twice).
-- `packages/analytics/src/server/index.ts` exports `resetServerAnalyticsForTests`.
+### P1 (partial) — Single-flight instance ID
 
-### MCP product analytics
-
-- Events in `events.ts`: `mcp_rpc_requested`, `mcp_tool_called`, `mcp_tool_denied`, `mcp_auth_failed`, `mcp_rate_limited`, consent events, etc.
-- `mcp-analytics.ts` wired from auth middleware, policy (RPC: `initialize`, `tools/list` only), mount (tool success/error), audit (denials).
-- **No double `mcp_tool_called` for redaction** — `redaction_applied` / audit signals no-op in analytics switch; `redaction_count` on tool success only.
-- Uses `options.hmacSecret` (not deprecated `getTelemetryHmacSecret` in production path).
-- `Promise.all` for anonymous + identified when both run; dedupe skips anonymous when `shouldDedupeIdentifiedPosthogEvents()` && identified distinct id exists.
-
-### Server capture / routes
-
-- `/collect` returns 404 when `!collectEnabled || !enabled`.
-- `ingestTelemetryCollectBatch` returns `{ error: 'disabled' }` when `!options.enabled`.
-- Collect ingest uses `sendPosthogBatch(..., { mergeRuntime: false })` to avoid cloud host stamping OSS batches incorrectly.
-- `/events` returns **503** when `collectEnabled` but missing PostHog key or HMAC secret.
-- Strict validation on `/events` and `/collect` — unknown events / forbidden properties → **400**.
-- Identified distinct IDs hashed (`hashIdentifiedUserDistinctId`, `hashIdentifiedOrganizationDistinctId`).
-- Cached anonymous instance ID via `telemetryInstallationRepository.readAnonymousInstanceId()` + process cache in `configure-server-analytics.ts`.
-
-### Correctness fixes (verified)
-
-- Sanitizer skips `undefined` optional MCP properties (was causing silent drop of entire events).
-- `validateTelemetryPayload` merge order: server runtime overrides client on `/events`.
-- Telemetry tests split: forbidden props → 400; valid props → 202 + forward.
-- `packages/analytics/src/server/validate.test.ts` added.
-- Dead code removed: `principalToAnalyticsIdentity` in policy middleware; unused `telemetryInstallationRepository` import in `telemetry.ts`; route re-exports of `hashTelemetryIdentifier`.
-- `apps/web/src/routes/consent.tsx` imports `@durabull/analytics/events` + `@durabull/analytics/browser`.
-
-### Review loop status
-
-- **Two** full parallel-code-review cycles run (4× explore subagents each).
-- **Critical/High correctness:** addressed; re-review reported **none** for sanitizer/validate/telemetry/MCP paths after fixes.
-- **Not done:** Security/perf hardening items below (intentionally deferred).
+- `resolveAnonymousInstanceId` deduplicates concurrent DB reads via in-flight promise.
+- Eager warm at `bootstrapServerAnalytics()` in production (non-blocking).
 
 ---
 
-## 4. Remaining work (prioritized for “perfection”)
+## Remaining work (one PR each recommended)
 
-Use `/parallel-code-review` after each batch; fix **Critical/High** before claiming done. User wanted loop until no serious issues — interpret **serious** as Critical + High **correctness** and **High security** in this diff’s scope.
+### P1 — Performance
 
-### P0 — Trust & honest HTTP semantics (correctness + security)
+| Task | Files | Notes |
+|------|-------|-------|
+| Single-flight instance ID | `configure-server-analytics.ts`, `app.ts` | ✅ done this branch |
+| Dedupe/coalesce PostHog when same project | `mcp-analytics.ts`, `capture.ts` | One `sendPosthogBatch` per MCP event when keys match |
+| Remove duplicate connection access DB query | `policy-engine.ts`, `mcp-policy-middleware.ts`, `tools/shared.ts` | Set `mcpResolvedConnection` once after grant |
+| Async `/collect` flush | `telemetry.ts`, `capture.ts` | Bounded worker like MCP analytics queue |
 
-| # | Task | Files | Acceptance criteria |
-|---|------|-------|---------------------|
-| 1 | **Server runtime on `/collect` ingest** | `capture.ts` `ingestTelemetryCollectBatch` | Pass `options.getRuntimeContext()` into `validateTelemetryPayload` for each event (same merge as `/events`). Update `telemetry-collect.test.ts` if tests assumed client-only `authless`/`environment`. |
-| 2 | **Complete `/events` preflight** | `telemetry.ts`, optionally export helper from `capture.ts` | Return **503** when `collectEnabled` but `getDurabullTelemetryCollectConfig(options)` is null (includes **invalid PostHog host**). Today: key+HMAC checked but invalid URL → **202** + silent no-op in capture. Add test mirroring collect “invalid PostHog batch host”. |
-| 3 | **Fix self-hosted forward runtime merge** | `capture.ts` `forwardAnonymousToCloudCollect` ~95–98 | Use `...input.properties, ...input.runtimeContext` (match validate). Add unit or route test. |
-| 4 | **PostHog host allowlist** | `posthog-batch.ts`, align `app.ts` `getPosthogApiHost` | HTTPS only; allowlist `*.posthog.com` / `*.i.posthog.com`; reject private/link-local IPs. Test invalid host → 503 on collect and events. |
+### P2 — Security hardening
 
-### P1 — MCP hot path & cost (performance)
+| Task | Notes |
+|------|-------|
+| Require `DURABULL_TELEMETRY_HMAC_SECRET` in prod collect mode | Remove `BETTER_AUTH_SECRET` fallback |
+| Clamp/ignore client `timestamp` on collect | Anti-replay enrichment |
+| Browser `client.ts` runtime merge | Before `/events` |
 
-| # | Task | Files | Notes |
-|---|------|-------|-------|
-| 5 | **Dedupe/coalesce PostHog** | `mcp-analytics.ts`, `capture.ts` | When same project/URL/key: one `sendPosthogBatch` per MCP event. Test: `dedupeIdentifiedPosthogEvents: true` → only identified capture called (`mcp-analytics.test.ts` currently mocks dedupe false). |
-| 6 | **Remove duplicate connection access DB query** | `policy-engine.ts`, `mcp-policy-middleware.ts`, `tools/shared.ts` | Policy already calls `canDelegatedUserAccessConnection`; middleware calls it again in `resolveConnectionForPrincipal`. Set `mcpResolvedConnection` once after grant. |
-| 7 | **Single-flight instance ID** | `configure-server-analytics.ts` | Prevent thundering herd on cold start; optional eager resolve in `app.ts` at bootstrap. |
-| 8 | **Async `/collect`** | `telemetry.ts`, `capture.ts` | Return 202 immediately; flush via bounded worker (pattern: `mcp-analytics-queue.ts`). |
+### P3 — Maintainability
 
-### P2 — Security hardening (separate PR acceptable)
-
-| # | Task | Notes |
-|---|------|-------|
-| 9 | Require `DURABULL_TELEMETRY_HMAC_SECRET` in production collect mode | Remove `BETTER_AUTH_SECRET` fallback in `configure-server-analytics.ts` |
-| 10 | Rate limit: trust `X-Forwarded-For` only when proxy trusted | `apps/api/src/middleware/rate-limit.ts` |
-| 11 | `/collect` authentication | Signed batches or install token — larger design |
-| 12 | Browser `client.ts` runtime merge | `...(properties), ...runtimeContext` before `/events` |
-| 13 | Clamp or ignore client `timestamp` on collect | `telemetry.ts`, `capture.ts` |
-
-### P3 — Maintainability (readability review)
-
-| # | Task |
-|---|------|
-| 14 | Root `packages/analytics/src/index.ts`: stop re-exporting full browser SDK; migrate web to `/browser` |
-| 15 | Unify `McpPrincipalType` from `@durabull/dal` in MCP modules |
-| 16 | Extract shared `createBoundedAsyncQueue` (audit + analytics) |
-| 17 | Remove dead `DEFAULT_POSTHOG_BATCH_HOST` from `server/config.ts`; dedupe with `posthog-batch.ts` |
-| 18 | Add `AnalyticsProperties.REDACTION_COUNT`; use in `mcp-analytics.ts` |
-| 19 | Remove deprecated `getTelemetryHmacSecret` from public `server/index.ts` exports; update test mocks |
-| 20 | Document which `McpTelemetrySignal` values are counter/log-only vs PostHog |
-
-### P4 — Test gaps to close
-
-- `/events` 503 when collect misconfigured (secrets) — **partially done**; extend for invalid host.
-- `/collect` 502 (`upstream_rejected`) and 503 (`upstream_unavailable`) — mock `fetch` failures.
-- MCP dedupe integration test (real `validateTelemetryPayload` path, not only mocks).
-- `capture.ts` / `posthog-batch.ts` unit tests (optional but valuable).
-- Forward path runtime merge test.
+See original handoff §4 P3 table (barrel exports, `McpPrincipalType`, shared queue helper, etc.)
 
 ---
 
-## 5. Verification commands
+## Verification commands
 
 ```bash
-# Core regression suite (fast)
 bun test \
+  packages/analytics/src/server/collect-auth.test.ts \
   packages/analytics/src/server/validate.test.ts \
   packages/analytics/src/server/identifiers.test.ts \
+  packages/analytics/src/server/posthog-batch.test.ts \
   apps/api/src/routes/telemetry.test.ts \
   apps/api/src/routes/telemetry-collect.test.ts \
-  apps/api/src/mcp/observability/mcp-analytics.test.ts
-
-# Broader API if touching app bootstrap / middleware
-bun test apps/api/src/app.test.ts
-
-# Typecheck analytics package
-cd packages/analytics && bun run check  # or monorepo equivalent
+  apps/api/src/mcp/observability/mcp-analytics.test.ts \
+  apps/api/src/middleware/rate-limit.test.ts
 ```
 
-**Expected:** 23 pass in the core suite (as of handoff date).
+**Expected:** 46 pass.
+
+**Gotcha:** `apps/api/src/app.test.ts` may fail locally with `CI=true` or missing `MCP_AUTHLESS_BEARER_TOKEN` — not a telemetry regression.
 
 ---
 
-## 6. Environment & configuration reference
+## Environment reference
 
 | Variable | Purpose |
 |----------|---------|
-| `DURABULL_TELEMETRY_POSTHOG_KEY` | Durabull product analytics PostHog key |
-| `DURABULL_TELEMETRY_POSTHOG_HOST` | Batch ingest host |
-| `DURABULL_TELEMETRY_HMAC_SECRET` | HMAC for distinct_id / instance_key (falls back to `BETTER_AUTH_SECRET` today — **change in P2**) |
-| `POSTHOG_KEY` / `POSTHOG_HOST` | App/customer PostHog (identified events) |
-| `DURABULL_CLOUD` / managed host | Enables `/collect` on cloud API |
-| `MCP_TELEMETRY_LOG` | Set `false` to disable sync stdout MCP telemetry |
-
-**Dedupe:** `dedupeIdentifiedPosthogEvents` in `configure-server-analytics.ts` when app and Durabull telemetry keys match (cloud).
+| `DURABULL_TELEMETRY_COLLECT_SECRET` | HMAC signing for `/collect` batches (OSS + cloud) |
+| `TRUST_PROXY` | Honor forwarding headers for rate limits (auto on `DURABULL_CLOUD`) |
+| `DURABULL_TELEMETRY_HMAC_SECRET` | distinct_id / instance_key HMAC |
+| `DURABULL_TELEMETRY_POSTHOG_KEY` | Durabull product PostHog key |
+| `DURABULL_TELEMETRY_POSTHOG_HOST` | Batch ingest host (HTTPS allowlist) |
+| `DURABULL_CLOUD` | Enables `/collect` on cloud API + trusted proxy |
 
 ---
 
-## 7. Non-obvious behaviors (read before changing)
+## Lessons
 
-1. **`validateTelemetryPayload` failure in capture** — `captureAnonymousServerEvent` / `captureIdentifiedServerEvent` return void on invalid input (no throw). Route-level validation is required for honest HTTP status codes.
-
-2. **`/collect` vs `/events` validation** — After P0 #1, both should merge server runtime. Until then, collect accepts client `authless`/`environment` (documented High security finding).
-
-3. **Double PostHog events** — When `dedupeIdentifiedPosthogEvents` is false, each identified MCP event sends **two** HTTP requests (anonymous + identified). Intentional for separate projects; bug if same project.
-
-4. **RPC analytics** — `recordMcpRpcAnalytics` from policy middleware **without** identity for `initialize` / `tools/list`; session id falls back to `'mcp-server'`. Product metrics are coarse unless you pass session/principal (P2/low).
-
-5. **MCP analytics queue** — Drops silently at depth 512; audit queue logs drops. Add metric if fixing P2.
-
-6. **Barrel exports** — Workspace rule: avoid new barrel files; prefer direct imports. Do not add new `index.ts` re-exports in app code.
-
-7. **Commits** — User rules: **only commit when explicitly asked**. This handoff is uncommitted work on `main`.
-
-8. **Linear** — Tie PR to Linear issue when creating PR (workspace rule).
+- **Do not `git stash` to peek while holding uncommitted work** — a failed pop can silently strip edits. Use a worktree or WIP commit instead.
 
 ---
 
-## 8. Suggested workflow for next agent
+## Definition of done (#109)
 
-1. Read this file + skim `packages/analytics/src/server/capture.ts` and `apps/api/src/mcp/observability/mcp-analytics.ts`.
-2. Implement **P0 items 1–4** in order; run verification commands after each.
-3. Run **`/parallel-code-review`** (four explore subagents) on full file list from `git diff --name-only` + untracked list in §9.
-4. Fix remaining **Critical/High**; repeat review until clean or only accepted architectural deferrals documented in PR.
-5. Implement **P1** if time; otherwise list in PR “Follow-up”.
-6. Update `tasks/todo.md` with checkboxes; add `tasks/lessons.md` entry if user corrects anything.
-
-### Parallel review file list (copy-paste)
-
-```
-apps/api/src/app.ts
-apps/api/src/lib/configure-server-analytics.ts
-apps/api/src/mcp/audit/mcp-audit.ts
-apps/api/src/mcp/auth/mcp-session-middleware.ts
-apps/api/src/mcp/json-rpc-tool-call.ts
-apps/api/src/mcp/mount.ts
-apps/api/src/mcp/observability/mcp-analytics-queue.ts
-apps/api/src/mcp/observability/mcp-analytics.ts
-apps/api/src/mcp/observability/mcp-analytics.test.ts
-apps/api/src/mcp/observability/mcp-telemetry-signals.ts
-apps/api/src/mcp/observability/mcp-telemetry.ts
-apps/api/src/mcp/policy/mcp-policy-middleware.ts
-apps/api/src/routes/telemetry-collect.test.ts
-apps/api/src/routes/telemetry.test.ts
-apps/api/src/routes/telemetry.ts
-apps/web/src/routes/consent.tsx
-packages/analytics/package.json
-packages/analytics/src/browser.ts
-packages/analytics/src/events.ts
-packages/analytics/src/index.ts
-packages/analytics/src/react.ts
-packages/analytics/src/sanitizer.ts
-packages/analytics/src/server/capture.ts
-packages/analytics/src/server/config.ts
-packages/analytics/src/server/identifiers.ts
-packages/analytics/src/server/index.ts
-packages/analytics/src/server/posthog-batch.ts
-packages/analytics/src/server/validate.ts
-packages/analytics/src/server/validate.test.ts
-packages/dal/src/repositories/telemetry-installation.ts
-packages/mcp/src/request-context.ts
-packages/mcp/src/tools/register-read-tools.ts
-```
-
----
-
-## 9. PR description starter
-
-**Title:** feat(analytics): server capture package + MCP PostHog product telemetry
-
-**Summary:**
-- Add `@durabull/analytics/server` for validated, HMAC-scoped PostHog capture and cloud collect ingest.
-- Emit MCP product events (`mcp_tool_called`, auth failures, rate limits, etc.) with bounded async queue.
-- Harden `/events` validation and fail-closed when collect is misconfigured.
-
-**Test plan:**
-- [ ] `bun test` on telemetry + mcp-analytics + server validate/identifiers
-- [ ] Manual: MCP tool call on dev stack → events in PostHog (anonymous + identified as configured)
-- [ ] `/collect` rejects spoofed forbidden keys; server runtime applied after P0
-- [ ] Invalid PostHog host returns 503 on `/events` and `/collect` after P0
-
-**Known follow-ups:** P1–P3 table above; `/collect` signing not in scope unless P2 #11 done.
-
----
-
-## 10. Conversation context
-
-- Prior transcript: `.cursor/projects/Users-gregg-dev-durabull/agent-transcripts/d7d60e35-aacc-4edb-aaa8-52f8e3463c64/` (analytics consolidation + review-fix loop).
-- User attached skills: `loop` (monitored shell for recurring review), `parallel-code-review` (4× explore Task tool).
-
-**Definition of done (perfection):** P0 complete + parallel review shows no Critical/High correctness or High security findings in changed files + all tests green + PR description documents accepted deferrals.
+P0 complete ✅ — parallel review + PR still needed before merge claim.

--- a/tooling/env/src/index.ts
+++ b/tooling/env/src/index.ts
@@ -78,6 +78,8 @@ const envSchema = z.object({
   GITHUB_OAUTH_CLIENT_ID: optionalString,
   GITHUB_OAUTH_CLIENT_SECRET: optionalString,
   DISABLE_RATE_LIMIT: optionalBoolean,
+  /** When true, honor X-Forwarded-For / X-Real-IP / CF-Connecting-IP for rate limiting. Auto-enabled on Durabull Cloud. */
+  TRUST_PROXY: optionalBoolean,
   CI: optionalBoolean,
   ASSET_PRELOAD_MAX_SIZE: optionalNonNegativeInt,
   ASSET_PRELOAD_VERBOSE_LOGGING: optionalBoolean,
@@ -85,6 +87,7 @@ const envSchema = z.object({
   POSTHOG_KEY: optionalString,
   POSTHOG_HOST: optionalString,
   DURABULL_TELEMETRY_HMAC_SECRET: optionalString,
+  DURABULL_TELEMETRY_COLLECT_SECRET: optionalString,
   DURABULL_TELEMETRY_POSTHOG_HOST: optionalString,
   DURABULL_TELEMETRY_POSTHOG_KEY: optionalString,
   DURABULL_CLOUD: optionalBoolean,


### PR DESCRIPTION
## Summary

Closes the #109 security/correctness gap left after #108 (telemetry P0 hardening):

- **P0-A — `/collect` authentication:** HMAC-signed batches via `DURABULL_TELEMETRY_COLLECT_SECRET` (`collect-auth.ts`). Unsigned or invalid signatures return **401**. Collect payload requires top-level `runtime`; cloud ingest uses the authenticated client runtime so OSS→cloud forwarding preserves honest deployment attribution.
- **P0-B — Rate-limit proxy trust:** Forwarding headers (`X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`) are honored only when `TRUST_PROXY=true` or `DURABULL_CLOUD=true`. On untrusted ingress, spoofed XFF cannot mint fresh rate-limit keys. When trusted, priority is CF-Connecting-IP → X-Real-IP → rightmost XFF hop (not client-spoofable leftmost).
- **P1 (partial):** Single-flight anonymous instance ID resolution with non-blocking eager bootstrap warm.
- **Review-loop fixes:** Decouple collect signing from PostHog ingest config (cloud `/events` no longer blocked by missing collect secret), fire-and-forget `/events` capture (DB blips return 202 not 500), correct `apiRateLimiter` JSON `retryAfter` (60s), clear poisoned instance-id inflight promises on DB failure.

## Deploy notes

| Variable | Required when |
|----------|----------------|
| `DURABULL_TELEMETRY_COLLECT_SECRET` | OSS→cloud telemetry forwarding **and** cloud `/collect` ingest (same value on both sides) |
| `TRUST_PROXY=true` | Self-hosted behind nginx/ALB that sets forwarding headers |

Without matching `DURABULL_TELEMETRY_COLLECT_SECRET`, OSS forward is skipped (console warning) and cloud `/collect` returns 401/503.

## Test plan

- [x] `bun test` — collect-auth, telemetry routes, mcp-analytics, posthog-batch, rate-limit (**48 pass**)
- [x] Two `/parallel-code-review` rounds — no remaining Critical/High findings
- [ ] Manual: OSS install forwards signed batch → cloud `/collect` accepts; PostHog shows correct `authless`/`persistence` runtime
- [ ] Manual: unsigned `/collect` on cloud returns 401
- [ ] Manual: spoofed `X-Forwarded-For` without `TRUST_PROXY` shares one rate-limit bucket (no bypass)

## Follow-ups (deferred)

- P1: PostHog dedupe/coalesce, duplicate connection access query, async `/collect` flush
- P2: require dedicated `DURABULL_TELEMETRY_HMAC_SECRET` (drop `BETTER_AUTH_SECRET` fallback), client timestamp clamp, signature replay LRU
- P3: maintainability cleanups (see `tasks/handoff-analytics-mcp-telemetry.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added signed telemetry collection using HMAC authentication for enhanced security
  * Introduced trusted proxy support to improve rate limit accuracy in reverse proxy deployments

* **Bug Fixes**
  * Improved rate limiting to properly validate client IPs through trusted proxy headers
  * Made anonymous event capture non-blocking to prevent telemetry from affecting application performance

* **Documentation**
  * Updated security hardening guide with proxy configuration guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->