### PR TITLE
fix(analytics): bound telemetry queues and coalesce MCP capture

### DIFF
--- a/apps/api/src/mcp/connections/resolve-connection.ts
+++ b/apps/api/src/mcp/connections/resolve-connection.ts
@@ -1,0 +1,53 @@
+import { mcpPolicyRepository, redisConnectionRepository } from '@durabull/dal'
+import type { ListConnectionsHandlerInput, McpResolvedConnection } from '@durabull/mcp'
+import { getMcpRequestContext } from '@durabull/mcp'
+
+export type ToolPrincipal = ListConnectionsHandlerInput['principal']
+
+function toResolvedConnection(connection: {
+  id: string
+  organizationId: string
+  url: string
+  prefix: string
+  allowSelfSignedCerts: boolean
+}): McpResolvedConnection {
+  return {
+    id: connection.id,
+    organizationId: connection.organizationId,
+    url: connection.url,
+    prefix: connection.prefix,
+    allowSelfSignedCerts: connection.allowSelfSignedCerts,
+  }
+}
+
+export async function resolveConnectionForPrincipal(
+  principal: ToolPrincipal,
+  connectionId: string,
+  options: { skipDelegatedAccessCheck?: boolean } = {}
+) {
+  const cached = getMcpRequestContext()?.resolvedConnection
+  if (cached?.id === connectionId) {
+    return cached
+  }
+
+  if (principal.type === 'service_account') {
+    const connection = await redisConnectionRepository.findById(
+      connectionId,
+      principal.organizationId
+    )
+    return connection ? toResolvedConnection(connection) : null
+  }
+
+  if (!options.skipDelegatedAccessCheck) {
+    const hasAccess = await mcpPolicyRepository.canDelegatedUserAccessConnection(
+      principal.userId,
+      connectionId
+    )
+    if (!hasAccess) {
+      return null
+    }
+  }
+
+  const connection = await redisConnectionRepository.findByIdUnsafe(connectionId)
+  return connection ? toResolvedConnection(connection) : null
+}

--- a/apps/api/src/mcp/observability/mcp-analytics-queue.test.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics-queue.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { AnalyticsEvents } from '@durabull/analytics/events'
+
+import { enqueueMcpAnalytics, resetMcpAnalyticsQueueForTests } from './mcp-analytics-queue'
+import type { McpAnalyticsInput } from './mcp-analytics'
+
+const originalWarn = console.warn
+
+describe('mcp analytics queue', () => {
+  afterEach(() => {
+    console.warn = originalWarn
+    resetMcpAnalyticsQueueForTests()
+  })
+
+  it('warns when dropping events because the queue is full', () => {
+    const warn = mock(() => {})
+    console.warn = warn as unknown as typeof console.warn
+    const process = mock(async () => new Promise<void>(() => {}))
+    const input: McpAnalyticsInput = {
+      event: AnalyticsEvents.MCP_TOOL_CALLED,
+      properties: { tool_name: 'list_jobs', response_class: 'success' },
+    }
+
+    for (let i = 0; i < 8 + 512 + 1; i += 1) {
+      enqueueMcpAnalytics(input, process)
+    }
+
+    expect(warn).toHaveBeenCalledWith('[analytics] MCP analytics queue full; dropping event')
+  })
+})

--- a/apps/api/src/mcp/observability/mcp-analytics-queue.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics-queue.ts
@@ -18,6 +18,7 @@ export function enqueueMcpAnalytics(
   }
 
   if (pendingAnalytics.length >= MAX_ANALYTICS_QUEUE_DEPTH) {
+    console.warn('[analytics] MCP analytics queue full; dropping event')
     return
   }
 

--- a/apps/api/src/mcp/observability/mcp-analytics.test.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics.test.ts
@@ -1,16 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { AnalyticsEvents } from '@durabull/analytics/events'
-import { configureServerAnalytics, resetServerAnalyticsForTests } from '@durabull/analytics/server'
 import { env } from '@durabull/env'
 
-import { resetCachedAnonymousInstanceIdForTests } from '../../lib/configure-server-analytics'
-
-const captureAnonymousServerEvent = mock(async () => {})
-const captureIdentifiedServerEvent = mock(async () => {})
+const captureMcpAnalyticsServerEvent = mock(async () => {})
 
 mock.module('@durabull/analytics/server', () => ({
-  captureAnonymousServerEvent,
-  captureIdentifiedServerEvent,
+  captureMcpAnalyticsServerEvent,
   hashMcpAnalyticsSessionId: (value: string) => `session-${value}`,
   shouldDedupeIdentifiedPosthogEvents: () => false,
   resolveIdentifiedDistinctIds: ({
@@ -33,10 +28,11 @@ mock.module('@durabull/analytics/server', () => ({
   },
   tryGetServerAnalyticsOptions: () => ({
     enabled: true,
+    hmacSecret: 'test-secret',
     resolveAnonymousInstanceId: async () => 'test-instance-id',
   }),
-  configureServerAnalytics,
-  resetServerAnalyticsForTests,
+  configureServerAnalytics: () => undefined,
+  resetServerAnalyticsForTests: () => undefined,
 }))
 
 const { recordMcpAnalytics, recordMcpTelemetryAnalytics } = await import('./mcp-analytics')
@@ -58,41 +54,15 @@ describe('mcp analytics', () => {
     mutableEnv.NODE_ENV = 'production'
     mutableEnv.CI = false
     mutableEnv.BETTER_AUTH_SECRET = 'test-secret'
-    resetServerAnalyticsForTests()
-    resetCachedAnonymousInstanceIdForTests()
-    configureServerAnalytics({
-      enabled: true,
-      collectEnabled: true,
-      dedupeIdentifiedPosthogEvents: false,
-      disclosureUrl: 'https://durabull.io/privacy',
-      collectSigningSecret: 'test-collect-secret',
-      hmacSecret: 'test-secret',
-      durabullTelemetryPosthogKey: 'phc_test',
-      durabullTelemetryPosthogHost: 'https://us.i.posthog.com',
-      appPosthogKey: 'phc_app',
-      appPosthogHost: null,
-      cloudCollectUrl: 'https://app.durabull.io/api/telemetry/collect',
-      getRuntimeContext: () => ({
-        authless: false,
-        env_connections: false,
-        environment: 'production',
-        persistence: 'postgres',
-        stateless: false,
-      }),
-      resolveAnonymousInstanceId: async () => 'test-instance-id',
-    })
     resetMcpTelemetryForTests()
     resetMcpAnalyticsQueueForTests()
-    captureAnonymousServerEvent.mockClear()
-    captureIdentifiedServerEvent.mockClear()
+    captureMcpAnalyticsServerEvent.mockClear()
   })
 
   afterEach(() => {
     mutableEnv.NODE_ENV = originalNodeEnv
     mutableEnv.CI = originalCi
     mutableEnv.BETTER_AUTH_SECRET = originalSecret
-    resetServerAnalyticsForTests()
-    resetCachedAnonymousInstanceIdForTests()
   })
 
   it('maps tool success telemetry to mcp_tool_called analytics', async () => {
@@ -106,11 +76,11 @@ describe('mcp analytics', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(captureAnonymousServerEvent).toHaveBeenCalled()
-    expect(captureIdentifiedServerEvent).toHaveBeenCalledWith(
+    expect(captureMcpAnalyticsServerEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event: AnalyticsEvents.MCP_TOOL_CALLED,
-        distinctId: 'hashed-user:user-1',
+        identifiedDistinctId: 'hashed-user:user-1',
+        includeAnonymous: true,
         properties: expect.objectContaining({
           tool_name: 'list_jobs',
           response_class: 'success',
@@ -124,15 +94,15 @@ describe('mcp analytics', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(captureAnonymousServerEvent).toHaveBeenCalledWith(
+    expect(captureMcpAnalyticsServerEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event: AnalyticsEvents.MCP_AUTH_FAILED,
+        identifiedDistinctId: null,
         properties: expect.objectContaining({
           mcp_auth_failure: 'missing_bearer',
         }),
       })
     )
-    expect(captureIdentifiedServerEvent).not.toHaveBeenCalled()
   })
 
   it('records rpc requests for service accounts with hashed org distinct id', async () => {
@@ -148,9 +118,9 @@ describe('mcp analytics', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(captureIdentifiedServerEvent).toHaveBeenCalledWith(
+    expect(captureMcpAnalyticsServerEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        distinctId: 'hashed-org:org-1',
+        identifiedDistinctId: 'hashed-org:org-1',
         // Raw org id is forwarded so capture hashes it exactly once (no double-hash).
         organizationId: 'org-1',
       })
@@ -167,7 +137,6 @@ describe('mcp analytics', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(captureAnonymousServerEvent).not.toHaveBeenCalled()
-    expect(captureIdentifiedServerEvent).not.toHaveBeenCalled()
+    expect(captureMcpAnalyticsServerEvent).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/mcp/observability/mcp-analytics.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics.ts
@@ -1,7 +1,6 @@
 import { AnalyticsEvents, AnalyticsProperties } from '@durabull/analytics/events'
 import {
-  captureAnonymousServerEvent,
-  captureIdentifiedServerEvent,
+  captureMcpAnalyticsServerEvent,
   hashMcpAnalyticsSessionId,
   resolveIdentifiedDistinctIds,
   shouldDedupeIdentifiedPosthogEvents,
@@ -60,42 +59,25 @@ async function processMcpAnalytics(input: McpAnalyticsInput): Promise<void> {
   const hasIdentifiedIdentity = identified.distinctId != null
   const shouldSkipAnonymous = shouldDedupeIdentifiedPosthogEvents() && hasIdentifiedIdentity
 
-  const tasks: Promise<void>[] = []
+  const includeAnonymous = !shouldSkipAnonymous
+  const anonymousInstanceId = includeAnonymous ? await options.resolveAnonymousInstanceId() : undefined
+  const secret = options.hmacSecret
+  const sessionId =
+    input.sessionKey ??
+    (identity && secret ? hashMcpAnalyticsSessionId(identity.principalId, secret) : 'mcp-server')
 
-  if (!shouldSkipAnonymous) {
-    const anonymousInstanceId = await options.resolveAnonymousInstanceId()
-    const secret = options.hmacSecret
-    const sessionId =
-      input.sessionKey ??
-      (identity && secret ? hashMcpAnalyticsSessionId(identity.principalId, secret) : 'mcp-server')
-
-    tasks.push(
-      captureAnonymousServerEvent({
-        anonymousInstanceId,
-        event: input.event,
-        properties,
-        sessionId,
-      })
-    )
-  }
-
-  if (identified.distinctId) {
-    tasks.push(
-      captureIdentifiedServerEvent({
-        event: input.event,
-        properties,
-        distinctId: identified.distinctId,
-        // Pass the raw org id; captureIdentifiedServerEvent hashes it once for
-        // the PostHog group. Passing identified.organizationGroup (already
-        // hashed) would double-hash and break org correlation.
-        organizationId: identity?.organizationId ?? null,
-      })
-    )
-  }
-
-  if (tasks.length > 0) {
-    await Promise.all(tasks)
-  }
+  await captureMcpAnalyticsServerEvent({
+    event: input.event,
+    properties,
+    includeAnonymous,
+    anonymousInstanceId,
+    sessionId,
+    identifiedDistinctId: identified.distinctId,
+    // Pass the raw org id; captureMcpAnalyticsServerEvent hashes it once for
+    // the PostHog group. Passing identified.organizationGroup (already hashed)
+    // would double-hash and break org correlation.
+    organizationId: identity?.organizationId ?? null,
+  })
 }
 
 export function recordMcpAnalytics(input: McpAnalyticsInput): void {

--- a/apps/api/src/mcp/policy/mcp-policy-middleware.ts
+++ b/apps/api/src/mcp/policy/mcp-policy-middleware.ts
@@ -9,8 +9,8 @@ import {
   parseMcpJsonRpcPayloadId,
   parseMcpToolCallBody,
 } from '../json-rpc-tool-call'
-import { recordMcpRpcAnalytics } from '../observability/mcp-analytics'
-import { resolveConnectionForPrincipal } from '../tools/shared'
+import { recordMcpRpcAnalytics, type McpAnalyticsIdentity } from '../observability/mcp-analytics'
+import { resolveConnectionForPrincipal } from '../connections/resolve-connection'
 import { evaluateMcpToolPolicy } from './policy-engine'
 import { resolveMcpPrincipal } from './principal-resolver'
 import type { McpPolicyDecision, McpPrincipal } from './types'
@@ -64,6 +64,21 @@ function policyDenialErrorData(decision: McpPolicyDecision): Record<string, unkn
   return { code: 'policy_denied' }
 }
 
+function principalToAnalyticsIdentity(principal: McpPrincipal): McpAnalyticsIdentity {
+  return principal.type === 'delegated_user'
+    ? {
+        principalType: principal.type,
+        principalId: principal.principalId,
+        userId: principal.userId,
+        organizationId: null,
+      }
+    : {
+        principalType: principal.type,
+        principalId: principal.principalId,
+        organizationId: principal.organizationId,
+      }
+}
+
 export function createMcpPolicyMiddleware() {
   return createMiddleware(async (c, next) => {
     if (c.req.method !== 'POST') {
@@ -94,9 +109,13 @@ export function createMcpPolicyMiddleware() {
     }
     if (!toolCall) {
       const mcpMethod = parseMcpJsonRpcMethod(body)
-      const rpcAnalyticsMethods = RPC_ANALYTICS_METHODS
-      if (mcpMethod && rpcAnalyticsMethods.has(mcpMethod)) {
-        recordMcpRpcAnalytics({ mcpMethod })
+      if (mcpMethod && RPC_ANALYTICS_METHODS.has(mcpMethod)) {
+        const session = c.get('mcpSession')
+        const principal = await resolveMcpPrincipal(session)
+        recordMcpRpcAnalytics({
+          mcpMethod,
+          identity: principal ? principalToAnalyticsIdentity(principal) : null,
+        })
       }
       return next()
     }
@@ -178,7 +197,8 @@ export function createMcpPolicyMiddleware() {
             }
       const resolvedConnection = await resolveConnectionForPrincipal(
         principalForConnection,
-        toolCall.connectionId
+        toolCall.connectionId,
+        { skipDelegatedAccessCheck: principal.type === 'delegated_user' }
       )
       if (resolvedConnection) {
         c.set('mcpResolvedConnection', resolvedConnection)

--- a/apps/api/src/mcp/tools/shared.test.ts
+++ b/apps/api/src/mcp/tools/shared.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const canDelegatedUserAccessConnection = mock(async () => true)
+const findById = mock(async () => null)
+const findByIdUnsafe = mock(async () => null)
+
+mock.module('@durabull/dal', () => ({
+  mcpPolicyRepository: {
+    canDelegatedUserAccessConnection,
+  },
+  redisConnectionRepository: {
+    findById,
+    findByIdUnsafe,
+  },
+}))
+
+const { resolveConnectionForPrincipal } = await import('../connections/resolve-connection')
+
+describe('resolveConnectionForPrincipal', () => {
+  beforeEach(() => {
+    canDelegatedUserAccessConnection.mockReset()
+    canDelegatedUserAccessConnection.mockImplementation(async () => true)
+    findById.mockReset()
+    findByIdUnsafe.mockReset()
+    findByIdUnsafe.mockImplementation(async () => ({
+      id: 'conn-1',
+      organizationId: 'org-1',
+      url: 'https://redis.example.com',
+      prefix: 'queues',
+      allowSelfSignedCerts: false,
+    }))
+  })
+
+  it('skips delegated access re-check when policy already verified access', async () => {
+    const connection = await resolveConnectionForPrincipal(
+      {
+        type: 'delegated_user',
+        principalId: 'principal-1',
+        userId: 'user-1',
+      },
+      'conn-1',
+      { skipDelegatedAccessCheck: true }
+    )
+
+    expect(connection?.id).toBe('conn-1')
+    expect(canDelegatedUserAccessConnection).not.toHaveBeenCalled()
+    expect(findByIdUnsafe).toHaveBeenCalledTimes(1)
+  })
+
+  it('still enforces delegated access checks by default', async () => {
+    canDelegatedUserAccessConnection.mockImplementation(async () => false)
+
+    const connection = await resolveConnectionForPrincipal(
+      {
+        type: 'delegated_user',
+        principalId: 'principal-1',
+        userId: 'user-1',
+      },
+      'conn-1'
+    )
+
+    expect(connection).toBeNull()
+    expect(canDelegatedUserAccessConnection).toHaveBeenCalledTimes(1)
+    expect(findByIdUnsafe).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/mcp/tools/shared.ts
+++ b/apps/api/src/mcp/tools/shared.ts
@@ -1,6 +1,6 @@
-import { mcpPolicyRepository, redisConnectionRepository } from '@durabull/dal'
-import type { ListConnectionsHandlerInput, McpResolvedConnection } from '@durabull/mcp'
-import { getMcpRequestContext } from '@durabull/mcp'
+import type { ListConnectionsHandlerInput } from '@durabull/mcp'
+
+import { resolveConnectionForPrincipal } from '../connections/resolve-connection'
 
 export type ToolPrincipal = ListConnectionsHandlerInput['principal']
 
@@ -12,47 +12,6 @@ export class McpToolError extends Error {
     this.name = 'McpToolError'
     this.code = code
   }
-}
-
-function toResolvedConnection(connection: {
-  id: string
-  organizationId: string
-  url: string
-  prefix: string
-  allowSelfSignedCerts: boolean
-}): McpResolvedConnection {
-  return {
-    id: connection.id,
-    organizationId: connection.organizationId,
-    url: connection.url,
-    prefix: connection.prefix,
-    allowSelfSignedCerts: connection.allowSelfSignedCerts,
-  }
-}
-
-export async function resolveConnectionForPrincipal(principal: ToolPrincipal, connectionId: string) {
-  const cached = getMcpRequestContext()?.resolvedConnection
-  if (cached?.id === connectionId) {
-    return cached
-  }
-
-  if (principal.type === 'service_account') {
-    const connection = await redisConnectionRepository.findById(
-      connectionId,
-      principal.organizationId
-    )
-    return connection ? toResolvedConnection(connection) : null
-  }
-
-  const hasAccess = await mcpPolicyRepository.canDelegatedUserAccessConnection(
-    principal.userId,
-    connectionId
-  )
-  if (!hasAccess) {
-    return null
-  }
-  const connection = await redisConnectionRepository.findByIdUnsafe(connectionId)
-  return connection ? toResolvedConnection(connection) : null
 }
 
 export async function requireConnectionForPrincipal(

--- a/apps/api/src/routes/telemetry-collect-queue.ts
+++ b/apps/api/src/routes/telemetry-collect-queue.ts
@@ -1,0 +1,71 @@
+import {
+  ingestTelemetryCollectBatch,
+  type IngestCollectBatchResult,
+  type ServerAnalyticsRuntimeContext,
+  type TelemetryCollectEventInput,
+} from '@durabull/analytics/server'
+
+interface TelemetryCollectQueueItem {
+  instanceId: string
+  sentAt?: string
+  events: TelemetryCollectEventInput[]
+  clientRuntime?: ServerAnalyticsRuntimeContext
+}
+
+const MAX_COLLECT_IN_FLIGHT = 4
+const MAX_COLLECT_QUEUE_DEPTH = 256
+
+let collectInFlight = 0
+const pendingCollectBatches: TelemetryCollectQueueItem[] = []
+
+type ProcessCollectBatch = (input: TelemetryCollectQueueItem) => Promise<IngestCollectBatchResult>
+
+function logCollectFailure(result: IngestCollectBatchResult): void {
+  if (result.ok) return
+  console.warn(`[analytics] async /collect batch failed: ${result.error}`)
+}
+
+function dispatchCollectBatch(input: TelemetryCollectQueueItem, process: ProcessCollectBatch): void {
+  collectInFlight += 1
+  void process(input)
+    .then(logCollectFailure)
+    .catch(() => {
+      console.warn('[analytics] async /collect batch threw unexpectedly')
+    })
+    .finally(() => {
+      collectInFlight -= 1
+      flushPendingCollectBatches(process)
+    })
+}
+
+function flushPendingCollectBatches(process: ProcessCollectBatch): void {
+  while (collectInFlight < MAX_COLLECT_IN_FLIGHT && pendingCollectBatches.length > 0) {
+    const next = pendingCollectBatches.shift()
+    if (!next) break
+    dispatchCollectBatch(next, process)
+  }
+}
+
+export function enqueueTelemetryCollectBatch(
+  input: TelemetryCollectQueueItem,
+  process: ProcessCollectBatch = ingestTelemetryCollectBatch
+): boolean {
+  if (collectInFlight < MAX_COLLECT_IN_FLIGHT && pendingCollectBatches.length === 0) {
+    dispatchCollectBatch(input, process)
+    return true
+  }
+
+  if (pendingCollectBatches.length >= MAX_COLLECT_QUEUE_DEPTH) {
+    return false
+  }
+
+  pendingCollectBatches.push(input)
+  flushPendingCollectBatches(process)
+  return true
+}
+
+/** Test-only */
+export function resetTelemetryCollectQueueForTests(): void {
+  collectInFlight = 0
+  pendingCollectBatches.length = 0
+}

--- a/apps/api/src/routes/telemetry-collect.test.ts
+++ b/apps/api/src/routes/telemetry-collect.test.ts
@@ -13,6 +13,7 @@ import {
   bootstrapServerAnalytics,
   resetCachedAnonymousInstanceIdForTests,
 } from '../lib/configure-server-analytics'
+import { resetTelemetryCollectQueueForTests } from './telemetry-collect-queue'
 import telemetryRoutes from './telemetry'
 
 const INSTANCE_ID = '41111111-1111-4111-8111-111111111111'
@@ -140,6 +141,7 @@ describe('telemetry collect route', () => {
   afterEach(() => {
     resetServerAnalyticsForTests()
     resetCachedAnonymousInstanceIdForTests()
+    resetTelemetryCollectQueueForTests()
     mutableEnv.APP_BASE_URL = originalAppBaseUrl
     mutableEnv.BETTER_AUTH_SECRET = originalBetterAuthSecret
     mutableEnv.CI = originalCi
@@ -302,18 +304,19 @@ describe('telemetry collect route', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('returns 502 when PostHog rejects the batch', async () => {
+  it('accepts collect requests even when PostHog rejects the batch asynchronously', async () => {
     const fetchMock = mock(async () => new Response(null, { status: 400 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
     const app = createTelemetryRouteApp()
 
     const response = await postCollect(app, collectPayload())
 
-    expect(response.status).toBe(502)
-    expect(await response.json()).toEqual({ error: 'Telemetry upstream rejected batch' })
+    expect(response.status).toBe(202)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(fetchMock).toHaveBeenCalled()
   })
 
-  it('returns 502 when PostHog responds with a redirect', async () => {
+  it('accepts collect requests even when PostHog responds with a redirect', async () => {
     const fetchMock = mock(
       async () =>
         new Response(null, {
@@ -326,11 +329,12 @@ describe('telemetry collect route', () => {
 
     const response = await postCollect(app, collectPayload())
 
-    expect(response.status).toBe(502)
-    expect(await response.json()).toEqual({ error: 'Telemetry upstream rejected batch' })
+    expect(response.status).toBe(202)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(fetchMock).toHaveBeenCalled()
   })
 
-  it('returns 503 when PostHog is unreachable', async () => {
+  it('accepts collect requests even when PostHog is unreachable', async () => {
     const fetchMock = mock(async () => {
       throw new Error('PostHog unavailable')
     })
@@ -339,8 +343,9 @@ describe('telemetry collect route', () => {
 
     const response = await postCollect(app, collectPayload())
 
-    expect(response.status).toBe(503)
-    expect(await response.json()).toEqual({ error: 'Telemetry upstream unavailable' })
+    expect(response.status).toBe(202)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(fetchMock).toHaveBeenCalled()
   })
 
   it('returns not found when product telemetry is disabled', async () => {

--- a/apps/api/src/routes/telemetry-events-queue.test.ts
+++ b/apps/api/src/routes/telemetry-events-queue.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+import { enqueueTelemetryEvent, resetTelemetryEventsQueueForTests } from './telemetry-events-queue'
+
+describe('telemetry events queue', () => {
+  afterEach(() => {
+    resetTelemetryEventsQueueForTests()
+  })
+
+  it('rejects new events when the bounded queue is full', () => {
+    const process = mock(async () => new Promise<void>(() => {}))
+    const input = {
+      event: 'queue_paused',
+      properties: { success: true },
+      sessionId: 'session-1',
+      timestamp: '2026-05-28T00:00:00.000Z',
+    }
+
+    for (let i = 0; i < 4 + 256; i += 1) {
+      expect(enqueueTelemetryEvent(input, process)).toBe(true)
+    }
+
+    expect(enqueueTelemetryEvent(input, process)).toBe(false)
+  })
+})

--- a/apps/api/src/routes/telemetry-events-queue.ts
+++ b/apps/api/src/routes/telemetry-events-queue.ts
@@ -1,0 +1,77 @@
+import {
+  captureAnonymousServerEvent,
+  tryGetServerAnalyticsOptions,
+} from '@durabull/analytics/server'
+
+interface TelemetryEventQueueItem {
+  event: string
+  properties: Record<string, unknown>
+  sessionId: string
+  timestamp: string
+}
+
+const MAX_EVENTS_IN_FLIGHT = 4
+const MAX_EVENTS_QUEUE_DEPTH = 256
+
+let eventsInFlight = 0
+const pendingEvents: TelemetryEventQueueItem[] = []
+
+type ProcessTelemetryEvent = (input: TelemetryEventQueueItem) => Promise<void>
+
+async function processTelemetryEvent(input: TelemetryEventQueueItem): Promise<void> {
+  const options = tryGetServerAnalyticsOptions()
+  if (!options?.enabled) return
+
+  const anonymousInstanceId = await options.resolveAnonymousInstanceId()
+  await captureAnonymousServerEvent({
+    anonymousInstanceId,
+    event: input.event,
+    properties: input.properties,
+    sessionId: input.sessionId,
+    timestamp: input.timestamp,
+  })
+}
+
+function dispatchTelemetryEvent(input: TelemetryEventQueueItem, process: ProcessTelemetryEvent): void {
+  eventsInFlight += 1
+  void process(input)
+    .catch(() => {
+      // Local telemetry must never affect the product experience.
+    })
+    .finally(() => {
+      eventsInFlight -= 1
+      flushPendingTelemetryEvents(process)
+    })
+}
+
+function flushPendingTelemetryEvents(process: ProcessTelemetryEvent): void {
+  while (eventsInFlight < MAX_EVENTS_IN_FLIGHT && pendingEvents.length > 0) {
+    const next = pendingEvents.shift()
+    if (!next) break
+    dispatchTelemetryEvent(next, process)
+  }
+}
+
+export function enqueueTelemetryEvent(
+  input: TelemetryEventQueueItem,
+  process: ProcessTelemetryEvent = processTelemetryEvent
+): boolean {
+  if (eventsInFlight < MAX_EVENTS_IN_FLIGHT && pendingEvents.length === 0) {
+    dispatchTelemetryEvent(input, process)
+    return true
+  }
+
+  if (pendingEvents.length >= MAX_EVENTS_QUEUE_DEPTH) {
+    return false
+  }
+
+  pendingEvents.push(input)
+  flushPendingTelemetryEvents(process)
+  return true
+}
+
+/** Test-only */
+export function resetTelemetryEventsQueueForTests(): void {
+  eventsInFlight = 0
+  pendingEvents.length = 0
+}

--- a/apps/api/src/routes/telemetry.test.ts
+++ b/apps/api/src/routes/telemetry.test.ts
@@ -11,6 +11,7 @@ import {
   bootstrapServerAnalytics,
   resetCachedAnonymousInstanceIdForTests,
 } from '../lib/configure-server-analytics'
+import { resetTelemetryEventsQueueForTests } from './telemetry-events-queue'
 
 const QUEUE_PAUSED_EVENT = 'queue_paused'
 
@@ -76,6 +77,7 @@ describe('telemetry routes', () => {
     await closeDb()
     resetServerAnalyticsForTests()
     resetCachedAnonymousInstanceIdForTests()
+    resetTelemetryEventsQueueForTests()
     mutableEnv.APP_BASE_URL = originalAppBaseUrl
     mutableEnv.BETTER_AUTH_SECRET = originalBetterAuthSecret
     mutableEnv.CI = originalCi

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -1,7 +1,5 @@
 import {
-  captureAnonymousServerEvent,
   getTelemetryStatusFromOptions,
-  ingestTelemetryCollectBatch,
   isDurabullTelemetryCollectConfigured,
   TELEMETRY_COLLECT_SIGNATURE_HEADER,
   TELEMETRY_COLLECT_TIMESTAMP_HEADER,
@@ -13,6 +11,8 @@ import {
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { enqueueTelemetryCollectBatch } from './telemetry-collect-queue'
+import { enqueueTelemetryEvent } from './telemetry-events-queue'
 
 const MAX_COLLECT_EVENTS_PER_BATCH = 50
 
@@ -102,27 +102,29 @@ const telemetryRoutes = new Hono()
     }
 
     const payload = payloadResult.data
-    const result = await ingestTelemetryCollectBatch({
+    if (!options || !isDurabullTelemetryCollectConfigured(options)) {
+      return c.json({ error: 'Telemetry collection is not configured' }, 503)
+    }
+
+    for (const event of payload.events) {
+      const validated = validateTelemetryPayload(event.event, event.properties, payload.runtime)
+      if (!validated.ok) {
+        if (validated.error === 'unknown_event') {
+          return c.json({ error: 'Unknown telemetry event' }, 400)
+        }
+        return c.json({ error: 'Invalid telemetry properties' }, 400)
+      }
+    }
+
+    const enqueued = enqueueTelemetryCollectBatch({
       instanceId: payload.instanceId,
       sentAt: payload.sentAt,
       events: payload.events,
       clientRuntime: payload.runtime,
     })
 
-    if (!result.ok) {
-      if (result.error === 'disabled' || result.error === 'not_configured') {
-        return c.json({ error: 'Telemetry collection is not configured' }, 503)
-      }
-      if (result.error === 'unknown_event') {
-        return c.json({ error: 'Unknown telemetry event' }, 400)
-      }
-      if (result.error === 'invalid_properties') {
-        return c.json({ error: 'Invalid telemetry properties' }, 400)
-      }
-      if (result.error === 'upstream_unavailable') {
-        return c.json({ error: 'Telemetry upstream unavailable' }, 503)
-      }
-      return c.json({ error: 'Telemetry upstream rejected batch' }, 502)
+    if (!enqueued) {
+      return c.json({ error: 'Telemetry collect queue is full' }, 503)
     }
 
     return c.json({ accepted: true }, 202)
@@ -155,20 +157,16 @@ const telemetryRoutes = new Hono()
       return c.json({ error: 'Telemetry collection is not configured' }, 503)
     }
 
-    void (async () => {
-      try {
-        const anonymousInstanceId = await options.resolveAnonymousInstanceId()
-        await captureAnonymousServerEvent({
-          anonymousInstanceId,
-          event: validated.event,
-          properties: validated.properties,
-          sessionId: body.sessionId,
-          timestamp: body.timestamp ?? new Date().toISOString(),
-        })
-      } catch {
-        // Telemetry must never affect the local product experience.
-      }
-    })()
+    const enqueued = enqueueTelemetryEvent({
+      event: validated.event,
+      properties: validated.properties,
+      sessionId: body.sessionId,
+      timestamp: body.timestamp ?? new Date().toISOString(),
+    })
+
+    if (!enqueued) {
+      return c.json({ error: 'Telemetry event queue is full' }, 503)
+    }
 
     return c.json({ accepted: true }, 202)
   })

--- a/packages/analytics/src/server/capture.test.ts
+++ b/packages/analytics/src/server/capture.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { AnalyticsEvents } from '../events'
-import { captureIdentifiedServerEvent, ingestTelemetryCollectBatch } from './capture'
+import {
+  captureIdentifiedServerEvent,
+  captureMcpAnalyticsServerEvent,
+  ingestTelemetryCollectBatch,
+} from './capture'
 import {
   configureServerAnalytics,
   resetServerAnalyticsForTests,
@@ -141,5 +145,64 @@ describe('ingestTelemetryCollectBatch timestamp clamping', () => {
 
     const batch = (bodies[0] as { batch: Array<{ timestamp: string }> }).batch
     expect(batch[0].timestamp).toBe(recent)
+  })
+})
+
+describe('captureMcpAnalyticsServerEvent coalescing', () => {
+  beforeEach(() => {
+    resetServerAnalyticsForTests()
+    configure()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    resetServerAnalyticsForTests()
+  })
+
+  it('coalesces anonymous and identified captures into one batch request when targets match', async () => {
+    resetServerAnalyticsForTests()
+    configure({ appPosthogKey: 'phc_durabull' })
+    const { bodies, restore } = captureFetchBodies()
+
+    await captureMcpAnalyticsServerEvent({
+      event: AnalyticsEvents.MCP_TOOL_CALLED,
+      properties: { tool_name: 'list_jobs', response_class: 'success' },
+      includeAnonymous: true,
+      anonymousInstanceId: 'anon-instance-id',
+      sessionId: 'session-1',
+      identifiedDistinctId: 'hashed-user-1',
+      organizationId: 'org-1',
+    })
+
+    restore()
+
+    expect(bodies).toHaveLength(1)
+    const batch = (bodies[0] as { batch: Array<{ properties: Record<string, unknown> }> }).batch
+    expect(batch).toHaveLength(2)
+    expect(batch.some((event) => event.properties.$process_person_profile === false)).toBe(true)
+    expect(batch.some((event) => event.properties.$process_person_profile === true)).toBe(true)
+  })
+
+  it('sends separate batch requests when identified telemetry uses a different project key', async () => {
+    resetServerAnalyticsForTests()
+    configure({ appPosthogKey: 'phc_different_app_project' })
+    const { bodies, restore } = captureFetchBodies()
+
+    await captureMcpAnalyticsServerEvent({
+      event: AnalyticsEvents.MCP_TOOL_CALLED,
+      properties: { tool_name: 'list_jobs', response_class: 'success' },
+      includeAnonymous: true,
+      anonymousInstanceId: 'anon-instance-id',
+      sessionId: 'session-1',
+      identifiedDistinctId: 'hashed-user-1',
+      organizationId: 'org-1',
+    })
+
+    restore()
+
+    expect(bodies).toHaveLength(2)
+    expect(
+      bodies.every((body) => (body as { batch: Array<unknown> }).batch.length === 1)
+    ).toBe(true)
   })
 })

--- a/packages/analytics/src/server/capture.ts
+++ b/packages/analytics/src/server/capture.ts
@@ -102,6 +102,37 @@ function buildAnonymousCapture(input: {
   }
 }
 
+function buildIdentifiedCapture(input: {
+  event: string
+  properties: Record<string, string | number | boolean | null>
+  distinctId: string
+  organizationId?: string | null
+  timestamp?: string
+  hmacSecret: string | null
+}): PosthogBatchCapture {
+  const organizationGroup =
+    input.organizationId && input.hmacSecret
+      ? hashIdentifiedOrganizationDistinctId(input.organizationId, input.hmacSecret)
+      : null
+
+  return {
+    event: input.event,
+    properties: input.properties,
+    distinctId: input.distinctId,
+    organizationId: organizationGroup,
+    processPersonProfile: true,
+    timestamp: input.timestamp,
+  }
+}
+
+function isSamePosthogConfig(
+  left: PosthogBatchClientConfig | null,
+  right: PosthogBatchClientConfig | null
+): left is PosthogBatchClientConfig {
+  if (!left || !right) return false
+  return left.posthogBatchUrl === right.posthogBatchUrl && left.posthogKey === right.posthogKey
+}
+
 async function forwardAnonymousToCloudCollect(input: {
   cloudCollectUrl: string
   collectSigningSecret: string
@@ -223,26 +254,147 @@ export async function captureIdentifiedServerEvent(input: {
   const config = getIdentifiedPosthogConfig(options)
   if (!config) return
 
-  const hmacSecret = options.hmacSecret
-  const organizationGroup =
-    input.organizationId && hmacSecret
-      ? hashIdentifiedOrganizationDistinctId(input.organizationId, hmacSecret)
-      : null
-
   await sendPosthogBatch(
     config,
     [
-      {
+      buildIdentifiedCapture({
         event: validated.event,
         properties: validated.properties,
         distinctId: input.distinctId,
-        organizationId: organizationGroup,
-        processPersonProfile: true,
+        organizationId: input.organizationId,
         timestamp: input.timestamp,
-      },
+        hmacSecret: options.hmacSecret,
+      }),
     ],
     { runtimeContext, mergeRuntime: true }
   )
+}
+
+export async function captureMcpAnalyticsServerEvent(input: {
+  event: string
+  properties: Record<string, unknown>
+  includeAnonymous: boolean
+  anonymousInstanceId?: string
+  sessionId?: string
+  identifiedDistinctId?: string | null
+  organizationId?: string | null
+  timestamp?: string
+}): Promise<void> {
+  const options = getOptions()
+  if (!options?.enabled) return
+
+  const runtimeContext = options.getRuntimeContext()
+  const validated = validateTelemetryPayload(input.event, input.properties, runtimeContext)
+  if (!validated.ok) return
+
+  const timestamp = input.timestamp ?? new Date().toISOString()
+  const shouldCaptureAnonymous = input.includeAnonymous && !!input.anonymousInstanceId && !!input.sessionId
+  const shouldCaptureIdentified = !!input.identifiedDistinctId
+
+  if (!shouldCaptureAnonymous && !shouldCaptureIdentified) {
+    return
+  }
+
+  if (options.collectEnabled) {
+    const anonymousConfig = shouldCaptureAnonymous ? getDurabullPosthogIngestConfig(options) : null
+    const identifiedConfig = shouldCaptureIdentified ? getIdentifiedPosthogConfig(options) : null
+    const anonymousCapture =
+      shouldCaptureAnonymous && anonymousConfig
+        ? buildAnonymousCapture({
+            anonymousInstanceId: input.anonymousInstanceId!,
+            sessionId: input.sessionId!,
+            event: validated.event,
+            properties: validated.properties,
+            timestamp,
+            hmacSecret: anonymousConfig.hmacSecret,
+          })
+        : null
+    const identifiedCapture =
+      shouldCaptureIdentified && identifiedConfig
+        ? buildIdentifiedCapture({
+            event: validated.event,
+            properties: validated.properties,
+            distinctId: input.identifiedDistinctId!,
+            organizationId: input.organizationId ?? null,
+            timestamp,
+            hmacSecret: options.hmacSecret,
+          })
+        : null
+
+    if (
+      anonymousCapture &&
+      identifiedCapture &&
+      isSamePosthogConfig(anonymousConfig, identifiedConfig)
+    ) {
+      await sendPosthogBatch(anonymousConfig, [anonymousCapture, identifiedCapture], {
+        runtimeContext,
+        mergeRuntime: true,
+      })
+      return
+    }
+
+    const tasks: Promise<boolean>[] = []
+    if (anonymousCapture && anonymousConfig) {
+      tasks.push(
+        sendPosthogBatch(anonymousConfig, [anonymousCapture], { runtimeContext, mergeRuntime: true })
+      )
+    }
+    if (identifiedCapture && identifiedConfig) {
+      tasks.push(
+        sendPosthogBatch(identifiedConfig, [identifiedCapture], { runtimeContext, mergeRuntime: true })
+      )
+    }
+    if (tasks.length > 0) {
+      await Promise.all(tasks)
+    }
+    return
+  }
+
+  const tasks: Promise<void>[] = []
+  if (shouldCaptureAnonymous) {
+    if (!options.collectSigningSecret) {
+      console.warn('[analytics] cloud collect forward skipped: missing collect signing secret')
+    } else {
+      tasks.push(
+        forwardAnonymousToCloudCollect({
+          cloudCollectUrl: options.cloudCollectUrl,
+          collectSigningSecret: options.collectSigningSecret,
+          anonymousInstanceId: input.anonymousInstanceId!,
+          event: validated.event,
+          properties: validated.properties,
+          sessionId: input.sessionId!,
+          timestamp,
+          runtimeContext,
+        })
+      )
+    }
+  }
+
+  if (shouldCaptureIdentified) {
+    const identifiedConfig = getIdentifiedPosthogConfig(options)
+    if (identifiedConfig) {
+      tasks.push(
+        sendPosthogBatch(
+          identifiedConfig,
+          [
+            buildIdentifiedCapture({
+              event: validated.event,
+              properties: validated.properties,
+              distinctId: input.identifiedDistinctId!,
+              organizationId: input.organizationId ?? null,
+              timestamp,
+              hmacSecret: options.hmacSecret,
+            }),
+          ],
+          { runtimeContext, mergeRuntime: true }
+        ).then(() => {})
+      )
+    }
+  }
+
+  if (tasks.length > 0) {
+    await Promise.all(tasks)
+  }
 }
 
 export interface TelemetryCollectEventInput {

--- a/packages/analytics/src/server/index.ts
+++ b/packages/analytics/src/server/index.ts
@@ -20,6 +20,7 @@ export {
 export {
   captureAnonymousServerEvent,
   captureIdentifiedServerEvent,
+  captureMcpAnalyticsServerEvent,
   ingestTelemetryCollectBatch,
   isDurabullTelemetryCollectConfigured,
   resolveIdentifiedDistinctIds,

--- a/tasks/handoff-analytics-mcp-telemetry.md
+++ b/tasks/handoff-analytics-mcp-telemetry.md
@@ -49,9 +49,11 @@ Fixed Critical/High: poisoned inflight promise, XFF leftmost spoof, collect secr
 
 | Priority | Item |
 |----------|------|
-| P1 | PostHog dedupe/coalesce, dup connection query, async `/collect` |
+| P1 | ✅ Done on `main` (2026-05-28): PostHog dedupe/coalesce, delegated connection query de-dup, async `/collect` queue, bounded `/events` queue |
 | P2 | Dedicated `DURABULL_TELEMETRY_HMAC_SECRET` (drop `BETTER_AUTH_SECRET` fallback), signature replay LRU |
 | P3 | Barrel migration, shared queue helper, telemetry signal docs |
+
+**Parallel review loop:** Pass 1 found High items in `/events` backpressure, MCP RPC identity, policy/tools layering, and MCP analytics drop visibility. Fixed them, reran four-lens review, and pass 2 reported **no Critical/High issues**.
 
 ---
 
@@ -64,6 +66,9 @@ bun test \
   packages/analytics/src/server/validate.test.ts \
   packages/analytics/src/server/identifiers.test.ts \
   packages/analytics/src/server/posthog-batch.test.ts \
+  apps/api/src/mcp/observability/mcp-analytics-queue.test.ts \
+  apps/api/src/mcp/tools/shared.test.ts \
+  apps/api/src/routes/telemetry-events-queue.test.ts \
   apps/api/src/routes/telemetry.test.ts \
   apps/api/src/routes/telemetry-collect.test.ts \
   apps/api/src/mcp/observability/mcp-analytics.test.ts \


### PR DESCRIPTION
## Summary
- Coalesce MCP anonymous + identified analytics into one PostHog batch when targets match.
- Add bounded async queues for `/collect` and `/events`, with backpressure on full queues.
- Move MCP connection resolution to a neutral module, preserve delegated access checks, and add queue/backpressure tests.

## Test plan
- `bun test packages/analytics/src/server/collect-auth.test.ts packages/analytics/src/server/capture.test.ts packages/analytics/src/server/validate.test.ts packages/analytics/src/server/identifiers.test.ts packages/analytics/src/server/posthog-batch.test.ts apps/api/src/mcp/observability/mcp-analytics-queue.test.ts apps/api/src/mcp/tools/shared.test.ts apps/api/src/routes/telemetry-events-queue.test.ts apps/api/src/routes/telemetry.test.ts apps/api/src/routes/telemetry-collect.test.ts apps/api/src/mcp/observability/mcp-analytics.test.ts apps/api/src/middleware/rate-limit.test.ts`
- Four-lens parallel code review loop rerun after fixes; pass 2 reported no Critical/High findings.

## Linear
- Not linked: no Linear issue was provided for this follow-up.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Asynchronous telemetry event and collect batch processing through dedicated queues
  - MCP analytics queue with warnings when capacity limits are reached

* **Improvements**
  - Enhanced MCP analytics tracking with unified event capture and improved identity handling
  - Better telemetry performance through non-blocking queue-based processing with backpressure support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->