### PR TITLE
fix(analytics): share telemetry queue backpressure handling

### DIFF
--- a/apps/api/src/lib/bounded-async-queue.test.ts
+++ b/apps/api/src/lib/bounded-async-queue.test.ts
@@ -3,6 +3,22 @@ import { describe, expect, it, mock } from 'bun:test'
 import { createBoundedAsyncQueue } from './bounded-async-queue'
 
 describe('createBoundedAsyncQueue', () => {
+  it('rejects invalid queue limits at construction time', () => {
+    expect(() =>
+      createBoundedAsyncQueue<string>({
+        maxInFlight: 0,
+        maxQueueDepth: 1,
+      })
+    ).toThrow('maxInFlight must be a positive integer')
+
+    expect(() =>
+      createBoundedAsyncQueue<string>({
+        maxInFlight: 1,
+        maxQueueDepth: -1,
+      })
+    ).toThrow('maxQueueDepth must be a non-negative integer')
+  })
+
   it('bounds pending work and reports drops', () => {
     const onDrop = mock(() => {})
     const queue = createBoundedAsyncQueue<string>({

--- a/apps/api/src/lib/bounded-async-queue.test.ts
+++ b/apps/api/src/lib/bounded-async-queue.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, mock } from 'bun:test'
+
+import { createBoundedAsyncQueue } from './bounded-async-queue'
+
+describe('createBoundedAsyncQueue', () => {
+  it('bounds pending work and reports drops', () => {
+    const onDrop = mock(() => {})
+    const queue = createBoundedAsyncQueue<string>({
+      maxInFlight: 1,
+      maxQueueDepth: 2,
+      onDrop,
+    })
+    const process = mock(async () => new Promise<void>(() => {}))
+
+    expect(queue.enqueue('one', process)).toBe(true)
+    expect(queue.enqueue('two', process)).toBe(true)
+    expect(queue.enqueue('three', process)).toBe(true)
+    expect(queue.enqueue('four', process)).toBe(false)
+
+    expect(queue.getState()).toEqual({
+      dropped: 1,
+      inFlight: 1,
+      queued: 2,
+    })
+    expect(onDrop).toHaveBeenCalledWith('four', {
+      dropped: 1,
+      inFlight: 1,
+      queued: 2,
+    })
+  })
+
+  it('uses each pending item processor when workers free up', async () => {
+    let resolveFirst!: () => void
+    const firstRun = new Promise<void>((resolve) => {
+      resolveFirst = resolve
+    })
+    const processed: string[] = []
+    const queue = createBoundedAsyncQueue<string>({
+      maxInFlight: 1,
+      maxQueueDepth: 2,
+    })
+    const firstProcessor = mock(async (input: string) => {
+      processed.push(`first:${input}`)
+      await firstRun
+    })
+    const secondProcessor = mock(async (input: string) => {
+      processed.push(`second:${input}`)
+    })
+
+    expect(queue.enqueue('one', firstProcessor)).toBe(true)
+    expect(queue.enqueue('two', secondProcessor)).toBe(true)
+
+    resolveFirst()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(processed).toEqual(['first:one', 'second:two'])
+  })
+
+  it('recovers capacity when a processor throws synchronously', async () => {
+    const onError = mock(() => {})
+    const queue = createBoundedAsyncQueue<string>({
+      maxInFlight: 1,
+      maxQueueDepth: 0,
+      onError,
+    })
+
+    expect(
+      queue.enqueue('one', () => {
+        throw new Error('boom')
+      })
+    ).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(queue.getState()).toEqual({
+      dropped: 0,
+      inFlight: 0,
+      queued: 0,
+    })
+    expect(queue.enqueue('two', async () => {})).toBe(true)
+  })
+
+  it('ignores stale in-flight completions after a test reset', async () => {
+    let resolveFirst!: () => void
+    const firstRun = new Promise<void>((resolve) => {
+      resolveFirst = resolve
+    })
+    const onResult = mock(() => {})
+    const queue = createBoundedAsyncQueue<string>({
+      maxInFlight: 1,
+      maxQueueDepth: 1,
+      onResult,
+    })
+
+    expect(queue.enqueue('one', async () => firstRun)).toBe(true)
+    queue.resetForTests()
+    expect(queue.enqueue('two', async () => {})).toBe(true)
+
+    resolveFirst()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(queue.getState()).toEqual({
+      dropped: 0,
+      inFlight: 0,
+      queued: 0,
+    })
+    expect(onResult).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/api/src/lib/bounded-async-queue.ts
+++ b/apps/api/src/lib/bounded-async-queue.ts
@@ -1,0 +1,134 @@
+export type BoundedAsyncQueueProcessor<TInput, TResult = void> = (
+  input: TInput
+) => Promise<TResult>
+
+export interface BoundedAsyncQueueState {
+  dropped: number
+  inFlight: number
+  queued: number
+}
+
+interface PendingQueueItem<TInput, TResult> {
+  input: TInput
+  process: BoundedAsyncQueueProcessor<TInput, TResult>
+}
+
+interface CreateBoundedAsyncQueueOptions<TInput, TResult> {
+  maxInFlight: number
+  maxQueueDepth: number
+  onDrop?: (input: TInput, state: BoundedAsyncQueueState) => void
+  onError?: (error: unknown, input: TInput) => void
+  onResult?: (result: TResult, input: TInput) => void
+}
+
+export function createBoundedAsyncQueue<TInput, TResult = void>({
+  maxInFlight,
+  maxQueueDepth,
+  onDrop,
+  onError,
+  onResult,
+}: CreateBoundedAsyncQueueOptions<TInput, TResult>) {
+  let inFlight = 0
+  let dropped = 0
+  let epoch = 0
+  const pending: PendingQueueItem<TInput, TResult>[] = []
+
+  function getState(): BoundedAsyncQueueState {
+    return {
+      dropped,
+      inFlight,
+      queued: pending.length,
+    }
+  }
+
+  function notifyDrop(input: TInput): void {
+    if (!onDrop) return
+
+    try {
+      onDrop(input, getState())
+    } catch {
+      // Queue accounting must not be disrupted by operational metric hooks.
+    }
+  }
+
+  function notifyError(error: unknown, input: TInput): void {
+    if (!onError) return
+
+    try {
+      onError(error, input)
+    } catch {
+      // Queue workers should keep draining even if an error hook fails.
+    }
+  }
+
+  function notifyResult(result: TResult, input: TInput): void {
+    if (!onResult) return
+
+    try {
+      onResult(result, input)
+    } catch (error) {
+      notifyError(error, input)
+    }
+  }
+
+  function dispatch(item: PendingQueueItem<TInput, TResult>): void {
+    inFlight += 1
+    const dispatchEpoch = epoch
+    void Promise.resolve()
+      .then(() => item.process(item.input))
+      .then((result) => {
+        if (dispatchEpoch !== epoch) return
+        notifyResult(result, item.input)
+      })
+      .catch((error) => {
+        if (dispatchEpoch !== epoch) return
+        notifyError(error, item.input)
+      })
+      .finally(() => {
+        if (dispatchEpoch !== epoch) return
+        inFlight -= 1
+        flush()
+      })
+  }
+
+  function flush(): void {
+    while (inFlight < maxInFlight && pending.length > 0) {
+      const next = pending.shift()
+      if (!next) break
+      dispatch(next)
+    }
+  }
+
+  function enqueue(
+    input: TInput,
+    process: BoundedAsyncQueueProcessor<TInput, TResult>
+  ): boolean {
+    if (inFlight < maxInFlight && pending.length === 0) {
+      dispatch({ input, process })
+      return true
+    }
+
+    if (pending.length >= maxQueueDepth) {
+      dropped += 1
+      notifyDrop(input)
+      return false
+    }
+
+    pending.push({ input, process })
+    flush()
+    return true
+  }
+
+  function resetForTests(): void {
+    epoch += 1
+    inFlight = 0
+    dropped = 0
+    pending.length = 0
+  }
+
+  return {
+    enqueue,
+    getState,
+    resetForTests,
+  }
+}

--- a/apps/api/src/lib/bounded-async-queue.ts
+++ b/apps/api/src/lib/bounded-async-queue.ts
@@ -28,6 +28,14 @@ export function createBoundedAsyncQueue<TInput, TResult = void>({
   onError,
   onResult,
 }: CreateBoundedAsyncQueueOptions<TInput, TResult>) {
+  if (!Number.isInteger(maxInFlight) || maxInFlight < 1) {
+    throw new RangeError('maxInFlight must be a positive integer')
+  }
+
+  if (!Number.isInteger(maxQueueDepth) || maxQueueDepth < 0) {
+    throw new RangeError('maxQueueDepth must be a non-negative integer')
+  }
+
   let inFlight = 0
   let dropped = 0
   let epoch = 0

--- a/apps/api/src/lib/telemetry-queue-metrics.ts
+++ b/apps/api/src/lib/telemetry-queue-metrics.ts
@@ -1,0 +1,44 @@
+export type TelemetryQueueName =
+  | 'mcp_analytics'
+  | 'telemetry_collect'
+  | 'telemetry_events'
+
+interface TelemetryQueueDropInput {
+  dropped: number
+  inFlight: number
+  queueName: TelemetryQueueName
+  queued: number
+}
+
+const dropTotals = new Map<TelemetryQueueName, number>()
+
+export function recordTelemetryQueueDrop({
+  dropped,
+  inFlight,
+  queueName,
+  queued,
+}: TelemetryQueueDropInput): void {
+  dropTotals.set(queueName, (dropTotals.get(queueName) ?? 0) + 1)
+
+  console.info(
+    JSON.stringify({
+      type: 'telemetry_queue',
+      signal: 'queue_dropped',
+      queueName,
+      count: 1,
+      dropped,
+      inFlight,
+      queued,
+    })
+  )
+}
+
+/** Test-only helper for asserting operational telemetry queue counters. */
+export function getTelemetryQueueDropTotalsForTests(): ReadonlyMap<TelemetryQueueName, number> {
+  return dropTotals
+}
+
+/** Test-only helper to reset queue counters between tests. */
+export function resetTelemetryQueueDropTotalsForTests(): void {
+  dropTotals.clear()
+}

--- a/apps/api/src/mcp/observability/mcp-analytics-queue.test.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics-queue.test.ts
@@ -1,19 +1,28 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { AnalyticsEvents } from '@durabull/analytics/events'
 
+import {
+  getTelemetryQueueDropTotalsForTests,
+  resetTelemetryQueueDropTotalsForTests,
+} from '../../lib/telemetry-queue-metrics'
 import { enqueueMcpAnalytics, resetMcpAnalyticsQueueForTests } from './mcp-analytics-queue'
 import type { McpAnalyticsInput } from './mcp-analytics'
 
+const originalInfo = console.info
 const originalWarn = console.warn
 
 describe('mcp analytics queue', () => {
   afterEach(() => {
+    console.info = originalInfo
     console.warn = originalWarn
     resetMcpAnalyticsQueueForTests()
+    resetTelemetryQueueDropTotalsForTests()
   })
 
-  it('warns when dropping events because the queue is full', () => {
+  it('warns and records a drop metric when dropping events because the queue is full', () => {
+    const info = mock(() => {})
     const warn = mock(() => {})
+    console.info = info as unknown as typeof console.info
     console.warn = warn as unknown as typeof console.warn
     const process = mock(async () => new Promise<void>(() => {}))
     const input: McpAnalyticsInput = {
@@ -26,5 +35,17 @@ describe('mcp analytics queue', () => {
     }
 
     expect(warn).toHaveBeenCalledWith('[analytics] MCP analytics queue full; dropping event')
+    expect(getTelemetryQueueDropTotalsForTests().get('mcp_analytics')).toBe(1)
+    expect(info).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'telemetry_queue',
+        signal: 'queue_dropped',
+        queueName: 'mcp_analytics',
+        count: 1,
+        dropped: 1,
+        inFlight: 8,
+        queued: 512,
+      })
+    )
   })
 })

--- a/apps/api/src/mcp/observability/mcp-analytics-queue.ts
+++ b/apps/api/src/mcp/observability/mcp-analytics-queue.ts
@@ -1,53 +1,37 @@
+import { createBoundedAsyncQueue } from '../../lib/bounded-async-queue'
+import { recordTelemetryQueueDrop } from '../../lib/telemetry-queue-metrics'
 import type { McpAnalyticsInput } from './mcp-analytics'
 
 const MAX_ANALYTICS_IN_FLIGHT = 8
 const MAX_ANALYTICS_QUEUE_DEPTH = 512
 
-let analyticsInFlight = 0
-const pendingAnalytics: McpAnalyticsInput[] = []
-
 export type ProcessMcpAnalytics = (input: McpAnalyticsInput) => Promise<void>
+
+const analyticsQueue = createBoundedAsyncQueue<McpAnalyticsInput>({
+  maxInFlight: MAX_ANALYTICS_IN_FLIGHT,
+  maxQueueDepth: MAX_ANALYTICS_QUEUE_DEPTH,
+  onDrop: (_input, state) => {
+    recordTelemetryQueueDrop({
+      dropped: state.dropped,
+      inFlight: state.inFlight,
+      queueName: 'mcp_analytics',
+      queued: state.queued,
+    })
+    console.warn('[analytics] MCP analytics queue full; dropping event')
+  },
+  onError: () => {
+    // Analytics must never affect MCP behavior.
+  },
+})
 
 export function enqueueMcpAnalytics(
   input: McpAnalyticsInput,
   process: ProcessMcpAnalytics
 ): void {
-  if (analyticsInFlight < MAX_ANALYTICS_IN_FLIGHT && pendingAnalytics.length === 0) {
-    dispatchMcpAnalytics(input, process)
-    return
-  }
-
-  if (pendingAnalytics.length >= MAX_ANALYTICS_QUEUE_DEPTH) {
-    console.warn('[analytics] MCP analytics queue full; dropping event')
-    return
-  }
-
-  pendingAnalytics.push(input)
-  flushPendingMcpAnalytics(process)
-}
-
-function dispatchMcpAnalytics(input: McpAnalyticsInput, process: ProcessMcpAnalytics): void {
-  analyticsInFlight += 1
-  void process(input)
-    .catch(() => {
-      // Analytics must never affect MCP behavior.
-    })
-    .finally(() => {
-      analyticsInFlight -= 1
-      flushPendingMcpAnalytics(process)
-    })
-}
-
-function flushPendingMcpAnalytics(process: ProcessMcpAnalytics): void {
-  while (analyticsInFlight < MAX_ANALYTICS_IN_FLIGHT && pendingAnalytics.length > 0) {
-    const next = pendingAnalytics.shift()
-    if (!next) break
-    dispatchMcpAnalytics(next, process)
-  }
+  analyticsQueue.enqueue(input, process)
 }
 
 /** Test-only */
 export function resetMcpAnalyticsQueueForTests(): void {
-  analyticsInFlight = 0
-  pendingAnalytics.length = 0
+  analyticsQueue.resetForTests()
 }

--- a/apps/api/src/routes/telemetry-collect-queue.test.ts
+++ b/apps/api/src/routes/telemetry-collect-queue.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+import { resetTelemetryQueueDropTotalsForTests } from '../lib/telemetry-queue-metrics'
+import {
+  enqueueTelemetryCollectBatch,
+  resetTelemetryCollectQueueForTests,
+} from './telemetry-collect-queue'
+
+const originalInfo = console.info
+
+describe('telemetry collect queue', () => {
+  afterEach(() => {
+    console.info = originalInfo
+    resetTelemetryCollectQueueForTests()
+    resetTelemetryQueueDropTotalsForTests()
+  })
+
+  it('rejects new batches and records a drop metric when the bounded queue is full', () => {
+    const info = mock(() => {})
+    console.info = info as unknown as typeof console.info
+    const process = mock(async () => new Promise<never>(() => {}))
+    const input = {
+      events: [{ event: 'queue_paused', properties: {}, sessionId: 'session-1' }],
+      instanceId: 'instance-1',
+    }
+
+    for (let i = 0; i < 4 + 256; i += 1) {
+      expect(enqueueTelemetryCollectBatch(input, process)).toBe(true)
+    }
+
+    expect(enqueueTelemetryCollectBatch(input, process)).toBe(false)
+    expect(info).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'telemetry_queue',
+        signal: 'queue_dropped',
+        queueName: 'telemetry_collect',
+        count: 1,
+        dropped: 1,
+        inFlight: 4,
+        queued: 256,
+      })
+    )
+  })
+})

--- a/apps/api/src/routes/telemetry-collect-queue.ts
+++ b/apps/api/src/routes/telemetry-collect-queue.ts
@@ -4,6 +4,8 @@ import {
   type ServerAnalyticsRuntimeContext,
   type TelemetryCollectEventInput,
 } from '@durabull/analytics/server'
+import { createBoundedAsyncQueue } from '../lib/bounded-async-queue'
+import { recordTelemetryQueueDrop } from '../lib/telemetry-queue-metrics'
 
 interface TelemetryCollectQueueItem {
   instanceId: string
@@ -15,9 +17,6 @@ interface TelemetryCollectQueueItem {
 const MAX_COLLECT_IN_FLIGHT = 4
 const MAX_COLLECT_QUEUE_DEPTH = 256
 
-let collectInFlight = 0
-const pendingCollectBatches: TelemetryCollectQueueItem[] = []
-
 type ProcessCollectBatch = (input: TelemetryCollectQueueItem) => Promise<IngestCollectBatchResult>
 
 function logCollectFailure(result: IngestCollectBatchResult): void {
@@ -25,47 +24,34 @@ function logCollectFailure(result: IngestCollectBatchResult): void {
   console.warn(`[analytics] async /collect batch failed: ${result.error}`)
 }
 
-function dispatchCollectBatch(input: TelemetryCollectQueueItem, process: ProcessCollectBatch): void {
-  collectInFlight += 1
-  void process(input)
-    .then(logCollectFailure)
-    .catch(() => {
-      console.warn('[analytics] async /collect batch threw unexpectedly')
+const collectQueue = createBoundedAsyncQueue<
+  TelemetryCollectQueueItem,
+  IngestCollectBatchResult
+>({
+  maxInFlight: MAX_COLLECT_IN_FLIGHT,
+  maxQueueDepth: MAX_COLLECT_QUEUE_DEPTH,
+  onDrop: (_input, state) => {
+    recordTelemetryQueueDrop({
+      dropped: state.dropped,
+      inFlight: state.inFlight,
+      queueName: 'telemetry_collect',
+      queued: state.queued,
     })
-    .finally(() => {
-      collectInFlight -= 1
-      flushPendingCollectBatches(process)
-    })
-}
-
-function flushPendingCollectBatches(process: ProcessCollectBatch): void {
-  while (collectInFlight < MAX_COLLECT_IN_FLIGHT && pendingCollectBatches.length > 0) {
-    const next = pendingCollectBatches.shift()
-    if (!next) break
-    dispatchCollectBatch(next, process)
-  }
-}
+  },
+  onError: () => {
+    console.warn('[analytics] async /collect batch threw unexpectedly')
+  },
+  onResult: logCollectFailure,
+})
 
 export function enqueueTelemetryCollectBatch(
   input: TelemetryCollectQueueItem,
   process: ProcessCollectBatch = ingestTelemetryCollectBatch
 ): boolean {
-  if (collectInFlight < MAX_COLLECT_IN_FLIGHT && pendingCollectBatches.length === 0) {
-    dispatchCollectBatch(input, process)
-    return true
-  }
-
-  if (pendingCollectBatches.length >= MAX_COLLECT_QUEUE_DEPTH) {
-    return false
-  }
-
-  pendingCollectBatches.push(input)
-  flushPendingCollectBatches(process)
-  return true
+  return collectQueue.enqueue(input, process)
 }
 
 /** Test-only */
 export function resetTelemetryCollectQueueForTests(): void {
-  collectInFlight = 0
-  pendingCollectBatches.length = 0
+  collectQueue.resetForTests()
 }

--- a/apps/api/src/routes/telemetry-events-queue.test.ts
+++ b/apps/api/src/routes/telemetry-events-queue.test.ts
@@ -1,13 +1,23 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 
+import {
+  getTelemetryQueueDropTotalsForTests,
+  resetTelemetryQueueDropTotalsForTests,
+} from '../lib/telemetry-queue-metrics'
 import { enqueueTelemetryEvent, resetTelemetryEventsQueueForTests } from './telemetry-events-queue'
+
+const originalInfo = console.info
 
 describe('telemetry events queue', () => {
   afterEach(() => {
+    console.info = originalInfo
     resetTelemetryEventsQueueForTests()
+    resetTelemetryQueueDropTotalsForTests()
   })
 
-  it('rejects new events when the bounded queue is full', () => {
+  it('rejects new events and records a drop metric when the bounded queue is full', () => {
+    const info = mock(() => {})
+    console.info = info as unknown as typeof console.info
     const process = mock(async () => new Promise<void>(() => {}))
     const input = {
       event: 'queue_paused',
@@ -21,5 +31,17 @@ describe('telemetry events queue', () => {
     }
 
     expect(enqueueTelemetryEvent(input, process)).toBe(false)
+    expect(getTelemetryQueueDropTotalsForTests().get('telemetry_events')).toBe(1)
+    expect(info).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'telemetry_queue',
+        signal: 'queue_dropped',
+        queueName: 'telemetry_events',
+        count: 1,
+        dropped: 1,
+        inFlight: 4,
+        queued: 256,
+      })
+    )
   })
 })

--- a/apps/api/src/routes/telemetry-events-queue.ts
+++ b/apps/api/src/routes/telemetry-events-queue.ts
@@ -2,6 +2,8 @@ import {
   captureAnonymousServerEvent,
   tryGetServerAnalyticsOptions,
 } from '@durabull/analytics/server'
+import { createBoundedAsyncQueue } from '../lib/bounded-async-queue'
+import { recordTelemetryQueueDrop } from '../lib/telemetry-queue-metrics'
 
 interface TelemetryEventQueueItem {
   event: string
@@ -12,9 +14,6 @@ interface TelemetryEventQueueItem {
 
 const MAX_EVENTS_IN_FLIGHT = 4
 const MAX_EVENTS_QUEUE_DEPTH = 256
-
-let eventsInFlight = 0
-const pendingEvents: TelemetryEventQueueItem[] = []
 
 type ProcessTelemetryEvent = (input: TelemetryEventQueueItem) => Promise<void>
 
@@ -32,46 +31,30 @@ async function processTelemetryEvent(input: TelemetryEventQueueItem): Promise<vo
   })
 }
 
-function dispatchTelemetryEvent(input: TelemetryEventQueueItem, process: ProcessTelemetryEvent): void {
-  eventsInFlight += 1
-  void process(input)
-    .catch(() => {
-      // Local telemetry must never affect the product experience.
+const eventsQueue = createBoundedAsyncQueue<TelemetryEventQueueItem>({
+  maxInFlight: MAX_EVENTS_IN_FLIGHT,
+  maxQueueDepth: MAX_EVENTS_QUEUE_DEPTH,
+  onDrop: (_input, state) => {
+    recordTelemetryQueueDrop({
+      dropped: state.dropped,
+      inFlight: state.inFlight,
+      queueName: 'telemetry_events',
+      queued: state.queued,
     })
-    .finally(() => {
-      eventsInFlight -= 1
-      flushPendingTelemetryEvents(process)
-    })
-}
-
-function flushPendingTelemetryEvents(process: ProcessTelemetryEvent): void {
-  while (eventsInFlight < MAX_EVENTS_IN_FLIGHT && pendingEvents.length > 0) {
-    const next = pendingEvents.shift()
-    if (!next) break
-    dispatchTelemetryEvent(next, process)
-  }
-}
+  },
+  onError: () => {
+    // Local telemetry must never affect the product experience.
+  },
+})
 
 export function enqueueTelemetryEvent(
   input: TelemetryEventQueueItem,
   process: ProcessTelemetryEvent = processTelemetryEvent
 ): boolean {
-  if (eventsInFlight < MAX_EVENTS_IN_FLIGHT && pendingEvents.length === 0) {
-    dispatchTelemetryEvent(input, process)
-    return true
-  }
-
-  if (pendingEvents.length >= MAX_EVENTS_QUEUE_DEPTH) {
-    return false
-  }
-
-  pendingEvents.push(input)
-  flushPendingTelemetryEvents(process)
-  return true
+  return eventsQueue.enqueue(input, process)
 }
 
 /** Test-only */
 export function resetTelemetryEventsQueueForTests(): void {
-  eventsInFlight = 0
-  pendingEvents.length = 0
+  eventsQueue.resetForTests()
 }

--- a/apps/docs/content/documentation/getting-started/environment-variables.mdx
+++ b/apps/docs/content/documentation/getting-started/environment-variables.mdx
@@ -93,6 +93,17 @@ raw URLs, search patterns, stack traces, or raw error messages.
 Self-hosted deployments do not need a separate collector service or telemetry hostname. The app
 forwards sanitized telemetry to Durabull's existing cloud API.
 
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `DURABULL_TELEMETRY_COLLECT_SECRET` | Cloud + self-hosted telemetry forwarding | HMAC signing secret for batches sent to `/api/telemetry/collect` |
+| `DURABULL_TELEMETRY_HMAC_SECRET` | Production telemetry | Dedicated HMAC secret for anonymous instance and distinct identifiers. This is not derived from `BETTER_AUTH_SECRET`. |
+| `DURABULL_CLOUD` | Durabull cloud collector only | Enables cloud-only telemetry collection behavior |
+| `TRUST_PROXY` | Behind a trusted reverse proxy | Honors forwarding headers for rate limits and request context |
+
+Telemetry queue backpressure emits stdout JSON with `type: "telemetry_queue"` and
+`signal: "queue_dropped"`. These operational signals report queue names and counts only; they do not
+include user, organization, Redis, queue, job, key, URL, or payload values.
+
 ## Optional Runtime Toggles
 
 | Variable | Required | Purpose |

--- a/apps/docs/content/documentation/reference/http-api.mdx
+++ b/apps/docs/content/documentation/reference/http-api.mdx
@@ -96,6 +96,11 @@ aggregate buckets. It does not include Redis URLs, queue names, Redis key names,
 emails, names, organizations, hostnames, raw URLs, search patterns, stack traces, or raw error
 messages.
 
+Telemetry endpoints return `202` after a sanitized event or batch is accepted into the bounded
+background queue. If the queue is full, the endpoint returns `503` and the API emits a stdout
+`telemetry_queue` signal with `signal: "queue_dropped"` and the operational queue name. That signal
+contains only queue depth counters and does not include product event properties.
+
 ## Connection Management
 
 - `GET /api/connections`

--- a/apps/web/src/components/add-job-dialog.tsx
+++ b/apps/web/src/components/add-job-dialog.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { Loader2, Plus } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'

--- a/apps/web/src/components/add-job-dialog.tsx
+++ b/apps/web/src/components/add-job-dialog.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { Loader2, Plus } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -107,7 +107,7 @@ export function AddJobDialog({ open, onOpenChange, queueName, onSuccess }: AddJo
       open={open}
       onOpenChange={(newOpen) => {
         trackEvent(newOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
-          dialog_type: DialogType.ADD_JOB,
+          [AnalyticsProperties.DIALOG_TYPE]: DialogType.ADD_JOB,
         })
         onOpenChange(newOpen)
       }}

--- a/apps/web/src/components/app-update-banner.test.tsx
+++ b/apps/web/src/components/app-update-banner.test.tsx
@@ -1,4 +1,4 @@
-import { AnalyticsEvents } from '@durabull/analytics'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,13 +9,9 @@ const mocks = vi.hoisted(() => ({
   useAppVersionCheck: vi.fn(),
 }))
 
-vi.mock('@durabull/analytics', async () => {
-  const actual = await vi.importActual<typeof import('@durabull/analytics')>('@durabull/analytics')
-  return {
-    ...actual,
-    trackEvent: mocks.trackEvent,
-  }
-})
+vi.mock('@durabull/analytics/browser', () => ({
+  trackEvent: mocks.trackEvent,
+}))
 
 vi.mock('@/hooks/use-app-version-check', () => ({
   useAppVersionCheck: mocks.useAppVersionCheck,

--- a/apps/web/src/components/app-update-banner.tsx
+++ b/apps/web/src/components/app-update-banner.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, AnalyticsProperties, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, AnalyticsProperties } from '@durabull/analytics/events'
 import { RefreshCw } from 'lucide-react'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'

--- a/apps/web/src/components/connection-selector.tsx
+++ b/apps/web/src/components/connection-selector.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import {
   AlertCircle,
   Check,

--- a/apps/web/src/components/delete-job-logs-button.tsx
+++ b/apps/web/src/components/delete-job-logs-button.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { AlertTriangle, ChevronDown, Loader2, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
@@ -137,7 +137,7 @@ export function DeleteJobLogsButton({ queueName, jobId, logCount }: DeleteJobLog
         open={confirmOpen}
         onOpenChange={(newOpen) => {
           trackEvent(newOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
-            dialog_type: DialogType.DELETE_JOB_LOGS,
+            [AnalyticsProperties.DIALOG_TYPE]: DialogType.DELETE_JOB_LOGS,
           })
           setConfirmOpen(newOpen)
         }}

--- a/apps/web/src/components/delete-job-logs-button.tsx
+++ b/apps/web/src/components/delete-job-logs-button.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { AlertTriangle, ChevronDown, Loader2, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'

--- a/apps/web/src/components/delete-queue-dialog.tsx
+++ b/apps/web/src/components/delete-queue-dialog.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { useState, useEffect } from 'react'
 import { AlertTriangle, Trash2, Loader2 } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'

--- a/apps/web/src/components/delete-queue-dialog.tsx
+++ b/apps/web/src/components/delete-queue-dialog.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { useState, useEffect } from 'react'
 import { AlertTriangle, Trash2, Loader2 } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
@@ -60,11 +60,11 @@ export function DeleteQueueDialog({ queueName, open, onOpenChange }: DeleteQueue
       onOpenChange={(newOpen) => {
         if (newOpen) {
           trackEvent(AnalyticsEvents.DIALOG_OPENED, {
-            dialog_type: DialogType.DELETE_QUEUE,
+            [AnalyticsProperties.DIALOG_TYPE]: DialogType.DELETE_QUEUE,
           })
         } else {
           trackEvent(AnalyticsEvents.DIALOG_CLOSED, {
-            dialog_type: DialogType.DELETE_QUEUE,
+            [AnalyticsProperties.DIALOG_TYPE]: DialogType.DELETE_QUEUE,
           })
         }
         onOpenChange(newOpen)

--- a/apps/web/src/components/duplicate-job-dialog.tsx
+++ b/apps/web/src/components/duplicate-job-dialog.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { Copy, Loader2, Play } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'

--- a/apps/web/src/components/duplicate-job-dialog.tsx
+++ b/apps/web/src/components/duplicate-job-dialog.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { Copy, Loader2, Play } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -113,7 +113,7 @@ export function DuplicateJobDialog({
       open={open}
       onOpenChange={(newOpen) => {
         trackEvent(newOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
-          dialog_type: DialogType.DUPLICATE_JOB,
+          [AnalyticsProperties.DIALOG_TYPE]: DialogType.DUPLICATE_JOB,
         })
         onOpenChange(newOpen)
       }}

--- a/apps/web/src/components/invoke-job-dialog.tsx
+++ b/apps/web/src/components/invoke-job-dialog.tsx
@@ -1,7 +1,8 @@
 import { Loader2, Zap } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { JsonEditor } from '@/components/json-editor'
 import { Button } from '@/components/ui/button'
 import {

--- a/apps/web/src/components/invoke-job-dialog.tsx
+++ b/apps/web/src/components/invoke-job-dialog.tsx
@@ -2,7 +2,7 @@ import { Loader2, Zap } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { JsonEditor } from '@/components/json-editor'
 import { Button } from '@/components/ui/button'
 import {
@@ -82,7 +82,7 @@ export function InvokeJobDialog({
       open={open}
       onOpenChange={(newOpen) => {
         trackEvent(newOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
-          dialog_type: DialogType.INVOKE_JOB,
+          [AnalyticsProperties.DIALOG_TYPE]: DialogType.INVOKE_JOB,
         })
         onOpenChange(newOpen)
       }}

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { useNavigate } from '@tanstack/react-router'
 import { ChevronsUpDown, LogOut, Monitor, Moon, Settings, Sun } from 'lucide-react'
 import { useTheme } from '@/components/theme-provider'

--- a/apps/web/src/components/organization-onboarding.tsx
+++ b/apps/web/src/components/organization-onboarding.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { Link } from '@tanstack/react-router'
 import { motion } from 'framer-motion'
 import type { LucideIcon } from 'lucide-react'

--- a/apps/web/src/components/organization-selector.tsx
+++ b/apps/web/src/components/organization-selector.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { AlertCircle, Building2, Check, ChevronsUpDown, Loader2, Plus, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'

--- a/apps/web/src/components/organization-selector.tsx
+++ b/apps/web/src/components/organization-selector.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { AlertCircle, Building2, Check, ChevronsUpDown, Loader2, Plus, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -223,11 +223,11 @@ function CreateOrganizationDialog({
       onOpenChange={(newOpen) => {
         if (newOpen) {
           trackEvent(AnalyticsEvents.DIALOG_OPENED, {
-            dialog_type: DialogType.CREATE_ORGANIZATION,
+            [AnalyticsProperties.DIALOG_TYPE]: DialogType.CREATE_ORGANIZATION,
           })
         } else {
           trackEvent(AnalyticsEvents.DIALOG_CLOSED, {
-            dialog_type: DialogType.CREATE_ORGANIZATION,
+            [AnalyticsProperties.DIALOG_TYPE]: DialogType.CREATE_ORGANIZATION,
           })
         }
         onOpenChange(newOpen)

--- a/apps/web/src/components/purge-queue-dialog.tsx
+++ b/apps/web/src/components/purge-queue-dialog.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { Loader2, Trash2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'

--- a/apps/web/src/components/purge-queue-dialog.tsx
+++ b/apps/web/src/components/purge-queue-dialog.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { Loader2, Trash2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -190,7 +190,7 @@ export function PurgeQueueDialog({
       open={open}
       onOpenChange={(newOpen) => {
         trackEvent(newOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
-          dialog_type: DialogType.PURGE_QUEUE,
+          [AnalyticsProperties.DIALOG_TYPE]: DialogType.PURGE_QUEUE,
         })
         onOpenChange(newOpen)
       }}

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import {
   AlertCircle,

--- a/apps/web/src/hooks/use-connections.ts
+++ b/apps/web/src/hooks/use-connections.ts
@@ -3,7 +3,8 @@
  * Types are automatically inferred from the server via InferResponseType
  */
 
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { connectionsQueryKey } from '@/components/connection-provider'
 import { api, handleRes, type InferResponseType } from '@/lib/api'

--- a/apps/web/src/hooks/use-organization.ts
+++ b/apps/web/src/hooks/use-organization.ts
@@ -1,9 +1,9 @@
 import {
-  AnalyticsEvents,
   identifyOrganization,
   trackEvent,
   trackOrganizationCreated,
-} from '@durabull/analytics'
+} from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { organization } from '@durabull/auth/client'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'

--- a/apps/web/src/hooks/use-page-view-tracking.ts
+++ b/apps/web/src/hooks/use-page-view-tracking.ts
@@ -1,4 +1,4 @@
-import { trackPageView } from '@durabull/analytics'
+import { trackPageView } from '@durabull/analytics/browser'
 import { useLocation } from '@tanstack/react-router'
 import { useEffect, useRef } from 'react'
 

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -3,7 +3,8 @@
  * Types are inferred from the server via InferResponseType
  */
 
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import { useConnection } from '@/components/connection-provider'

--- a/apps/web/src/hooks/use-redis-keys.ts
+++ b/apps/web/src/hooks/use-redis-keys.ts
@@ -3,7 +3,8 @@
  * Types are inferred from the server via InferResponseType
  */
 
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useConnection } from '@/components/connection-provider'
 import { ApiError, api, handleRes, type InferResponseType } from '@/lib/api'

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,4 @@
-import { configureDurabullTelemetry } from '@durabull/analytics'
+import { configureDurabullTelemetry } from '@durabull/analytics/browser'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { zodValidator } from '@tanstack/zod-adapter'
 import {

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { zodValidator } from '@tanstack/zod-adapter'

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.scheduled-jobs.$schedulerId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.scheduled-jobs.$schedulerId.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { ArrowLeft, ChevronRight, Layers } from 'lucide-react'
 import { useCallback, useEffect, useMemo } from 'react'

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.scheduled-jobs.new.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.scheduled-jobs.new.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { ArrowLeft, ChevronRight, Layers } from 'lucide-react'
 import { useCallback, useEffect, useMemo } from 'react'

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.redis-keys.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.redis-keys.tsx
@@ -10,7 +10,8 @@ interface RedisKeyInfo {
   memoryBytes?: number
 }
 
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   AlertCircle,

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.scheduled-jobs.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.scheduled-jobs.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import {
   AlertCircle,

--- a/apps/web/src/routes/$orgSlug.connections.tsx
+++ b/apps/web/src/routes/$orgSlug.connections.tsx
@@ -12,7 +12,8 @@ interface RedisConnection {
   prefix: string
 }
 
-import { AnalyticsEvents, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
 import {
   AlertCircle,
   Check,

--- a/apps/web/src/routes/$orgSlug.team.tsx
+++ b/apps/web/src/routes/$orgSlug.team.tsx
@@ -62,7 +62,8 @@ import {
   useResendInvitation,
   useUpdateMemberRole,
 } from '@/hooks/use-organization'
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/$orgSlug/team')({

--- a/apps/web/src/routes/$orgSlug.team.tsx
+++ b/apps/web/src/routes/$orgSlug.team.tsx
@@ -63,7 +63,7 @@ import {
   useUpdateMemberRole,
 } from '@/hooks/use-organization'
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/$orgSlug/team')({
@@ -275,7 +275,7 @@ function TeamPage() {
                   canManage={canManageMembers && member.role !== 'owner'}
                   onRemove={() => {
                     trackEvent(AnalyticsEvents.DIALOG_OPENED, {
-                      dialog_type: DialogType.REMOVE_MEMBER,
+                      [AnalyticsProperties.DIALOG_TYPE]: DialogType.REMOVE_MEMBER,
                     })
                     setRemovingMember(member)
                   }}
@@ -308,7 +308,7 @@ function TeamPage() {
                     organizationId={activeOrg?.id ?? ''}
                     onCancel={() => {
                       trackEvent(AnalyticsEvents.DIALOG_OPENED, {
-                        dialog_type: DialogType.CANCEL_INVITATION,
+                        [AnalyticsProperties.DIALOG_TYPE]: DialogType.CANCEL_INVITATION,
                       })
                       setCancelingInvitation(invitation)
                     }}
@@ -325,7 +325,7 @@ function TeamPage() {
         open={inviteDialogOpen}
         onOpenChange={(open) => {
           trackEvent(open ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
-            dialog_type: DialogType.INVITE_MEMBER,
+            [AnalyticsProperties.DIALOG_TYPE]: DialogType.INVITE_MEMBER,
           })
           setInviteDialogOpen(open)
         }}
@@ -339,7 +339,7 @@ function TeamPage() {
         onOpenChange={(open) => {
           if (!open) {
             trackEvent(AnalyticsEvents.DIALOG_CLOSED, {
-              dialog_type: DialogType.REMOVE_MEMBER,
+              [AnalyticsProperties.DIALOG_TYPE]: DialogType.REMOVE_MEMBER,
             })
             setRemovingMember(null)
           }
@@ -353,7 +353,7 @@ function TeamPage() {
         onOpenChange={(open) => {
           if (!open) {
             trackEvent(AnalyticsEvents.DIALOG_CLOSED, {
-              dialog_type: DialogType.CANCEL_INVITATION,
+              [AnalyticsProperties.DIALOG_TYPE]: DialogType.CANCEL_INVITATION,
             })
             setCancelingInvitation(null)
           }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import { configureDurabullTelemetry } from '@durabull/analytics'
+import { configureDurabullTelemetry } from '@durabull/analytics/browser'
 import type { QueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import {

--- a/apps/web/src/routes/job-detail-remove.test.tsx
+++ b/apps/web/src/routes/job-detail-remove.test.tsx
@@ -30,12 +30,15 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigateMock,
 }))
 
-vi.mock('@durabull/analytics', () => ({
+vi.mock('@durabull/analytics/browser', () => ({
+  trackEvent: trackEventMock,
+}))
+
+vi.mock('@durabull/analytics/events', () => ({
   AnalyticsEvents: {
     JOB_VIEWED: 'JOB_VIEWED',
     JOB_TAB_CHANGED: 'JOB_TAB_CHANGED',
   },
-  trackEvent: trackEventMock,
 }))
 
 vi.mock('@/components/app-top-bar', () => ({
@@ -70,6 +73,13 @@ vi.mock('@/components/queue-name-tag', () => ({
 
 vi.mock('@/components/retry-countdown', () => ({
   RetryCountdown: () => null,
+}))
+
+vi.mock('@/hooks/use-alerts', () => ({
+  useConnectionAlertEvents: () => ({
+    data: { events: [] },
+    isLoading: false,
+  }),
 }))
 
 vi.mock('@/hooks/use-queues', () => ({

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, AuthMethod, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, AuthMethod } from '@durabull/analytics/events'
 import {
   buildMcpAuthorizeResumeUrl,
   hasMcpAuthorizeQuery,

--- a/apps/web/src/routes/queue-detail-remove.test.tsx
+++ b/apps/web/src/routes/queue-detail-remove.test.tsx
@@ -48,11 +48,14 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigateMock,
 }))
 
-vi.mock('@durabull/analytics', () => ({
+vi.mock('@durabull/analytics/browser', () => ({
+  trackEvent: trackEventMock,
+}))
+
+vi.mock('@durabull/analytics/events', () => ({
   AnalyticsEvents: {
     QUEUE_VIEWED: 'QUEUE_VIEWED',
   },
-  trackEvent: trackEventMock,
 }))
 
 vi.mock('@/components/app-top-bar', () => ({

--- a/apps/web/src/routes/queue-detail-scheduled-create.test.tsx
+++ b/apps/web/src/routes/queue-detail-scheduled-create.test.tsx
@@ -50,11 +50,14 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigateMock,
 }))
 
-vi.mock('@durabull/analytics', () => ({
+vi.mock('@durabull/analytics/browser', () => ({
+  trackEvent: trackEventMock,
+}))
+
+vi.mock('@durabull/analytics/events', () => ({
   AnalyticsEvents: {
     QUEUE_VIEWED: 'QUEUE_VIEWED',
   },
-  trackEvent: trackEventMock,
 }))
 
 vi.mock('@/components/app-top-bar', () => ({

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -30,7 +30,11 @@ vi.mock('@tanstack/react-router', () => ({
   }),
 }))
 
-vi.mock('@durabull/analytics', () => ({
+vi.mock('@durabull/analytics/browser', () => ({
+  trackEvent: mocks.trackEvent,
+}))
+
+vi.mock('@durabull/analytics/events', () => ({
   AnalyticsEvents: {
     DIALOG_CLOSED: 'DIALOG_CLOSED',
     DIALOG_OPENED: 'DIALOG_OPENED',
@@ -40,7 +44,6 @@ vi.mock('@durabull/analytics', () => ({
   DialogType: {
     UNLINK_ACCOUNT: 'UNLINK_ACCOUNT',
   },
-  trackEvent: mocks.trackEvent,
 }))
 
 vi.mock('@/components/app-top-bar', () => ({

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@durabull/analytics/browser'
-import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { createFileRoute } from '@tanstack/react-router'
 import {
   AlertCircle,
@@ -486,11 +486,11 @@ function SettingsPage() {
         onOpenChange={(open) => {
           if (open) {
             trackEvent(AnalyticsEvents.DIALOG_OPENED, {
-              dialog_type: DialogType.UNLINK_ACCOUNT,
+              [AnalyticsProperties.DIALOG_TYPE]: DialogType.UNLINK_ACCOUNT,
             })
           } else {
             trackEvent(AnalyticsEvents.DIALOG_CLOSED, {
-              dialog_type: DialogType.UNLINK_ACCOUNT,
+              [AnalyticsProperties.DIALOG_TYPE]: DialogType.UNLINK_ACCOUNT,
             })
             setUnlinkingAccount(null)
           }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, DialogType, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, DialogType } from '@durabull/analytics/events'
 import { createFileRoute } from '@tanstack/react-router'
 import {
   AlertCircle,

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -1,4 +1,5 @@
-import { AnalyticsEvents, AuthMethod, trackEvent } from '@durabull/analytics'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, AuthMethod } from '@durabull/analytics/events'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { AlertCircle, Github, Loader2, UserPlus } from 'lucide-react'
 import { useState } from 'react'

--- a/docs/mcp-operations-runbook.md
+++ b/docs/mcp-operations-runbook.md
@@ -119,6 +119,22 @@ Auth failures (`401` / `403`) are returned on the HTTP response; monitor access 
 
 Disable stdout telemetry only if your platform duplicates logs elsewhere: `MCP_TELEMETRY_LOG=false`.
 
+### Structured logs (`telemetry_queue`)
+
+Telemetry ingestion is best-effort and protected by bounded in-process queues. When a telemetry queue is full, the API emits a stdout JSON line with `"type":"telemetry_queue"` and `"signal":"queue_dropped"` before dropping the new item.
+
+| Queue name | Source | Meaning | Operator action |
+| --- | --- | --- | --- |
+| `telemetry_collect` | `POST /api/telemetry/collect` cloud ingestion | Cloud collector cannot enqueue another forwarded batch | Check API CPU/network saturation and PostHog ingestion latency |
+| `telemetry_events` | `POST /api/telemetry/events` local browser telemetry | Self-host/local instance cannot enqueue another product event | Check local API saturation; telemetry loss should not affect product behavior |
+| `mcp_analytics` | MCP product analytics forwarding | MCP analytics event dropped under backpressure | Check MCP traffic spikes and PostHog ingestion latency |
+
+Example log shape:
+
+```json
+{"type":"telemetry_queue","signal":"queue_dropped","queueName":"mcp_analytics","count":1,"dropped":3,"inFlight":8,"queued":512}
+```
+
 ### Per-tool rate limits (60/min default, 30/min heavy tools)
 
 Enforced when `NODE_ENV=production` (skipped in local `development` / `test` unless you run with production `NODE_ENV`).
@@ -149,6 +165,7 @@ Wire your aggregator to count per hour:
 - `mcp_telemetry` where `signal` = `policy_denied`
 - `mcp_telemetry` where `signal` in (`rate_limited_ingress`, `rate_limited_tool`)
 - `mcp_telemetry` where `signal` = `tool_error`
+- `telemetry_queue` where `signal` = `queue_dropped`, grouped by `queueName`
 - HTTP `401` / `403` / `429` on `/mcp` (access logs or edge metrics)
 - `POST /api/auth/mcp/register` volume (dynamic client registration is rate-limited but unauthenticated)
 

--- a/tasks/handoff-analytics-mcp-telemetry.md
+++ b/tasks/handoff-analytics-mcp-telemetry.md
@@ -1,8 +1,8 @@
 # Handoff: Analytics package split + MCP product telemetry
 
-**Branch:** `main` (P2 landed locally; open PR when ready)  
-**Last verified:** 2026-05-28 — run full suite after merge with `main` (see Verification)  
-**Timeline:** #107 → #108 → #109 → #110 → #112 (all merged) → **P2 complete** → P3 next
+**Branch:** `main`
+**Last verified:** 2026-05-28 — P3 focused telemetry/web/docs checks passed; unrelated current-main checks noted below
+**Timeline:** #107 → #108 → #109 → #110 → #112 → #113 (all merged) → **P3 complete locally**
 
 ---
 
@@ -15,7 +15,8 @@
 | **PR #109** | MCP org `$groups` fix, fetch timeouts, single-flight instance id, timestamp clamp, hygiene | ✅ merged |
 | **PR #110** | P0-A `/collect` HMAC auth + trusted OSS runtime; P0-B XFF/proxy trust for rate limits | ✅ merged |
 | **PR #112** | P1: PostHog dedupe/coalesce, connection query de-dup, async `/collect` queue, bounded `/events` queue | ✅ merged |
-| **P2 (local)** | Dedicated `DURABULL_TELEMETRY_HMAC_SECRET`; `/collect` signature replay LRU | ✅ done |
+| **PR #113** | Dedicated `DURABULL_TELEMETRY_HMAC_SECRET`; `/collect` signature replay LRU | ✅ merged |
+| **P3 (local)** | Shared bounded telemetry queue helper, queue-drop operational signal, root barrel migration to `/browser`, telemetry signal docs | ✅ done |
 
 **Lesson:** Branch from latest `origin/main` before starting. Parallel PRs (#109 vs #110) touched the same files — rebase/merge required.
 
@@ -35,6 +36,32 @@
 - Replayed signatures within ±300s return `{ ok: false, error: 'replay' }` → route responds **401**.
 - `resetTelemetryCollectReplayCacheForTests()` exported for test isolation.
 
+## Completed on P3
+
+### Shared bounded telemetry queue
+
+- Added `createBoundedAsyncQueue` and moved `/collect`, `/events`, and MCP analytics onto it.
+- Each queue keeps its existing in-flight/depth limits and test-only reset helpers.
+- Queue-full paths emit a `telemetry_queue` stdout JSON signal with `signal: "queue_dropped"`, queue name, dropped count, in-flight count, and queued count.
+
+### Root barrel migration
+
+- Browser-side analytics imports now use `@durabull/analytics/browser`.
+- Analytics constants/types now use `@durabull/analytics/events`.
+- No TypeScript source/test files import the deprecated root `@durabull/analytics` barrel.
+
+### Telemetry signal docs
+
+- `docs/mcp-operations-runbook.md` documents `telemetry_queue` operational signals and suggested log-derived metrics.
+- Docs environment reference now lists telemetry HMAC/collect secrets and privacy boundaries.
+- HTTP API docs now call out `202` enqueue behavior, `503` backpressure, and queue-drop signal contents.
+
+### Parallel review loop
+
+- Four-lens review found one High correctness issue: stale in-flight queue work could mutate counters after `resetForTests()`.
+- `createBoundedAsyncQueue` now uses an epoch guard to ignore stale completions after reset and wraps processors so synchronous throws still release capacity.
+- Re-review across security, performance, correctness, and maintainability reported **no remaining Critical/High issues**.
+
 ---
 
 ## Remaining deferrals
@@ -43,7 +70,7 @@
 |----------|------|
 | P1 | ✅ Done (PR #112): PostHog dedupe/coalesce, delegated connection query de-dup, async `/collect` queue, bounded `/events` queue |
 | P2 | ✅ Done (2026-05-28): Dedicated `DURABULL_TELEMETRY_HMAC_SECRET`, signature replay LRU |
-| P3 | Barrel migration, shared queue helper, telemetry signal docs |
+| P3 | ✅ Done (2026-05-28): Barrel migration, shared queue helper, telemetry queue-drop signal/docs |
 
 **Parallel review loop (P2):** Pass 1 found Medium replay-cache TTL misalignment and unguarded test reset exports. Fixed both, plus off-by-one at tolerance boundary. Pass 3 reported **no Critical/High issues**.
 
@@ -58,6 +85,8 @@ bun test \
   packages/analytics/src/server/validate.test.ts \
   packages/analytics/src/server/identifiers.test.ts \
   packages/analytics/src/server/posthog-batch.test.ts \
+  apps/api/src/lib/bounded-async-queue.test.ts \
+  apps/api/src/routes/telemetry-collect-queue.test.ts \
   apps/api/src/mcp/observability/mcp-analytics-queue.test.ts \
   apps/api/src/mcp/tools/shared.test.ts \
   apps/api/src/routes/telemetry-events-queue.test.ts \
@@ -68,6 +97,21 @@ bun test \
 ```
 
 **Gotcha:** `apps/api/src/app.test.ts` fails in sandbox with `CI=true` / missing `MCP_AUTHLESS_BEARER_TOKEN`.
+
+Additional P3 verification:
+
+- `bun run test:unit src/components/app-update-banner.test.tsx src/routes/settings.test.tsx src/routes/queue-detail-scheduled-create.test.tsx src/routes/queue-detail-remove.test.tsx src/routes/job-detail-remove.test.tsx` in `apps/web` ✅
+- `bun run typecheck` in `apps/web` ✅
+- `bun run lint` in `apps/docs` ✅
+- `bun test apps/api/src/lib/bounded-async-queue.test.ts apps/api/src/routes/telemetry-events-queue.test.ts apps/api/src/routes/telemetry-collect-queue.test.ts apps/api/src/mcp/observability/mcp-analytics-queue.test.ts` ✅ after review-loop fix
+- `rg "from ['\"]@durabull/analytics['\"]|vi\.mock\(['\"]@durabull/analytics['\"]|importActual<typeof import\(['\"]@durabull/analytics['\"]\)>"` ✅ no matches
+
+Current-main verification caveats, unrelated to P3:
+
+- `bun run typecheck` in `apps/api` fails in `src/mcp/tools/shared.test.ts` and `src/routes/alerts-global.test.ts`.
+- `bun run lint` in `apps/api` reports pre-existing warnings in `src/lib/alert-webhook-payload.ts` and `src/mcp/auth/authless-metadata.ts`.
+- `bun run lint` in `apps/web` reports pre-existing hook dependency warnings in queue/consent/login routes.
+- `bun run typecheck` in `apps/docs` fails on stale `.next/types/app/home-2/*` generated references.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -174,4 +174,23 @@ Post-#108 telemetry/analytics follow-ups (see `tasks/handoff-analytics-mcp-telem
 - [x] Async `/collect` (202 + bounded worker) and single-batch PostHog coalesce; bounded `/events` queue (PR #112).
 - [x] Require dedicated `DURABULL_TELEMETRY_HMAC_SECRET` (remove `BETTER_AUTH_SECRET` fallback; env coordination).
 - [x] `/collect` signature replay LRU within the HMAC tolerance window.
-- [ ] Extract shared `createBoundedAsyncQueue`; queue-drop metric; root barrel migration to `/browser`; telemetry signal docs (P3).
+- [x] Extract shared `createBoundedAsyncQueue`; queue-drop metric; root barrel migration to `/browser`; telemetry signal docs (P3).
+
+## Current Task
+
+Analytics/MCP telemetry P3 follow-up from `tasks/handoff-analytics-mcp-telemetry.md`.
+
+- [x] Map existing bounded queue implementations and telemetry metric patterns.
+- [x] Extract a shared `createBoundedAsyncQueue` helper and cover queue-drop behavior.
+- [x] Migrate browser-side analytics imports away from the root package barrel where appropriate.
+- [x] Document telemetry signals, privacy boundaries, and required environment variables.
+- [x] Run focused tests/lint/typecheck for the touched analytics/API surface.
+
+## Result
+
+- Extracted `/collect`, `/events`, and MCP analytics queue backpressure into a shared bounded async queue helper.
+- Added `telemetry_queue` / `queue_dropped` stdout operational metrics and tests for queue-full behavior.
+- Migrated browser analytics imports to `@durabull/analytics/browser` and constants to `@durabull/analytics/events`.
+- Documented telemetry queue signals, required telemetry env vars, and HTTP telemetry backpressure behavior.
+- Verified focused telemetry tests, affected web tests, web typecheck, and docs lint. API/docs package-wide typecheck still has unrelated current-main failures noted in the handoff.
+- Ran the four-lens parallel review loop, fixed the High queue reset/in-flight correctness finding, and reran the review. Security, performance, correctness, and maintainability reviewers reported no remaining Critical/High issues.


### PR DESCRIPTION
## Summary
- Extract shared bounded async queue handling for telemetry collect, telemetry events, and MCP analytics queues.
- Add structured `telemetry_queue` drop signals and tests for saturated queue behavior.
- Move web analytics imports off the root barrel and document telemetry backpressure/env expectations.

## Test plan
- `bun test packages/analytics/src/server/collect-auth.test.ts packages/analytics/src/server/capture.test.ts packages/analytics/src/server/validate.test.ts packages/analytics/src/server/identifiers.test.ts packages/analytics/src/server/posthog-batch.test.ts apps/api/src/lib/bounded-async-queue.test.ts apps/api/src/routes/telemetry-collect-queue.test.ts apps/api/src/mcp/observability/mcp-analytics-queue.test.ts apps/api/src/mcp/tools/shared.test.ts apps/api/src/routes/telemetry-events-queue.test.ts apps/api/src/routes/telemetry.test.ts apps/api/src/routes/telemetry-collect.test.ts apps/api/src/mcp/observability/mcp-analytics.test.ts apps/api/src/middleware/rate-limit.test.ts`
- `bun run test:unit src/components/app-update-banner.test.tsx src/routes/settings.test.tsx src/routes/queue-detail-scheduled-create.test.tsx src/routes/queue-detail-remove.test.tsx src/routes/job-detail-remove.test.tsx` in `apps/web`
- `bun run typecheck` in `apps/web`
- `bun run lint` in `apps/docs`
- `git diff --check`

## Notes
- Parallel review loop found and fixed the serious queue reset/in-flight issue; re-review reported no remaining Critical/High issues.
- No Linear issue was provided for this follow-up.
- Current-main unrelated checks noted in `tasks/handoff-analytics-mcp-telemetry.md`: API typecheck, API/web lint warnings, and docs typecheck have pre-existing failures.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared bounded queue for telemetry/analytics with enforced capacity, backpressure, and drop signaling; telemetry endpoints return 202 when queued and 503 when full.
  * Structured operational logs emitting telemetry_queue / queue_dropped events with queue state metrics.

* **Documentation**
  * Added telemetry environment variables and updated HTTP API and operations guidance for queue backpressure signals.

* **Tests**
  * Expanded tests covering bounded-queue behavior, drops, metrics recording, and reset semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/durabullhq/durabull/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->