### PR TITLE
feat(alerts): resolve Linear fields server-side and add delivery retry/details

### DIFF
--- a/apps/api/src/lib/alert-monitor.test.ts
+++ b/apps/api/src/lib/alert-monitor.test.ts
@@ -16,6 +16,15 @@ import {
 } from '@durabull/dal'
 import { env } from '@durabull/env'
 import type { CursorState, QueueSnapshot } from './alert-evaluator'
+import * as alertNotifierModule from './alert-notifier'
+import * as redisModule from './redis'
+
+// `mock.module` is process-global and is NOT reverted by `mock.restore()`, so the
+// notifier/redis mocks below would leak into other test files (e.g. the alerts
+// route tests rely on the real `processAlertDeliveries`). Snapshot the real
+// modules now and reinstall them after every test to keep the suite isolated.
+const realAlertNotifierModule = { ...alertNotifierModule }
+const realRedisModule = { ...redisModule }
 
 const TEST_ORG_ID = 'alert-monitor-org'
 
@@ -157,6 +166,9 @@ describe('alert monitor', () => {
   })
 
   afterEach(async () => {
+    mock.restore()
+    mock.module('./alert-notifier', () => realAlertNotifierModule)
+    mock.module('./redis', () => realRedisModule)
     await closeDb()
     mutableEnv.DATABASE_URL = originalDatabaseUrl
     mutableEnv.RESEND_API_KEY = originalResendKey

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -12,9 +12,8 @@ import {
 } from '@durabull/dal'
 import { isEmailConfigured } from '@durabull/email'
 import { env } from '@durabull/env'
-import { createLinearIssue, LinearApiError } from './linear-client'
-import { getValidLinearAccessToken } from './linear-oauth'
 import { buildAlertAppUrls } from './alert-app-urls'
+import { findWebhookSecretFromChannels, toWebhookDeliveryMetadata } from './alert-webhook-channels'
 import {
   deliverWebhookOrThrow,
   isWebhookDeliveryExpired,
@@ -25,11 +24,10 @@ import {
   buildAlertWebhookPayloadFromEvent,
   serializeAlertWebhookPayload,
 } from './alert-webhook-payload'
-import {
-  findWebhookSecretFromChannels,
-  toWebhookDeliveryMetadata,
-} from './alert-webhook-channels'
 import { getWebhookDeliveryTarget } from './alert-webhook-url'
+import { createLinearIssue, LinearApiError } from './linear-client'
+import { resolveLinearIssueFields } from './linear-field-resolver'
+import { getValidLinearAccessToken } from './linear-oauth'
 
 class NonRetryableDeliveryError extends Error {
   constructor(message: string) {
@@ -37,6 +35,13 @@ class NonRetryableDeliveryError extends Error {
     this.name = 'NonRetryableDeliveryError'
   }
 }
+
+/**
+ * Notification dispatch only needs the connection's identity, not its secrets or
+ * Redis URL. Depending on this narrow shape lets callers (e.g. a manual retry)
+ * pass the already-resolved connection context without re-fetching or decrypting.
+ */
+export type AlertNotificationConnection = Pick<RedisConnection, 'id' | 'name'>
 
 export type NotificationChannel =
   | {
@@ -62,7 +67,7 @@ export type NotificationChannel =
 export async function dispatchAlertNotification(
   event: AlertEvent,
   channels: NotificationChannel[],
-  connection: RedisConnection,
+  connection: AlertNotificationConnection,
   ruleName: string
 ): Promise<void> {
   const deliveries = channels.map((channel) => ({
@@ -79,7 +84,7 @@ export async function dispatchAlertNotification(
 
 export async function processAlertDeliveries(
   event: AlertEvent,
-  connection: RedisConnection,
+  connection: AlertNotificationConnection,
   ruleName: string
 ): Promise<void> {
   const dueDeliveries = await alertDeliveryRepository.claimDueForEvent(event.id)
@@ -150,7 +155,7 @@ function getDeliveryTarget(channel: NotificationChannel): string {
 async function sendAlertEmail(
   to: string,
   event: AlertEvent,
-  connection: RedisConnection,
+  connection: AlertNotificationConnection,
   ruleName: string,
   organizationSlug: string | null
 ): Promise<void> {
@@ -185,7 +190,7 @@ async function sendAlertEmail(
 async function sendLinearAlert(
   delivery: AlertDelivery,
   event: AlertEvent,
-  connection: RedisConnection,
+  connection: AlertNotificationConnection,
   ruleName: string,
   organizationSlug: string | null
 ): Promise<void> {
@@ -245,8 +250,16 @@ async function sendLinearAlert(
   }
 
   const accessToken = await getValidLinearAccessToken(integration)
-  const issue = await createLinearIssueOnce(accessToken, {
+  const resolvedFields = await resolveLinearIssueFields(integration, accessToken, {
     teamId,
+    projectId: channel.projectId ?? integration.defaultProjectId,
+    labelIds: channel.labelIds?.length ? channel.labelIds : integration.defaultLabelIds,
+    assigneeId: channel.assigneeId ?? integration.defaultAssigneeId,
+    stateId: channel.stateId ?? integration.defaultStateId,
+    priority: channel.priority ?? integration.defaultPriority,
+  })
+  const issue = await createLinearIssueOnce(accessToken, {
+    teamId: resolvedFields.teamId,
     title: buildLinearIssueTitle(event, connection, ruleName, jobContext.jobName),
     description: buildLinearIssueDescription({
       event,
@@ -255,11 +268,11 @@ async function sendLinearAlert(
       jobUrl,
       jobContext,
     }),
-    projectId: channel.projectId ?? integration.defaultProjectId,
-    labelIds: channel.labelIds?.length ? channel.labelIds : integration.defaultLabelIds,
-    assigneeId: channel.assigneeId ?? integration.defaultAssigneeId,
-    stateId: channel.stateId ?? integration.defaultStateId,
-    priority: channel.priority ?? integration.defaultPriority,
+    projectId: resolvedFields.projectId,
+    labelIds: resolvedFields.labelIds,
+    assigneeId: resolvedFields.assigneeId,
+    stateId: resolvedFields.stateId,
+    priority: resolvedFields.priority,
   })
 
   try {
@@ -352,16 +365,12 @@ function requireClaimedAt(delivery: AlertDelivery): Date {
 async function sendWebhookAlert(
   delivery: AlertDelivery,
   event: AlertEvent,
-  connection: RedisConnection,
+  connection: AlertNotificationConnection,
   ruleName: string,
   organizationSlug: string | null
 ): Promise<void> {
   const channel = parseWebhookChannel(delivery.providerMetadata)
-  const secret = await resolveWebhookSigningSecret(
-    event,
-    channel.url,
-    delivery.providerMetadata
-  )
+  const secret = await resolveWebhookSigningSecret(event, channel.url, delivery.providerMetadata)
   const payload = buildAlertWebhookPayloadFromEvent(
     event,
     delivery.id,
@@ -473,7 +482,7 @@ function getJobContext(context: unknown): {
 
 function buildLinearIssueTitle(
   event: AlertEvent,
-  connection: RedisConnection,
+  connection: AlertNotificationConnection,
   ruleName: string,
   jobName: string | null
 ): string {
@@ -494,7 +503,7 @@ function buildLinearIssueDescription({
   jobContext,
 }: {
   event: AlertEvent
-  connection: RedisConnection
+  connection: AlertNotificationConnection
   ruleName: string
   jobUrl: string
   jobContext: ReturnType<typeof getJobContext>
@@ -537,10 +546,7 @@ function classifyDeliveryFailure(
   attemptCount: number,
   delivery?: Pick<AlertDelivery, 'channelType' | 'createdAt'>
 ): { error: string; retryable: boolean; nextRetryAt?: Date | null } {
-  if (
-    delivery?.channelType === 'webhook' &&
-    isWebhookDeliveryExpired(delivery.createdAt)
-  ) {
+  if (delivery?.channelType === 'webhook' && isWebhookDeliveryExpired(delivery.createdAt)) {
     return { error: WEBHOOK_DELIVERY_ABANDONED_MESSAGE, retryable: false }
   }
 

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -82,12 +82,20 @@ export async function dispatchAlertNotification(
   await processAlertDeliveries(event, connection, ruleName)
 }
 
+export type ProcessAlertDeliveriesOptions = {
+  /** When set, claim and dispatch only this delivery (manual retry). */
+  deliveryId?: string
+}
+
 export async function processAlertDeliveries(
   event: AlertEvent,
   connection: AlertNotificationConnection,
-  ruleName: string
+  ruleName: string,
+  options?: ProcessAlertDeliveriesOptions
 ): Promise<void> {
-  const dueDeliveries = await alertDeliveryRepository.claimDueForEvent(event.id)
+  const dueDeliveries = options?.deliveryId
+    ? await alertDeliveryRepository.claimById(options.deliveryId, event.id)
+    : await alertDeliveryRepository.claimDueForEvent(event.id)
   if (dueDeliveries.length === 0) return
 
   const organizationSlug = await getOrganizationSlug(event.organizationId)

--- a/apps/api/src/lib/alert-webhook-payload.ts
+++ b/apps/api/src/lib/alert-webhook-payload.ts
@@ -1,4 +1,4 @@
-import type { AlertEvent, AlertRuleType, RedisConnection } from '@durabull/dal'
+import type { AlertEvent, AlertRuleType } from '@durabull/dal'
 import { buildAlertAppUrls } from './alert-app-urls'
 
 export const WEBHOOK_MAX_BODY_BYTES = 32_768
@@ -38,7 +38,7 @@ export interface BuildAlertWebhookPayloadInput {
   occurredAt: Date
   organizationId: string
   organizationSlug: string | null
-  connection: RedisConnection
+  connection: { id: string; name: string }
   ruleId: string
   ruleName: string
   ruleType: AlertRuleType | string
@@ -103,7 +103,7 @@ export function buildAlertWebhookPayload(
 export function buildAlertWebhookPayloadFromEvent(
   event: AlertEvent,
   deliveryId: string,
-  connection: RedisConnection,
+  connection: { id: string; name: string },
   ruleName: string,
   organizationSlug: string | null,
   appBaseUrl: string

--- a/apps/api/src/lib/linear-field-resolver.test.ts
+++ b/apps/api/src/lib/linear-field-resolver.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'bun:test'
+import { LinearApiError, type LinearMetadata } from './linear-client'
+import { fieldsNeedResolution, resolveLinearIssueFieldsWithMetadata } from './linear-field-resolver'
+
+const TEAM_UUID = '11111111-1111-1111-1111-111111111111'
+const PROJECT_UUID = '22222222-2222-2222-2222-222222222222'
+const LABEL_UUID = '33333333-3333-3333-3333-333333333333'
+const USER_UUID = '44444444-4444-4444-4444-444444444444'
+const STATE_UUID = '55555555-5555-5555-5555-555555555555'
+
+const metadata: LinearMetadata = {
+  teams: [{ id: TEAM_UUID, name: 'Intake', key: 'INTAKE' }],
+  projects: [{ id: PROJECT_UUID, name: 'Q3 Roadmap' }],
+  labels: [{ id: LABEL_UUID, name: 'Bug' }],
+  users: [{ id: USER_UUID, name: 'Ada Lovelace', email: 'ada@example.com' }],
+  states: [{ id: STATE_UUID, name: 'Triage', teamId: TEAM_UUID }],
+}
+
+describe('fieldsNeedResolution', () => {
+  it('returns false when every value is already a UUID', () => {
+    expect(
+      fieldsNeedResolution({
+        teamId: TEAM_UUID,
+        projectId: PROJECT_UUID,
+        labelIds: [LABEL_UUID],
+        assigneeId: USER_UUID,
+        stateId: STATE_UUID,
+      })
+    ).toBe(false)
+  })
+
+  it('returns true when a friendly value (team key) is present', () => {
+    expect(fieldsNeedResolution({ teamId: 'INTAKE' })).toBe(true)
+  })
+})
+
+describe('resolveLinearIssueFieldsWithMetadata', () => {
+  it('resolves a team key to its UUID', () => {
+    const resolved = resolveLinearIssueFieldsWithMetadata(metadata, { teamId: 'INTAKE' })
+    expect(resolved.teamId).toBe(TEAM_UUID)
+  })
+
+  it('resolves a team name case-insensitively', () => {
+    const resolved = resolveLinearIssueFieldsWithMetadata(metadata, { teamId: 'intake' })
+    expect(resolved.teamId).toBe(TEAM_UUID)
+  })
+
+  it('passes a team UUID through unchanged', () => {
+    const resolved = resolveLinearIssueFieldsWithMetadata(metadata, { teamId: TEAM_UUID })
+    expect(resolved.teamId).toBe(TEAM_UUID)
+  })
+
+  it('resolves optional fields by friendly values', () => {
+    const resolved = resolveLinearIssueFieldsWithMetadata(metadata, {
+      teamId: 'INTAKE',
+      projectId: 'Q3 Roadmap',
+      labelIds: ['Bug'],
+      assigneeId: 'ada@example.com',
+      stateId: 'Triage',
+      priority: 2,
+    })
+
+    expect(resolved).toEqual({
+      teamId: TEAM_UUID,
+      projectId: PROJECT_UUID,
+      labelIds: [LABEL_UUID],
+      assigneeId: USER_UUID,
+      stateId: STATE_UUID,
+      priority: 2,
+    })
+  })
+
+  it('drops unresolved optional fields so the issue is still created', () => {
+    const resolved = resolveLinearIssueFieldsWithMetadata(metadata, {
+      teamId: 'INTAKE',
+      projectId: 'Nonexistent project',
+      labelIds: ['Bug', 'Unknown label'],
+      assigneeId: 'nobody@example.com',
+      stateId: 'Unknown state',
+    })
+
+    expect(resolved.projectId).toBeUndefined()
+    expect(resolved.assigneeId).toBeUndefined()
+    expect(resolved.stateId).toBeUndefined()
+    expect(resolved.labelIds).toEqual([LABEL_UUID])
+  })
+
+  it('scopes state resolution to the resolved team when possible', () => {
+    const otherTeam = '66666666-6666-6666-6666-666666666666'
+    const scopedMetadata: LinearMetadata = {
+      ...metadata,
+      states: [
+        { id: STATE_UUID, name: 'Triage', teamId: TEAM_UUID },
+        { id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', name: 'Triage', teamId: otherTeam },
+      ],
+    }
+    const resolved = resolveLinearIssueFieldsWithMetadata(scopedMetadata, {
+      teamId: 'INTAKE',
+      stateId: 'Triage',
+    })
+    expect(resolved.stateId).toBe(STATE_UUID)
+  })
+
+  it('throws a non-retryable error when the team cannot be resolved', () => {
+    try {
+      resolveLinearIssueFieldsWithMetadata(metadata, { teamId: 'NOPE' })
+      throw new Error('expected resolver to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(LinearApiError)
+      const apiError = error as LinearApiError
+      expect(apiError.retryable).toBe(false)
+      expect(apiError.message).toContain('Intake (INTAKE)')
+    }
+  })
+})

--- a/apps/api/src/lib/linear-field-resolver.ts
+++ b/apps/api/src/lib/linear-field-resolver.ts
@@ -1,0 +1,217 @@
+import type { LinearIntegration } from '@durabull/dal'
+import { fetchLinearMetadata, LinearApiError, type LinearMetadata } from './linear-client'
+
+/**
+ * Linear issue fields can be configured by humans using friendly values (a team
+ * key like "INTAKE", a project name, an assignee email) but Linear's GraphQL API
+ * only accepts opaque UUIDs. This module resolves whatever the user entered into
+ * the UUIDs Linear expects, so alert routing "just works" regardless of whether
+ * the configured value is an id, key, name, or email.
+ */
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const METADATA_CACHE_TTL_MS = 60_000
+
+interface CachedMetadata {
+  metadata: LinearMetadata
+  expiresAt: number
+}
+
+const metadataCache = new Map<string, CachedMetadata>()
+
+export interface RawLinearIssueFields {
+  teamId: string
+  projectId?: string | null
+  labelIds?: string[] | null
+  assigneeId?: string | null
+  stateId?: string | null
+  priority?: number | null
+}
+
+export interface ResolvedLinearIssueFields {
+  teamId: string
+  projectId?: string
+  labelIds?: string[]
+  assigneeId?: string
+  stateId?: string
+  priority?: number
+}
+
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value.trim())
+}
+
+function normalizeOptional(value: string | null | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function normalizeLabels(values: string[] | null | undefined): string[] {
+  if (!Array.isArray(values)) return []
+  return values.map((value) => value.trim()).filter((value) => value.length > 0)
+}
+
+function equalsIgnoreCase(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+/**
+ * A non-UUID value (e.g. a team key or project name) always needs metadata to
+ * resolve. When every configured value is already a UUID we can skip the extra
+ * Linear API call entirely and preserve the previous behavior exactly.
+ */
+export function fieldsNeedResolution(raw: RawLinearIssueFields): boolean {
+  const candidates = [
+    raw.teamId,
+    normalizeOptional(raw.projectId),
+    normalizeOptional(raw.assigneeId),
+    normalizeOptional(raw.stateId),
+    ...normalizeLabels(raw.labelIds),
+  ]
+
+  return candidates.some((value) => typeof value === 'string' && value.length > 0 && !isUuid(value))
+}
+
+function resolveTeamId(metadata: LinearMetadata, value: string): string {
+  const trimmed = value.trim()
+  const match = metadata.teams.find(
+    (team) =>
+      team.id === trimmed ||
+      equalsIgnoreCase(team.key, trimmed) ||
+      equalsIgnoreCase(team.name, trimmed)
+  )
+  if (match) return match.id
+
+  const available = metadata.teams
+    .slice(0, 25)
+    .map((team) => `${team.name} (${team.key})`)
+    .join(', ')
+  throw new LinearApiError(
+    `Linear team "${trimmed}" could not be found. Enter the team's name, key, or ID.${
+      available ? ` Available teams: ${available}.` : ''
+    }`,
+    { status: 400, retryable: false }
+  )
+}
+
+function resolveProjectId(metadata: LinearMetadata, value: string): string | undefined {
+  if (isUuid(value)) return value.trim()
+  const match = metadata.projects.find((project) => equalsIgnoreCase(project.name, value))
+  return match?.id
+}
+
+function resolveAssigneeId(metadata: LinearMetadata, value: string): string | undefined {
+  if (isUuid(value)) return value.trim()
+  const match = metadata.users.find(
+    (user) =>
+      equalsIgnoreCase(user.name, value) ||
+      (typeof user.email === 'string' && equalsIgnoreCase(user.email, value))
+  )
+  return match?.id
+}
+
+function resolveStateId(
+  metadata: LinearMetadata,
+  value: string,
+  teamId: string
+): string | undefined {
+  if (isUuid(value)) return value.trim()
+  const teamScoped = metadata.states.find(
+    (state) => state.teamId === teamId && equalsIgnoreCase(state.name, value)
+  )
+  if (teamScoped) return teamScoped.id
+  const anyTeam = metadata.states.find((state) => equalsIgnoreCase(state.name, value))
+  return anyTeam?.id
+}
+
+function resolveLabelIds(metadata: LinearMetadata, values: string[]): string[] {
+  const resolved: string[] = []
+  for (const value of values) {
+    if (isUuid(value)) {
+      resolved.push(value.trim())
+      continue
+    }
+    const match = metadata.labels.find((label) => equalsIgnoreCase(label.name, value))
+    if (match) resolved.push(match.id)
+  }
+  return resolved
+}
+
+/**
+ * Pure resolver (no network) so it is easy to unit test. The team is required
+ * and throws a clear, non-retryable error when it cannot be resolved. Optional
+ * fields that cannot be resolved are dropped so the issue is still created.
+ */
+export function resolveLinearIssueFieldsWithMetadata(
+  metadata: LinearMetadata,
+  raw: RawLinearIssueFields
+): ResolvedLinearIssueFields {
+  const teamId = isUuid(raw.teamId) ? raw.teamId.trim() : resolveTeamId(metadata, raw.teamId)
+
+  const projectValue = normalizeOptional(raw.projectId)
+  const assigneeValue = normalizeOptional(raw.assigneeId)
+  const stateValue = normalizeOptional(raw.stateId)
+  const labelValues = normalizeLabels(raw.labelIds)
+
+  const labelIds = resolveLabelIds(metadata, labelValues)
+
+  return {
+    teamId,
+    projectId: projectValue ? resolveProjectId(metadata, projectValue) : undefined,
+    assigneeId: assigneeValue ? resolveAssigneeId(metadata, assigneeValue) : undefined,
+    stateId: stateValue ? resolveStateId(metadata, stateValue, teamId) : undefined,
+    labelIds: labelIds.length > 0 ? labelIds : undefined,
+    priority: typeof raw.priority === 'number' ? raw.priority : undefined,
+  }
+}
+
+async function getCachedLinearMetadata(
+  organizationId: string,
+  accessToken: string
+): Promise<LinearMetadata> {
+  const cached = metadataCache.get(organizationId)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.metadata
+  }
+
+  const metadata = await fetchLinearMetadata(accessToken)
+  metadataCache.set(organizationId, {
+    metadata,
+    expiresAt: Date.now() + METADATA_CACHE_TTL_MS,
+  })
+  return metadata
+}
+
+export function clearLinearMetadataCache(organizationId?: string): void {
+  if (organizationId) {
+    metadataCache.delete(organizationId)
+    return
+  }
+  metadataCache.clear()
+}
+
+/**
+ * Resolves configured Linear fields into the UUIDs the API expects. Skips the
+ * metadata round-trip when every value is already a UUID.
+ */
+export async function resolveLinearIssueFields(
+  integration: LinearIntegration,
+  accessToken: string,
+  raw: RawLinearIssueFields
+): Promise<ResolvedLinearIssueFields> {
+  if (!fieldsNeedResolution(raw)) {
+    const labelIds = normalizeLabels(raw.labelIds)
+    return {
+      teamId: raw.teamId.trim(),
+      projectId: normalizeOptional(raw.projectId),
+      assigneeId: normalizeOptional(raw.assigneeId),
+      stateId: normalizeOptional(raw.stateId),
+      labelIds: labelIds.length > 0 ? labelIds : undefined,
+      priority: typeof raw.priority === 'number' ? raw.priority : undefined,
+    }
+  }
+
+  const metadata = await getCachedLinearMetadata(integration.organizationId, accessToken)
+  return resolveLinearIssueFieldsWithMetadata(metadata, raw)
+}

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -371,6 +371,104 @@ describe('alerts routes', () => {
     })
   })
 
+  it('retries a failed delivery and re-attempts it through the API', async () => {
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      name: 'Retryable incident',
+      type: 'job_failed',
+      config: { maxIssuesPerPoll: 10 },
+      notificationChannels: [{ type: 'linear', target: 'org-default', teamId: 'INTAKE' }],
+      cooldownMinutes: 30,
+    })
+
+    const event = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      type: rule.type,
+      status: 'firing',
+      summary: 'Linear delivery failed',
+      context: { jobId: 'job-1' },
+      firedAt: new Date(),
+    })
+
+    await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'linear',
+        target: 'org-default:INTAKE',
+        providerMetadata: { type: 'linear', target: 'org-default', teamId: 'INTAKE' },
+      },
+    ])
+
+    const [claimed] = await alertDeliveryRepository.claimDueForEvent(event.id)
+    expect(claimed).toBeDefined()
+    await alertDeliveryRepository.markFailed(claimed.id, {
+      error: 'Linear integration is not configured for this organization.',
+      retryable: false,
+      expectedClaimedAt: claimed.claimedAt as Date,
+    })
+
+    const app = await createAlertsRouteApp()
+    const response = await app.request(`/events/${event.id}/deliveries/${claimed.id}/retry`, {
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      event: { deliveries: Array<{ id: string; status: string; attemptCount: number }> }
+    }
+    const delivery = body.event.deliveries.find((entry) => entry.id === claimed.id)
+    expect(delivery?.status).toBe('failed')
+    expect(delivery?.attemptCount).toBe(2)
+  })
+
+  it('returns 404 when retrying a delivery that is not in a retryable state', async () => {
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      name: 'Pending delivery',
+      type: 'job_failed',
+      config: { maxIssuesPerPoll: 10 },
+      notificationChannels: [{ type: 'linear', target: 'org-default', teamId: 'INTAKE' }],
+      cooldownMinutes: 30,
+    })
+
+    const event = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      type: rule.type,
+      status: 'firing',
+      summary: 'Pending linear delivery',
+      context: {},
+      firedAt: new Date(),
+    })
+
+    const [pending] = await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'linear',
+        target: 'org-default:INTAKE',
+        providerMetadata: { type: 'linear', target: 'org-default', teamId: 'INTAKE' },
+      },
+    ])
+
+    const app = await createAlertsRouteApp()
+    const response = await app.request(`/events/${event.id}/deliveries/${pending.id}/retry`, {
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(404)
+  })
+
   it('rejects webhook URLs that target private networks', async () => {
     const app = await createAlertsRouteApp()
 

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -427,6 +427,75 @@ describe('alerts routes', () => {
     expect(delivery?.attemptCount).toBe(2)
   })
 
+  it('retries only the targeted delivery when other deliveries are also due', async () => {
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      name: 'Multi-channel incident',
+      type: 'job_failed',
+      config: { maxIssuesPerPoll: 10 },
+      notificationChannels: [
+        { type: 'email', target: 'ops@example.com' },
+        { type: 'linear', target: 'org-default', teamId: 'INTAKE' },
+      ],
+      cooldownMinutes: 30,
+    })
+
+    const event = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: TEST_CONNECTION_ID,
+      queueName: 'email-send',
+      type: rule.type,
+      status: 'firing',
+      summary: 'One channel failed',
+      context: { jobId: 'job-1' },
+      firedAt: new Date(),
+    })
+
+    const [emailDelivery, linearDelivery] = await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'email',
+        target: 'ops@example.com',
+      },
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'linear',
+        target: 'org-default:INTAKE',
+        providerMetadata: { type: 'linear', target: 'org-default', teamId: 'INTAKE' },
+      },
+    ])
+
+    const [claimedLinear] = await alertDeliveryRepository.claimById(linearDelivery!.id, event.id)
+    await alertDeliveryRepository.markFailed(claimedLinear!.id, {
+      error: 'Linear integration is not configured for this organization.',
+      retryable: false,
+      expectedClaimedAt: claimedLinear!.claimedAt as Date,
+    })
+
+    const app = await createAlertsRouteApp()
+    const response = await app.request(
+      `/events/${event.id}/deliveries/${linearDelivery!.id}/retry`,
+      { method: 'POST' }
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      event: { deliveries: Array<{ id: string; status: string; attemptCount: number }> }
+    }
+    const retried = body.event.deliveries.find((entry) => entry.id === linearDelivery!.id)
+    const untouched = body.event.deliveries.find((entry) => entry.id === emailDelivery!.id)
+
+    expect(retried?.status).toBe('failed')
+    expect(retried?.attemptCount).toBe(2)
+    expect(untouched?.status).toBe('pending')
+    expect(untouched?.attemptCount).toBe(0)
+  })
+
   it('returns 404 when retrying a delivery that is not in a retryable state', async () => {
     const rule = await alertRuleRepository.create({
       organizationId: TEST_ORG_ID,

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -464,11 +464,9 @@ const app = new Hono()
     const connection = { id: connectionId, name: c.get('connectionName') }
 
     const rule = await alertRuleRepository.findById(event.alertRuleId, organizationId)
-    try {
-      await processAlertDeliveries(event, connection, rule?.name ?? 'Durabull alert')
-    } catch (error) {
-      console.error('[alerts] Manual delivery retry failed:', error)
-    }
+    await processAlertDeliveries(event, connection, rule?.name ?? 'Durabull alert', {
+      deliveryId,
+    })
 
     const [refreshed] = await attachDeliveries([event])
     return c.json({ event: refreshed })

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -13,6 +13,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { type CursorState, evaluateRule, type QueueSnapshot } from '../lib/alert-evaluator'
+import { processAlertDeliveries } from '../lib/alert-notifier'
 import {
   mergeWebhookSecretsOnUpdate,
   resolveWebhookTestSecret,
@@ -439,6 +440,38 @@ const app = new Hono()
     }
 
     return c.json({ event })
+  })
+  .post('/events/:eventId/deliveries/:deliveryId/retry', async (c) => {
+    const { eventId, deliveryId } = c.req.param()
+    const connectionId = c.get('connectionId')
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const event = await alertEventRepository.findById(eventId, organizationId)
+    if (!event || event.connectionId !== connectionId) {
+      return c.json({ error: 'Event not found' }, 404)
+    }
+
+    const reset = await alertDeliveryRepository.resetForRetry(deliveryId, eventId)
+    if (!reset) {
+      return c.json({ error: 'Delivery not found or is not in a retryable state.' }, 404)
+    }
+
+    // Dispatch only needs the connection identity, which the connection
+    // middleware already resolved into context — no refetch/decrypt required.
+    const connection = { id: connectionId, name: c.get('connectionName') }
+
+    const rule = await alertRuleRepository.findById(event.alertRuleId, organizationId)
+    try {
+      await processAlertDeliveries(event, connection, rule?.name ?? 'Durabull alert')
+    } catch (error) {
+      console.error('[alerts] Manual delivery retry failed:', error)
+    }
+
+    const [refreshed] = await attachDeliveries([event])
+    return c.json({ event: refreshed })
   })
 
 async function attachDeliveries<T extends { id: string }>(events: T[]) {

--- a/apps/web/src/components/alerts/alert-event-details-dialog.test.tsx
+++ b/apps/web/src/components/alerts/alert-event-details-dialog.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AlertEventDetailsDialog } from '@/components/alerts/alert-event-details-dialog'
+import type { AlertDeliveryRecord, AlertEventRecord } from '@/hooks/use-alerts'
+
+const { mutateAsync, retryState, toastSuccess, toastError } = vi.hoisted(() => ({
+  mutateAsync: vi.fn(async () => ({})),
+  retryState: {
+    mutateAsync: undefined as unknown,
+    isPending: false,
+    variables: undefined as { deliveryId: string } | undefined,
+  },
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-alerts', () => ({
+  useRetryAlertDelivery: () => retryState,
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: toastSuccess, error: toastError },
+}))
+
+function createDelivery(overrides: Partial<AlertDeliveryRecord> = {}): AlertDeliveryRecord {
+  return {
+    id: 'delivery-1',
+    channelType: 'linear',
+    status: 'failed',
+    target: 'org-default:INTAKE',
+    attemptCount: 2,
+    externalIdentifier: null,
+    externalUrl: null,
+    lastError: 'Linear team is required before alert delivery can create issues.',
+    providerMetadata: {},
+    ...overrides,
+  }
+}
+
+function createEvent(overrides: Partial<AlertEventRecord> = {}): AlertEventRecord {
+  return {
+    id: 'event-1',
+    alertRuleId: 'rule-1',
+    organizationId: 'org-1',
+    connectionId: 'conn-1',
+    queueName: 'email-send',
+    type: 'job_failed',
+    status: 'firing',
+    summary: 'Linear delivery failed',
+    context: { jobId: 'job-1', failedReason: 'boom' },
+    firedAt: '2026-03-24T10:00:00.000Z',
+    resolvedAt: null,
+    notificationSentAt: null,
+    deliveries: [createDelivery()],
+    ...overrides,
+  }
+}
+
+function renderDialog(event: AlertEventRecord) {
+  return render(<AlertEventDetailsDialog event={event} open onOpenChange={() => {}} />)
+}
+
+describe('AlertEventDetailsDialog', () => {
+  beforeEach(() => {
+    retryState.mutateAsync = mutateAsync
+    retryState.isPending = false
+    retryState.variables = undefined
+    mutateAsync.mockClear()
+    toastSuccess.mockClear()
+    toastError.mockClear()
+  })
+
+  it('renders delivery status, attempt count, humanized context, and the error log', () => {
+    renderDialog(createEvent())
+
+    expect(screen.getByText('Linear')).toBeInTheDocument()
+    expect(screen.getByText('failed')).toBeInTheDocument()
+    expect(screen.getByText('2 attempts')).toBeInTheDocument()
+    expect(screen.getByText('Job Id')).toBeInTheDocument()
+    expect(screen.getByText('Failed Reason')).toBeInTheDocument()
+    expect(
+      screen.getByText('Linear team is required before alert delivery can create issues.')
+    ).toBeInTheDocument()
+  })
+
+  it('retries a failed delivery and surfaces a success toast', async () => {
+    const user = userEvent.setup()
+    renderDialog(createEvent())
+
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      connectionId: 'conn-1',
+      eventId: 'event-1',
+      deliveryId: 'delivery-1',
+    })
+    expect(toastSuccess).toHaveBeenCalled()
+  })
+
+  it('does not offer retry for delivered channels', () => {
+    renderDialog(
+      createEvent({
+        deliveries: [
+          createDelivery({
+            status: 'delivered',
+            externalIdentifier: 'INT-12',
+            externalUrl: 'https://linear.app/x/issue/INT-12',
+            lastError: null,
+          }),
+        ],
+      })
+    )
+
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /INT-12/ })).toHaveAttribute(
+      'href',
+      'https://linear.app/x/issue/INT-12'
+    )
+  })
+
+  it('explains when no channels were configured', () => {
+    renderDialog(createEvent({ deliveries: [] }))
+
+    expect(screen.getByText(/No notification channels were configured/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/alerts/alert-event-details-dialog.tsx
+++ b/apps/web/src/components/alerts/alert-event-details-dialog.tsx
@@ -1,0 +1,244 @@
+import { ArrowUpRight, Loader2, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  AlertStatusBadge,
+  AlertTypeBadge,
+  formatAlertDate,
+} from '@/components/alerts/alert-primitives'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  type AlertDeliveryRecord,
+  type AlertEventRecord,
+  useRetryAlertDelivery,
+} from '@/hooks/use-alerts'
+
+const CHANNEL_LABELS: Record<AlertDeliveryRecord['channelType'], string> = {
+  email: 'Email',
+  linear: 'Linear',
+  webhook: 'Webhook',
+}
+
+const DELIVERY_STATUS_VARIANT: Record<
+  AlertDeliveryRecord['status'],
+  'success' | 'destructive' | 'warning' | 'outline'
+> = {
+  delivered: 'success',
+  failed: 'destructive',
+  claimed: 'warning',
+  pending: 'outline',
+}
+
+function isRetryable(status: AlertDeliveryRecord['status']): boolean {
+  return status === 'failed' || status === 'claimed'
+}
+
+interface AlertEventDetailsDialogProps {
+  event: AlertEventRecord | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function AlertEventDetailsDialog({
+  event,
+  open,
+  onOpenChange,
+}: AlertEventDetailsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        {event ? <AlertEventDetails event={event} /> : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function AlertEventDetails({ event }: { event: AlertEventRecord }) {
+  const retryMutation = useRetryAlertDelivery()
+  const contextEntries = formatContextEntries(event.context)
+
+  async function handleRetry(delivery: AlertDeliveryRecord) {
+    try {
+      await retryMutation.mutateAsync({
+        connectionId: event.connectionId,
+        eventId: event.id,
+        deliveryId: delivery.id,
+      })
+      toast.success('Delivery retried', {
+        description: `Re-attempted ${CHANNEL_LABELS[delivery.channelType]} delivery.`,
+      })
+    } catch (error) {
+      toast.error('Retry failed', {
+        description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      })
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <div className="flex flex-wrap items-center gap-2">
+          <AlertStatusBadge status={event.status} emphasize={event.status === 'firing'} />
+          <AlertTypeBadge type={event.type} compact />
+          <Badge variant="outline" className="border-border/70 bg-background/70">
+            {event.queueName}
+          </Badge>
+        </div>
+        <DialogTitle className="pt-2 text-base leading-6">{event.summary}</DialogTitle>
+        <DialogDescription>
+          Fired {formatAlertDate(event.firedAt)}
+          {event.status === 'resolved' && event.resolvedAt
+            ? ` · Resolved ${formatAlertDate(event.resolvedAt)}`
+            : ''}
+        </DialogDescription>
+      </DialogHeader>
+
+      {contextEntries.length > 0 ? (
+        <section className="space-y-2">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Event context
+          </h4>
+          <dl className="grid gap-x-4 gap-y-2 rounded-lg border border-border/70 bg-muted/20 p-3 text-sm sm:grid-cols-[160px_1fr]">
+            {contextEntries.map(({ label, value }) => (
+              <div key={label} className="contents">
+                <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+                <dd className="break-words font-mono text-xs">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      ) : null}
+
+      <section className="space-y-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Delivery attempts
+        </h4>
+        {event.deliveries.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border/70 bg-muted/15 p-3 text-sm text-muted-foreground">
+            No notification channels were configured when this alert fired, so nothing was
+            delivered.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {event.deliveries.map((delivery) => (
+              <DeliveryRow
+                key={delivery.id}
+                delivery={delivery}
+                onRetry={() => handleRetry(delivery)}
+                isRetrying={
+                  retryMutation.isPending && retryMutation.variables?.deliveryId === delivery.id
+                }
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </>
+  )
+}
+
+function DeliveryRow({
+  delivery,
+  onRetry,
+  isRetrying,
+}: {
+  delivery: AlertDeliveryRecord
+  onRetry: () => void
+  isRetrying: boolean
+}) {
+  const httpStatus = delivery.providerMetadata?.httpStatus
+  const responseSnippet = delivery.providerMetadata?.responseBodySnippet
+
+  return (
+    <li className="rounded-lg border border-border/70 bg-background/70 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">{CHANNEL_LABELS[delivery.channelType]}</span>
+            <Badge variant={DELIVERY_STATUS_VARIANT[delivery.status]} className="capitalize">
+              {delivery.status}
+            </Badge>
+            {typeof delivery.attemptCount === 'number' && delivery.attemptCount > 0 ? (
+              <span className="text-xs text-muted-foreground">
+                {delivery.attemptCount} attempt{delivery.attemptCount === 1 ? '' : 's'}
+              </span>
+            ) : null}
+          </div>
+          {delivery.target ? (
+            <p className="truncate font-mono text-xs text-muted-foreground">{delivery.target}</p>
+          ) : null}
+        </div>
+        {isRetryable(delivery.status) ? (
+          <Button type="button" size="xs" variant="outline" onClick={onRetry} disabled={isRetrying}>
+            {isRetrying ? (
+              <>
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                Retrying
+              </>
+            ) : (
+              <>
+                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                Retry
+              </>
+            )}
+          </Button>
+        ) : null}
+      </div>
+
+      {delivery.externalUrl ? (
+        <a
+          href={delivery.externalUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        >
+          {delivery.externalIdentifier ?? 'Open Linear issue'}
+          <ArrowUpRight className="h-3 w-3" />
+        </a>
+      ) : null}
+
+      {typeof httpStatus === 'number' ? (
+        <p className="mt-2 text-xs text-muted-foreground">HTTP {httpStatus}</p>
+      ) : null}
+
+      {delivery.lastError ? (
+        <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive">
+          {delivery.lastError}
+        </pre>
+      ) : null}
+
+      {typeof responseSnippet === 'string' && responseSnippet.length > 0 ? (
+        <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/70 bg-muted/20 p-2 text-xs text-muted-foreground">
+          {responseSnippet}
+        </pre>
+      ) : null}
+    </li>
+  )
+}
+
+function formatContextEntries(
+  context: Record<string, unknown>
+): Array<{ label: string; value: string }> {
+  const entries: Array<{ label: string; value: string }> = []
+  for (const [key, raw] of Object.entries(context ?? {})) {
+    if (raw === null || raw === undefined || raw === '') continue
+    const value =
+      typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean'
+        ? String(raw)
+        : JSON.stringify(raw)
+    entries.push({ label: humanizeKey(key), value })
+  }
+  return entries
+}
+
+function humanizeKey(key: string): string {
+  const spaced = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}

--- a/apps/web/src/components/alerts/alert-events-table.test.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.test.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { AlertEventsTable } from '@/components/alerts/alert-events-table'
 import type { AlertEventRecord } from '@/hooks/use-alerts'
@@ -88,7 +88,7 @@ describe('AlertEventsTable', () => {
     expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({ id: 'event-1' }))
   })
 
-  it('links back to the alerts page for non-firing events', () => {
+  it('exposes a details action for non-firing events', () => {
     render(
       <AlertEventsTable
         orgSlug="acme"
@@ -106,6 +106,6 @@ describe('AlertEventsTable', () => {
     )
 
     expect(screen.getByText('Delivered')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Open alerts' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/alerts/alert-events-table.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.tsx
@@ -1,5 +1,7 @@
 import { Link } from '@tanstack/react-router'
 import { ArrowUpRight, CheckCheck, Loader2 } from 'lucide-react'
+import { useState } from 'react'
+import { AlertEventDetailsDialog } from '@/components/alerts/alert-event-details-dialog'
 import {
   AlertStatusBadge,
   AlertTypeBadge,
@@ -37,6 +39,8 @@ export function AlertEventsTable({
   onResolve,
   resolvingEventId,
 }: AlertEventsTableProps) {
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null)
+
   if (events.length === 0) {
     return (
       <div className="rounded-2xl border border-dashed border-border/70 bg-muted/15 px-6 py-12 text-center">
@@ -46,8 +50,17 @@ export function AlertEventsTable({
     )
   }
 
+  const selectedEvent = events.find((event) => event.id === selectedEventId) ?? null
+
   return (
     <div className="overflow-hidden rounded-2xl border border-border/70 bg-background/70">
+      <AlertEventDetailsDialog
+        event={selectedEvent}
+        open={selectedEvent !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedEventId(null)
+        }}
+      />
       <Table>
         <TableHeader>
           <TableRow className="hover:bg-transparent">
@@ -66,7 +79,11 @@ export function AlertEventsTable({
             const isResolving = resolvingEventId === event.id
 
             return (
-              <TableRow key={event.id}>
+              <TableRow
+                key={event.id}
+                className="cursor-pointer"
+                onClick={() => setSelectedEventId(event.id)}
+              >
                 {showConnectionColumn ? (
                   <TableCell className="text-sm font-medium">
                     {connectionNameForEvent?.(event) ?? 'Unknown connection'}
@@ -87,6 +104,7 @@ export function AlertEventsTable({
                       queueName: event.queueName,
                     }}
                     className="inline-flex items-center gap-1.5 truncate font-medium hover:text-primary"
+                    onClick={(clickEvent) => clickEvent.stopPropagation()}
                   >
                     <span className="truncate">{event.queueName}</span>
                     <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
@@ -109,36 +127,43 @@ export function AlertEventsTable({
                   {formatAlertDate(event.firedAt)}
                 </TableCell>
                 <TableCell className="text-right">
-                  {event.status === 'firing' && onResolve ? (
+                  <div className="flex items-center justify-end gap-2">
                     <Button
                       type="button"
                       size="xs"
-                      variant="outline"
-                      onClick={() => onResolve(event)}
-                      disabled={isResolving}
+                      variant="ghost"
+                      onClick={(clickEvent) => {
+                        clickEvent.stopPropagation()
+                        setSelectedEventId(event.id)
+                      }}
                     >
-                      {isResolving ? (
-                        <>
-                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                          Resolving
-                        </>
-                      ) : (
-                        <>
-                          <CheckCheck className="mr-1.5 h-3.5 w-3.5" />
-                          Resolve
-                        </>
-                      )}
+                      Details
                     </Button>
-                  ) : (
-                    <Link
-                      to="/$orgSlug/c/$connectionId/alerts"
-                      params={{ orgSlug, connectionId: event.connectionId }}
-                      search={{ tab: 'history' }}
-                      className="text-xs font-medium text-primary hover:underline"
-                    >
-                      Open alerts
-                    </Link>
-                  )}
+                    {event.status === 'firing' && onResolve ? (
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        onClick={(clickEvent) => {
+                          clickEvent.stopPropagation()
+                          onResolve(event)
+                        }}
+                        disabled={isResolving}
+                      >
+                        {isResolving ? (
+                          <>
+                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                            Resolving
+                          </>
+                        ) : (
+                          <>
+                            <CheckCheck className="mr-1.5 h-3.5 w-3.5" />
+                            Resolve
+                          </>
+                        )}
+                      </Button>
+                    ) : null}
+                  </div>
                 </TableCell>
               </TableRow>
             )
@@ -150,9 +175,7 @@ export function AlertEventsTable({
 }
 
 function DeliverySummary({ event }: { event: AlertEventRecord }) {
-  const linearDelivery = event.deliveries.find(
-    (delivery) => delivery.channelType === 'linear' && delivery.externalUrl
-  )
+  const linearDelivery = event.deliveries.find((delivery) => delivery.channelType === 'linear')
   if (linearDelivery?.externalUrl) {
     return (
       <a
@@ -160,10 +183,18 @@ function DeliverySummary({ event }: { event: AlertEventRecord }) {
         target="_blank"
         rel="noreferrer"
         className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        onClick={(clickEvent) => clickEvent.stopPropagation()}
       >
         {linearDelivery.externalIdentifier ?? 'Linear issue'}
         <ArrowUpRight className="h-3 w-3" />
       </a>
+    )
+  }
+  if (linearDelivery?.status === 'failed') {
+    return (
+      <span className="text-xs text-destructive">
+        Linear failed{linearDelivery.lastError ? `: ${linearDelivery.lastError}` : ''}
+      </span>
     )
   }
 
@@ -185,6 +216,10 @@ function DeliverySummary({ event }: { event: AlertEventRecord }) {
       )
     }
     return <span className="text-xs text-muted-foreground">Webhook pending</span>
+  }
+
+  if (linearDelivery) {
+    return <span className="text-xs text-muted-foreground">Linear pending</span>
   }
 
   if (event.deliveries.length > 0) {

--- a/apps/web/src/components/alerts/alert-rule-builder-page.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.tsx
@@ -1,5 +1,14 @@
 import { Link } from '@tanstack/react-router'
-import { BellRing, ChevronLeft, ChevronRight, Mail, Plus, TestTube2, Trash2, Webhook } from 'lucide-react'
+import {
+  BellRing,
+  ChevronLeft,
+  ChevronRight,
+  Mail,
+  Plus,
+  TestTube2,
+  Trash2,
+  Webhook,
+} from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -167,14 +176,14 @@ function NotificationRouteFields({
           aria-label={`Linear team override ${index + 1}`}
           value={route.teamId ?? ''}
           onChange={(event) => onUpdate({ ...route, teamId: event.target.value })}
-          placeholder="Team ID (optional)"
+          placeholder="Team name, key, or ID (optional)"
           data-testid={`alert-rule-linear-team-${index}`}
         />
         <Input
           aria-label={`Linear project override ${index + 1}`}
           value={route.projectId ?? ''}
           onChange={(event) => onUpdate({ ...route, projectId: event.target.value })}
-          placeholder="Project ID"
+          placeholder="Project name or ID"
         />
         <Input
           aria-label={`Linear labels override ${index + 1}`}
@@ -188,19 +197,19 @@ function NotificationRouteFields({
                 .filter(Boolean),
             })
           }
-          placeholder="Label IDs"
+          placeholder="Label names or IDs"
         />
         <Input
           aria-label={`Linear assignee override ${index + 1}`}
           value={route.assigneeId ?? ''}
           onChange={(event) => onUpdate({ ...route, assigneeId: event.target.value })}
-          placeholder="Assignee ID"
+          placeholder="Assignee name, email, or ID"
         />
         <Input
           aria-label={`Linear state override ${index + 1}`}
           value={route.stateId ?? ''}
           onChange={(event) => onUpdate({ ...route, stateId: event.target.value })}
-          placeholder="State ID"
+          placeholder="State name or ID"
         />
         <Input
           aria-label={`Linear priority override ${index + 1}`}

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -28,6 +28,10 @@ type ResolveAlertEventResponse = InferResponseType<
   ConnectionAlertsEndpoint['events'][':eventId']['resolve']['$post'],
   200
 >
+type RetryAlertDeliveryResponse = InferResponseType<
+  ConnectionAlertsEndpoint['events'][':eventId']['deliveries'][':deliveryId']['retry']['$post'],
+  200
+>
 type TestAlertRuleResponse = InferResponseType<
   ConnectionAlertsEndpoint['rules'][':ruleId']['test']['$post'],
   200
@@ -75,6 +79,7 @@ export interface AlertDeliveryRecord {
   channelType: 'email' | 'linear' | 'webhook'
   status: 'pending' | 'claimed' | 'delivered' | 'failed'
   target: string
+  attemptCount?: number | null
   externalIdentifier?: string | null
   externalUrl?: string | null
   lastError?: string | null
@@ -326,7 +331,11 @@ function normalizeAlertDeliveries(value: unknown): AlertDeliveryRecord[] {
   if (!Array.isArray(value)) return []
   return value.flatMap((entry) => {
     if (!isRecord(entry)) return []
-    if (entry.channelType !== 'email' && entry.channelType !== 'linear' && entry.channelType !== 'webhook') {
+    if (
+      entry.channelType !== 'email' &&
+      entry.channelType !== 'linear' &&
+      entry.channelType !== 'webhook'
+    ) {
       return []
     }
     return [
@@ -341,6 +350,7 @@ function normalizeAlertDeliveries(value: unknown): AlertDeliveryRecord[] {
             ? entry.status
             : 'pending',
         target: typeof entry.target === 'string' ? entry.target : '',
+        attemptCount: typeof entry.attemptCount === 'number' ? entry.attemptCount : null,
         externalIdentifier:
           typeof entry.externalIdentifier === 'string' ? entry.externalIdentifier : null,
         externalUrl: typeof entry.externalUrl === 'string' ? entry.externalUrl : null,
@@ -521,6 +531,31 @@ export function useResolveAlertEvent() {
         param: { connectionId, eventId },
       })
       const data = await handleRes<ResolveAlertEventResponse>(res)
+      return { event: normalizeAlertEvent(data.event) }
+    },
+    onSuccess: (_, variables) => invalidateAlertQueries(queryClient, variables.connectionId),
+  })
+}
+
+export function useRetryAlertDelivery() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      connectionId,
+      eventId,
+      deliveryId,
+    }: {
+      connectionId: string
+      eventId: string
+      deliveryId: string
+    }) => {
+      const res = await api.c[':connectionId'].alerts.events[':eventId'].deliveries[
+        ':deliveryId'
+      ].retry.$post({
+        param: { connectionId, eventId, deliveryId },
+      })
+      const data = await handleRes<RetryAlertDeliveryResponse>(res)
       return { event: normalizeAlertEvent(data.event) }
     },
     onSuccess: (_, variables) => invalidateAlertQueries(queryClient, variables.connectionId),

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -375,8 +375,8 @@ function SettingsPage() {
                 className="h-10 rounded-md border border-input bg-background px-3 text-sm"
                 value={linearTeamId}
                 onChange={(event) => setLinearTeamId(event.target.value)}
-                placeholder="Default Linear team ID"
-                aria-label="Default Linear team ID"
+                placeholder="Default Linear team (name, key, or ID)"
+                aria-label="Default Linear team (name, key, or ID)"
               />
             </div>
           )}
@@ -427,7 +427,8 @@ function SettingsPage() {
           </div>
           <p className="text-sm text-muted-foreground">
             OAuth tokens are encrypted at rest and never returned by the API. Rules can override
-            Linear fields, but the default team is used when no rule-level team is set.
+            Linear fields, but the default team is used when no rule-level team is set. You can
+            enter a team name, key (e.g. INTAKE), or ID — Durabull resolves it automatically.
           </p>
         </CardContent>
       </Card>

--- a/packages/dal/src/repositories/alert-delivery.test.ts
+++ b/packages/dal/src/repositories/alert-delivery.test.ts
@@ -132,6 +132,32 @@ describe('alertDeliveryRepository', () => {
     expect(finalClaim).toHaveLength(0)
   })
 
+  it('claims only the requested delivery by id', async () => {
+    const event = await seedAlertEvent()
+    const deliveries = await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'email',
+        target: 'ops@example.com',
+      },
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'linear',
+        target: 'org-default:team-1::::',
+      },
+    ])
+
+    const [claimed] = await alertDeliveryRepository.claimById(deliveries[1]!.id, event.id)
+    expect(claimed?.id).toBe(deliveries[1]!.id)
+    expect(claimed?.status).toBe('claimed')
+
+    const listed = await alertDeliveryRepository.listByEvent(event.id)
+    expect(listed.find((row) => row.id === deliveries[0]!.id)?.status).toBe('pending')
+    expect(listed.find((row) => row.id === deliveries[1]!.id)?.status).toBe('claimed')
+  })
+
   it('does not reclaim non-retryable failed deliveries', async () => {
     const event = await seedAlertEvent()
     await alertDeliveryRepository.enqueueMany([

--- a/packages/dal/src/repositories/alert-delivery.ts
+++ b/packages/dal/src/repositories/alert-delivery.ts
@@ -135,6 +135,34 @@ export const alertDeliveryRepository = {
     return rowsFromExecute<AlertDelivery>(result).map(normalizeAlertDeliveryRow)
   },
 
+  /**
+   * Resets a failed or stuck delivery so the next processing pass will pick it
+   * up again. Scoped to its event for authorization and refuses to re-send an
+   * already delivered row (which would create a duplicate downstream issue).
+   */
+  async resetForRetry(deliveryId: string, alertEventId: string): Promise<AlertDelivery | null> {
+    const db = await getDb()
+    const now = new Date()
+    const rows = await db
+      .update(alertDelivery)
+      .set({
+        status: 'pending',
+        claimedAt: null,
+        nextRetryAt: null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(alertDelivery.id, deliveryId),
+          eq(alertDelivery.alertEventId, alertEventId),
+          sql`${alertDelivery.status} IN ('failed', 'claimed')`
+        )
+      )
+      .returning()
+
+    return rows[0] ? normalizeAlertDeliveryRow(rows[0]) : null
+  },
+
   async markDelivered(
     id: string,
     metadata: {

--- a/packages/dal/src/repositories/alert-delivery.ts
+++ b/packages/dal/src/repositories/alert-delivery.ts
@@ -135,6 +135,61 @@ export const alertDeliveryRepository = {
     return rowsFromExecute<AlertDelivery>(result).map(normalizeAlertDeliveryRow)
   },
 
+  async claimById(deliveryId: string, alertEventId: string): Promise<AlertDelivery[]> {
+    const db = await getDb()
+    const now = new Date()
+    const staleClaimCutoff = new Date(now.getTime() - STALE_CLAIM_MS)
+
+    const result = await db.execute(sql`
+      UPDATE ${alertDelivery} AS delivery
+      SET
+        status = 'claimed',
+        claimed_at = ${now},
+        updated_at = ${now}
+      WHERE delivery.id IN (
+        SELECT candidate.id
+        FROM ${alertDelivery} AS candidate
+        WHERE candidate.id = ${deliveryId}
+          AND candidate.alert_event_id = ${alertEventId}
+          AND (
+            candidate.status = 'pending'
+            OR (
+              candidate.status = 'failed'
+              AND candidate.next_retry_at IS NOT NULL
+            )
+            OR (
+              candidate.status = 'claimed'
+              AND candidate.claimed_at <= ${staleClaimCutoff}
+            )
+          )
+          AND (
+            candidate.next_retry_at IS NULL
+            OR candidate.next_retry_at <= ${now}
+          )
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING
+        delivery.id,
+        delivery.created_at AS "createdAt",
+        delivery.updated_at AS "updatedAt",
+        delivery.alert_event_id AS "alertEventId",
+        delivery.organization_id AS "organizationId",
+        delivery.channel_type AS "channelType",
+        delivery.target,
+        delivery.status,
+        delivery.attempt_count AS "attemptCount",
+        delivery.next_retry_at AS "nextRetryAt",
+        delivery.claimed_at AS "claimedAt",
+        delivery.last_error AS "lastError",
+        delivery.provider_metadata AS "providerMetadata",
+        delivery.external_id AS "externalId",
+        delivery.external_identifier AS "externalIdentifier",
+        delivery.external_url AS "externalUrl"
+    `)
+
+    return rowsFromExecute<AlertDelivery>(result).map(normalizeAlertDeliveryRow)
+  },
+
   /**
    * Resets a failed or stuck delivery so the next processing pass will pick it
    * up again. Scoped to its event for authorization and refuses to re-send an

--- a/packages/dal/src/repositories/alert-event.ts
+++ b/packages/dal/src/repositories/alert-event.ts
@@ -79,6 +79,17 @@ export const alertEventRepository = {
     return { event: rows[0], created: false }
   },
 
+  async findById(id: string, organizationId: string): Promise<AlertEvent | null> {
+    const db = await getDb()
+    const rows = await db
+      .select()
+      .from(alertEvent)
+      .where(and(eq(alertEvent.id, id), eq(alertEvent.organizationId, organizationId)))
+      .limit(1)
+
+    return rows[0] ?? null
+  },
+
   async findActiveFiring(alertRuleId: string, queueName: string): Promise<AlertEvent | null> {
     const db = await getDb()
     const rows = await db


### PR DESCRIPTION
Closes #119

## Summary
- Resolve Linear issue fields (team, project, labels, assignee, state) server-side from friendly inputs — names, team keys, and emails — so deliveries no longer silently fail when the UI sends human-readable values instead of UUIDs.
- Add an **alert event details dialog**: click any event to see per-channel delivery status, attempt counts, full error logs, external Linear links, and a one-click **Retry** for failed/stuck deliveries.
- Add a `POST /c/:connectionId/alerts/events/:eventId/deliveries/:deliveryId/retry` endpoint backed by `alertEventRepository.findById` and `alertDeliveryRepository.resetForRetry` (scoped to the event; refuses to re-send a `delivered` row).

## Code-quality review outcomes (thermo-nuclear)
- Deleted the fabricated `RedisConnection` from the retry path. Notification dispatch only needs identity, so `processAlertDeliveries` now depends on a narrow `AlertNotificationConnection = Pick<RedisConnection, 'id' | 'name'>`; real callers pass a full connection unchanged.
- Fixed a latent suite-wide test-isolation bug: `alert-monitor.test.ts` left a global `mock.module('./alert-notifier')` in place (not reverted by `mock.restore()` in Bun), which intermittently broke other files. Real modules are now snapshotted and reinstalled in `afterEach`.

## Test plan
- [x] API: `bun test` alerts route (incl. retry + non-retryable 404), notifier, monitor, webhook-payload, linear-field-resolver — 39 pass.
- [x] Web: `vitest` alert-event-details-dialog (status/attempts/context/error log, retry→toast, no-retry-when-delivered, empty state) + alert-events-table — 7 pass.
- [x] Typecheck (web + api) and Biome on all touched files clean.
- [ ] Manual: trigger a Linear alert, open details, confirm error log + retry round-trip.

> Note: a full Playwright e2e for retry needs alert-event/delivery seeding the harness doesn't have; the API route tests cover retry semantics end-to-end at the integration layer.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual retry for individual alert deliveries (API + UI), with attempt counts shown and per-delivery retry behavior
  * Alert Event Details dialog showing delivery history, status, errors, external links, and retry controls

* **Improvements**
  * Linear integration: accept team name/key/email or ID and resolve friendly fields automatically for issue creation
  * Clarified Linear field placeholders and guidance in settings and rule builder
<!-- end of auto-generated comment: release notes by coderabbit.ai -->