### PR TITLE
fix(analytics): dedicated telemetry HMAC secret and collect replay protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,15 @@ BETTER_AUTH_SECRET=replace-me-with-a-long-random-string
 # EMAIL_FROM=Acme Ops <ops@acme.example>
 
 # -----------------------------------------------------------------------------
+# Telemetry (cloud / managed PostHog ingest)
+# -----------------------------------------------------------------------------
+# Required on Durabull Cloud and any host that ingests /api/telemetry/collect.
+# DURABULL_TELEMETRY_HMAC_SECRET=<long-random-secret>
+# DURABULL_TELEMETRY_COLLECT_SECRET=<long-random-secret>
+# DURABULL_TELEMETRY_POSTHOG_KEY=
+# DURABULL_TELEMETRY_POSTHOG_HOST=https://us.i.posthog.com
+
+# -----------------------------------------------------------------------------
 # Linear
 # -----------------------------------------------------------------------------
 # LINEAR_OAUTH_CLIENT_ID=

--- a/apps/api/src/lib/configure-server-analytics.ts
+++ b/apps/api/src/lib/configure-server-analytics.ts
@@ -70,8 +70,7 @@ export function bootstrapServerAnalytics(): void {
       durabullTelemetryPosthogKey === appPosthogKey,
     disclosureUrl: TELEMETRY_DISCLOSURE_URL,
     collectSigningSecret: env.DURABULL_TELEMETRY_COLLECT_SECRET?.trim() || null,
-    hmacSecret:
-      env.DURABULL_TELEMETRY_HMAC_SECRET?.trim() || env.BETTER_AUTH_SECRET?.trim() || null,
+    hmacSecret: env.DURABULL_TELEMETRY_HMAC_SECRET?.trim() || null,
     durabullTelemetryPosthogKey,
     durabullTelemetryPosthogHost: env.DURABULL_TELEMETRY_POSTHOG_HOST?.trim() || null,
     appPosthogKey,

--- a/apps/api/src/routes/telemetry-collect.test.ts
+++ b/apps/api/src/routes/telemetry-collect.test.ts
@@ -5,6 +5,7 @@ import { bodyLimit } from 'hono/body-limit'
 import {
   hashTelemetryIdentifier,
   resetServerAnalyticsForTests,
+  resetTelemetryCollectReplayCacheForTests,
   signTelemetryCollectBody,
   TELEMETRY_COLLECT_SIGNATURE_HEADER,
   TELEMETRY_COLLECT_TIMESTAMP_HEADER,
@@ -125,6 +126,7 @@ async function postCollect(
 
 describe('telemetry collect route', () => {
   beforeEach(() => {
+    resetTelemetryCollectReplayCacheForTests()
     mutableEnv.APP_BASE_URL = 'https://app.durabull.io'
     mutableEnv.BETTER_AUTH_SECRET = undefined
     mutableEnv.CI = false
@@ -155,10 +157,8 @@ describe('telemetry collect route', () => {
     globalThis.fetch = originalFetch
   })
 
-  it('can use the existing cloud API PostHog and auth secrets without extra telemetry setup', async () => {
-    mutableEnv.BETTER_AUTH_SECRET = HMAC_SECRET
+  it('can use POSTHOG_KEY when the dedicated telemetry PostHog key is unset', async () => {
     mutableEnv.POSTHOG_KEY = POSTHOG_KEY
-    mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = undefined
     mutableEnv.DURABULL_TELEMETRY_POSTHOG_KEY = undefined
     bootstrapServerAnalytics()
     const fetchMock = mock(async () => new Response(null, { status: 200 }))
@@ -178,6 +178,33 @@ describe('telemetry collect route', () => {
     expect(body.batch[0].properties.instance_key).toBe(
       hashTelemetryIdentifier(INSTANCE_ID, HMAC_SECRET)
     )
+  })
+
+  it('does not fall back to BETTER_AUTH_SECRET for telemetry HMAC', async () => {
+    mutableEnv.BETTER_AUTH_SECRET = HMAC_SECRET
+    mutableEnv.DURABULL_TELEMETRY_HMAC_SECRET = undefined
+    bootstrapServerAnalytics()
+    const fetchMock = mock(async () => new Response(null, { status: 200 }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const app = createTelemetryRouteApp()
+
+    const response = await postCollect(app, collectPayload())
+
+    expect(response.status).toBe(503)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects replayed signed collect requests', async () => {
+    const app = createTelemetryRouteApp()
+    const body = collectPayload()
+    const signed = signedCollectRequest(body)
+
+    const first = await app.request('/collect', signed)
+    expect(first.status).toBe(202)
+
+    const replay = await app.request('/collect', signed)
+    expect(replay.status).toBe(401)
+    expect(await replay.json()).toEqual({ error: 'Unauthorized telemetry collect request' })
   })
 
   it('forwards canonical sanitized events to PostHog batch with HMAC identifiers', async () => {

--- a/packages/analytics/src/server/collect-auth.test.ts
+++ b/packages/analytics/src/server/collect-auth.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it } from 'bun:test'
 
 import {
+  resetTelemetryCollectReplayCacheForTests,
   signTelemetryCollectBody,
   TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC,
   verifyTelemetryCollectSignature,
@@ -13,6 +14,9 @@ const RAW_BODY = JSON.stringify({
 })
 
 describe('telemetry collect auth', () => {
+  beforeEach(() => {
+    resetTelemetryCollectReplayCacheForTests()
+  })
   it('signs and verifies collect payloads', () => {
     const timestamp = 1_700_000_000
     const { signature, timestamp: timestampHeader } = signTelemetryCollectBody(
@@ -79,5 +83,88 @@ describe('telemetry collect auth', () => {
         nowSec: timestamp,
       })
     ).toEqual({ ok: false, error: 'invalid' })
+  })
+
+  it('rejects replayed signatures within the tolerance window', () => {
+    const timestamp = 1_700_000_000
+    const { signature, timestamp: timestampHeader } = signTelemetryCollectBody(
+      SECRET,
+      timestamp,
+      RAW_BODY
+    )
+
+    const input = {
+      secret: SECRET,
+      timestampHeader,
+      signatureHeader: signature,
+      rawBody: RAW_BODY,
+      nowSec: timestamp,
+    }
+
+    expect(verifyTelemetryCollectSignature(input)).toEqual({ ok: true })
+    expect(verifyTelemetryCollectSignature(input)).toEqual({ ok: false, error: 'replay' })
+  })
+
+  it('rejects replayed signatures near the end of the tolerance window', () => {
+    const timestamp = 1_700_000_000
+    const { signature, timestamp: timestampHeader } = signTelemetryCollectBody(
+      SECRET,
+      timestamp,
+      RAW_BODY
+    )
+
+    expect(
+      verifyTelemetryCollectSignature({
+        secret: SECRET,
+        timestampHeader,
+        signatureHeader: signature,
+        rawBody: RAW_BODY,
+        nowSec: timestamp,
+      })
+    ).toEqual({ ok: true })
+
+    expect(
+      verifyTelemetryCollectSignature({
+        secret: SECRET,
+        timestampHeader,
+        signatureHeader: signature,
+        rawBody: RAW_BODY,
+        nowSec: timestamp + TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC - 1,
+      })
+    ).toEqual({ ok: false, error: 'replay' })
+
+    expect(
+      verifyTelemetryCollectSignature({
+        secret: SECRET,
+        timestampHeader,
+        signatureHeader: signature,
+        rawBody: RAW_BODY,
+        nowSec: timestamp + TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC,
+      })
+    ).toEqual({ ok: false, error: 'replay' })
+  })
+
+  it('keeps replay protection for future-dated signatures until the validity window ends', () => {
+    const nowSec = 1_700_000_000
+    const futureTimestamp = nowSec + 200
+    const { signature, timestamp: timestampHeader } = signTelemetryCollectBody(
+      SECRET,
+      futureTimestamp,
+      RAW_BODY
+    )
+
+    const input = {
+      secret: SECRET,
+      timestampHeader,
+      signatureHeader: signature,
+      rawBody: RAW_BODY,
+      nowSec,
+    }
+
+    expect(verifyTelemetryCollectSignature(input)).toEqual({ ok: true })
+    expect(verifyTelemetryCollectSignature({ ...input, nowSec: nowSec + 250 })).toEqual({
+      ok: false,
+      error: 'replay',
+    })
   })
 })

--- a/packages/analytics/src/server/collect-auth.ts
+++ b/packages/analytics/src/server/collect-auth.ts
@@ -4,6 +4,66 @@ export const TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC = 300
 export const TELEMETRY_COLLECT_TIMESTAMP_HEADER = 'X-Durabull-Telemetry-Timestamp'
 export const TELEMETRY_COLLECT_SIGNATURE_HEADER = 'X-Durabull-Telemetry-Signature'
 
+const DEFAULT_REPLAY_MAX_ENTRIES = 4_096
+
+interface TelemetryCollectReplayCacheEntry {
+  expiresAtMs: number
+}
+
+export function createTelemetryCollectReplayCache(options?: {
+  maxEntries?: number
+}) {
+  const maxEntries = options?.maxEntries ?? DEFAULT_REPLAY_MAX_ENTRIES
+  const store = new Map<string, TelemetryCollectReplayCacheEntry>()
+
+  function consume(
+    signature: string,
+    nowMs: number,
+    signatureExpiresAtMs: number
+  ): 'fresh' | 'replay' {
+    const normalized = signature.trim()
+    const existing = store.get(normalized)
+    if (existing) {
+      if (existing.expiresAtMs < nowMs) {
+        store.delete(normalized)
+        // Expired; fall through to re-insert as fresh.
+      } else {
+        return 'replay'
+      }
+    }
+
+    if (store.size >= maxEntries) {
+      for (const [key, entry] of store) {
+        if (entry.expiresAtMs < nowMs) {
+          store.delete(key)
+        }
+      }
+    }
+
+    if (store.size >= maxEntries) {
+      const oldestKey = store.keys().next().value
+      if (oldestKey) store.delete(oldestKey)
+    }
+
+    store.set(normalized, { expiresAtMs: signatureExpiresAtMs })
+    return 'fresh'
+  }
+
+  function reset(): void {
+    store.clear()
+  }
+
+  return { consume, reset }
+}
+
+const defaultReplayCache = createTelemetryCollectReplayCache()
+
+/** Test-only: clear replay protection between cases. */
+export function resetTelemetryCollectReplayCacheForTests(): void {
+  if (process.env.NODE_ENV !== 'test') return
+  defaultReplayCache.reset()
+}
+
 export function signTelemetryCollectBody(
   secret: string,
   timestamp: number,
@@ -26,14 +86,15 @@ export function verifyTelemetryCollectSignature(input: {
   signatureHeader: string | undefined
   rawBody: string
   nowSec?: number
-}): { ok: true } | { ok: false; error: 'missing' | 'invalid' | 'expired' } {
+}): { ok: true } | { ok: false; error: 'missing' | 'invalid' | 'expired' | 'replay' } {
   const { secret, timestampHeader, signatureHeader, rawBody } = input
   if (!timestampHeader?.trim() || !signatureHeader?.trim()) {
     return { ok: false, error: 'missing' }
   }
 
-  const timestampSec = Number(timestampHeader.trim())
-  if (!Number.isFinite(timestampSec) || !/^\d+$/.test(timestampHeader.trim())) {
+  const timestampHeaderValue = timestampHeader.trim()
+  const timestampSec = Number(timestampHeaderValue)
+  if (!Number.isFinite(timestampSec) || !/^\d+$/.test(timestampHeaderValue)) {
     return { ok: false, error: 'invalid' }
   }
 
@@ -56,6 +117,14 @@ export function verifyTelemetryCollectSignature(input: {
     }
   } catch {
     return { ok: false, error: 'invalid' }
+  }
+
+  const signatureExpiresAtMs =
+    (timestampSec + TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC) * 1000
+  if (
+    defaultReplayCache.consume(provided, nowSec * 1000, signatureExpiresAtMs) === 'replay'
+  ) {
+    return { ok: false, error: 'replay' }
   }
 
   return { ok: true }

--- a/packages/analytics/src/server/config.ts
+++ b/packages/analytics/src/server/config.ts
@@ -52,6 +52,7 @@ export function tryGetServerAnalyticsOptions(): ServerAnalyticsOptions | null {
 
 /** Test-only: reset configured options between cases. */
 export function resetServerAnalyticsForTests(): void {
+  if (process.env.NODE_ENV !== 'test') return
   configuredOptions = null
 }
 

--- a/packages/analytics/src/server/index.ts
+++ b/packages/analytics/src/server/index.ts
@@ -11,6 +11,8 @@ export {
   type ServerAnalyticsRuntimeContext,
 } from './config'
 export {
+  createTelemetryCollectReplayCache,
+  resetTelemetryCollectReplayCacheForTests,
   signTelemetryCollectBody,
   TELEMETRY_COLLECT_SIGNATURE_HEADER,
   TELEMETRY_COLLECT_SIGNATURE_TOLERANCE_SEC,

--- a/tasks/handoff-analytics-mcp-telemetry.md
+++ b/tasks/handoff-analytics-mcp-telemetry.md
@@ -1,8 +1,8 @@
 # Handoff: Analytics package split + MCP product telemetry
 
-**Branch:** `cursor/analytics-collect-auth` (PR #110)  
+**Branch:** `main` (P2 landed locally; open PR when ready)  
 **Last verified:** 2026-05-28 — run full suite after merge with `main` (see Verification)  
-**Timeline:** #107 → #108 → #109 (merged to `main`) → **#110 open** (collect auth + XFF trust)
+**Timeline:** #107 → #108 → #109 → #110 → #112 (all merged) → **P2 complete** → P3 next
 
 ---
 
@@ -13,35 +13,27 @@
 | **PR #107** | Server capture package + MCP PostHog telemetry | ✅ merged |
 | **PR #108** | P0: server runtime on `/collect`, `/events` preflight, PostHog host allowlist | ✅ merged |
 | **PR #109** | MCP org `$groups` fix, fetch timeouts, single-flight instance id, timestamp clamp, hygiene | ✅ merged |
-| **PR #110** | P0-A `/collect` HMAC auth + trusted OSS runtime; P0-B XFF/proxy trust for rate limits | 🚧 **this branch** |
+| **PR #110** | P0-A `/collect` HMAC auth + trusted OSS runtime; P0-B XFF/proxy trust for rate limits | ✅ merged |
+| **PR #112** | P1: PostHog dedupe/coalesce, connection query de-dup, async `/collect` queue, bounded `/events` queue | ✅ merged |
+| **P2 (local)** | Dedicated `DURABULL_TELEMETRY_HMAC_SECRET`; `/collect` signature replay LRU | ✅ done |
 
-**Lesson:** Branch from latest `origin/main` before starting. PR #109 merged while #110 was in flight — rebase/merge required.
+**Lesson:** Branch from latest `origin/main` before starting. Parallel PRs (#109 vs #110) touched the same files — rebase/merge required.
 
 ---
 
-## Completed on PR #110
+## Completed on P2
 
-### P0-A — `/collect` authentication
+### Dedicated telemetry HMAC secret
 
-- `DURABULL_TELEMETRY_COLLECT_SECRET` — HMAC-signed batches (`collect-auth.ts`)
-- Unsigned/invalid → **401**; top-level `runtime` required; cloud uses authenticated client runtime
-- OSS forward signs batches (preserves deployment attribution without reopening spoof hole)
+- `configure-server-analytics.ts` now uses **only** `DURABULL_TELEMETRY_HMAC_SECRET` for distinct_id / instance_key HMAC.
+- `BETTER_AUTH_SECRET` fallback removed — cloud/OSS deploys must set the dedicated secret explicitly.
+- `POSTHOG_KEY` fallback for Durabull telemetry PostHog key remains unchanged.
 
-### P0-B — Rate-limit proxy trust
+### `/collect` signature replay protection
 
-- `TRUST_PROXY` (auto on `DURABULL_CLOUD`); ignore spoofable headers on untrusted ingress
-- Trusted priority: CF-Connecting-IP → X-Real-IP → rightmost XFF hop
-
-### Also merged from #109 (via `main`)
-
-- Timestamp clamp ±24h on `/collect`
-- Fetch timeouts + `redirect: 'manual'` on forward
-- Single-flight + eager instance id warm
-- MCP org `$groups` single-hash fix
-
-### Parallel review on #110
-
-Fixed Critical/High: poisoned inflight promise, XFF leftmost spoof, collect secret decoupled from ingest config, `/events` fire-and-forget (202 always), `apiRateLimiter` retryAfter.
+- `collect-auth.ts`: bounded in-process replay LRU (4096 entries, TTL = signature tolerance window).
+- Replayed signatures within ±300s return `{ ok: false, error: 'replay' }` → route responds **401**.
+- `resetTelemetryCollectReplayCacheForTests()` exported for test isolation.
 
 ---
 
@@ -49,11 +41,11 @@ Fixed Critical/High: poisoned inflight promise, XFF leftmost spoof, collect secr
 
 | Priority | Item |
 |----------|------|
-| P1 | ✅ Done on `main` (2026-05-28): PostHog dedupe/coalesce, delegated connection query de-dup, async `/collect` queue, bounded `/events` queue |
-| P2 | Dedicated `DURABULL_TELEMETRY_HMAC_SECRET` (drop `BETTER_AUTH_SECRET` fallback), signature replay LRU |
+| P1 | ✅ Done (PR #112): PostHog dedupe/coalesce, delegated connection query de-dup, async `/collect` queue, bounded `/events` queue |
+| P2 | ✅ Done (2026-05-28): Dedicated `DURABULL_TELEMETRY_HMAC_SECRET`, signature replay LRU |
 | P3 | Barrel migration, shared queue helper, telemetry signal docs |
 
-**Parallel review loop:** Pass 1 found High items in `/events` backpressure, MCP RPC identity, policy/tools layering, and MCP analytics drop visibility. Fixed them, reran four-lens review, and pass 2 reported **no Critical/High issues**.
+**Parallel review loop (P2):** Pass 1 found Medium replay-cache TTL misalignment and unguarded test reset exports. Fixed both, plus off-by-one at tolerance boundary. Pass 3 reported **no Critical/High issues**.
 
 ---
 
@@ -84,9 +76,11 @@ bun test \
 | Variable | Purpose |
 |----------|---------|
 | `DURABULL_TELEMETRY_COLLECT_SECRET` | HMAC signing for `/collect` (OSS + cloud) |
+| `DURABULL_TELEMETRY_HMAC_SECRET` | **Required** for distinct_id / instance_key HMAC (no auth-secret fallback) |
 | `TRUST_PROXY` | Honor forwarding headers for rate limits |
-| `DURABULL_TELEMETRY_HMAC_SECRET` | distinct_id / instance_key HMAC |
 | `DURABULL_CLOUD` | Enables `/collect` + trusted proxy |
+
+**Cloud deploy note:** Set `DURABULL_TELEMETRY_HMAC_SECRET` explicitly — it is no longer derived from `BETTER_AUTH_SECRET`.
 
 ---
 
@@ -94,3 +88,4 @@ bun test \
 
 - **Always `git fetch origin main` and rebase/merge before opening a telemetry PR** — parallel PRs (#109 vs #110) touched the same files.
 - **Do not `git stash` to peek** while holding uncommitted work — use a worktree or WIP commit.
+- **One deferral item per PR** — P3 should split barrel migration, shared queue helper, and signal docs if they grow large.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -169,7 +169,9 @@ Post-#108 telemetry/analytics follow-ups (see `tasks/handoff-analytics-mcp-telem
 
 ### Deferred to dedicated follow-up PRs (documented, not hacked)
 
-- `/collect` authentication / signed batches — also resolves OSS→cloud forwarded-runtime re-stamping fidelity loss and unauthenticated abuse.
-- Rate-limit `X-Forwarded-For` trust (High security; cross-cutting `rate-limit.ts`, needs trusted-proxy config).
-- Require dedicated `DURABULL_TELEMETRY_HMAC_SECRET` in prod (remove `BETTER_AUTH_SECRET` fallback; env coordination).
-- Async `/collect` (202 + bounded worker) and single-batch PostHog coalesce; extract shared `createBoundedAsyncQueue`; queue-drop metric; root barrel migration to `/browser`.
+- [x] `/collect` authentication / signed batches — also resolves OSS→cloud forwarded-runtime re-stamping fidelity loss and unauthenticated abuse (PR #110).
+- [x] Rate-limit `X-Forwarded-For` trust (High security; cross-cutting `rate-limit.ts`, needs trusted-proxy config) (PR #110).
+- [x] Async `/collect` (202 + bounded worker) and single-batch PostHog coalesce; bounded `/events` queue (PR #112).
+- [x] Require dedicated `DURABULL_TELEMETRY_HMAC_SECRET` (remove `BETTER_AUTH_SECRET` fallback; env coordination).
+- [x] `/collect` signature replay LRU within the HMAC tolerance window.
+- [ ] Extract shared `createBoundedAsyncQueue`; queue-drop metric; root barrel migration to `/browser`; telemetry signal docs (P3).


### PR DESCRIPTION
## Summary
- Require `DURABULL_TELEMETRY_HMAC_SECRET` for telemetry hashing (remove `BETTER_AUTH_SECRET` fallback).
- Add bounded in-process replay LRU for signed `/collect` requests, with TTL aligned to the signature tolerance window.
- Guard test-only reset helpers and expand collect-auth test coverage (boundary + future-dated timestamps).
- Update handoff/todo docs and `.env.example` telemetry env guidance.

## Deploy note
Cloud must set both `DURABULL_TELEMETRY_HMAC_SECRET` and `DURABULL_TELEMETRY_COLLECT_SECRET` before/after deploy. For identity continuity, `DURABULL_TELEMETRY_HMAC_SECRET` can initially mirror the existing `BETTER_AUTH_SECRET` value.

## Test plan
- [x] `bun test` on full telemetry handoff suite (61 pass)
- [ ] Merge + deploy to Render with env vars confirmed
- [ ] Smoke: `/api/telemetry/collect` accepts signed batches; replays return 401


Made with [Cursor](https://cursor.com)