### PR TITLE
Add saved alert webhook destinations

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -40,6 +40,7 @@ import teamRoutes from './routes/team'
 import telemetryRoutes, { getTelemetryStatus } from './routes/telemetry'
 import userSettingsRoutes from './routes/user-settings'
 import workersRoutes from './routes/workers'
+import alertWebhookDestinationsRoutes from './routes/alert-webhook-destinations'
 
 bootstrapServerAnalytics()
 
@@ -221,6 +222,7 @@ const apiRoutes = new Hono()
   .route('/team', teamRoutes)
   // User settings
   .route('/user-settings', userSettingsRoutes)
+  .route('/alerts/webhook-destinations', alertWebhookDestinationsRoutes)
   .route('/alerts', alertsGlobalRoutes)
   // Connected routes under /c/:connectionId
   .route('/c/:connectionId/alerts', alertsRoutes)
@@ -320,7 +322,7 @@ export async function createApiApp(options: CreateApiAppOptions = {}) {
     '/api/*',
     cors({
       origin: corsOrigins,
-      allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
       allowHeaders: ['Content-Type', 'Authorization'],
       credentials: true, // Required for auth cookies
     })
@@ -420,6 +422,7 @@ export async function createApiApp(options: CreateApiAppOptions = {}) {
     .route('/team', teamRoutes)
     .route('/user-settings', userSettingsRoutes)
     .route('/mcp', mcpOAuthRoutes)
+    .route('/alerts/webhook-destinations', alertWebhookDestinationsRoutes)
     .route('/alerts', alertsGlobalRoutes)
     .route('/c/:connectionId/alerts', alertsRoutes)
     .route('/c/:connectionId/queues', queuesRoutes)

--- a/apps/api/src/lib/alert-monitor.test.ts
+++ b/apps/api/src/lib/alert-monitor.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  alertDeliveryRepository,
   type AlertRule,
   alertCheckCursorRepository,
   alertEventRepository,
@@ -402,6 +403,68 @@ describe('alert monitor', () => {
       expect.anything()
     )
     expect(await listRuleEvents(rule.id)).toHaveLength(1)
+  })
+
+  it('claims due deliveries and hands them to the notifier with event context', async () => {
+    const processAlertDeliveriesMock = mock(async () => {})
+    mock.module('./alert-notifier', () => ({
+      ...realAlertNotifierModule,
+      processAlertDeliveries: processAlertDeliveriesMock,
+    }))
+    const { __alertMonitorTestUtils } = await loadMonitorModule()
+
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: testConnectionId,
+      queueName: 'email-send',
+      name: 'Webhook retry',
+      type: 'failure_threshold',
+      config: { count: 5, windowMinutes: 5 },
+      notificationChannels: [],
+      cooldownMinutes: 30,
+    })
+    const event = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: testConnectionId,
+      queueName: 'email-send',
+      type: rule.type,
+      status: 'firing',
+      summary: 'Retry pending delivery',
+      context: {},
+      firedAt: new Date(),
+    })
+    await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'webhook',
+        target: 'destination:webhook-destination-id',
+        providerMetadata: {
+          type: 'webhook',
+          destinationId: 'webhook-destination-id',
+          url: 'https://example.com/durabull',
+        },
+      },
+    ])
+
+    await __alertMonitorTestUtils.processDueAlertDeliveries()
+
+    expect(processAlertDeliveriesMock).toHaveBeenCalledTimes(1)
+    expect(processAlertDeliveriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: event.id }),
+      expect.objectContaining({ id: testConnectionId }),
+      'Webhook retry',
+      {
+        claimedDeliveries: [
+          expect.objectContaining({
+            alertEventId: event.id,
+            channelType: 'webhook',
+            status: 'claimed',
+          }),
+        ],
+      }
+    )
   })
 
   it('suppresses new events while the cooldown window is still active', async () => {

--- a/apps/api/src/lib/alert-monitor.ts
+++ b/apps/api/src/lib/alert-monitor.ts
@@ -5,6 +5,7 @@ import {
   alertRuleRepository,
   redisConnectionRepository,
   redisDiscoveredQueueRepository,
+  type AlertDelivery,
   type AlertRule,
   type RedisConnection,
 } from '@durabull/dal'
@@ -20,6 +21,7 @@ import { getQueue } from './redis'
 import { toRedisConnectionOptions } from './connection-options'
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000
+const DEFAULT_DELIVERY_SWEEP_INTERVAL_MS = 15_000
 const MAX_STARTUP_JITTER_MS = 30_000
 const CONNECTION_TIMEOUT_MS = 30_000
 const MAX_CONCURRENT_CONNECTIONS = 3
@@ -29,15 +31,24 @@ const CLEANUP_INTERVAL_MS = 60 * 60 * 1000
 const EVENT_RETENTION_DAYS = 90
 const DEFAULT_JOB_FAILED_MAX_ISSUES_PER_POLL = 100
 const HARD_CAP_JOB_FAILED_MAX_ISSUES_PER_POLL = 500
+const DELIVERY_SWEEP_LIMIT = 10
+const MAX_CONCURRENT_DELIVERY_SWEEPS = 10
+const DELIVERY_SWEEP_BUDGET_MS = 20_000
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
+let deliverySweepTimer: ReturnType<typeof setInterval> | null = null
 let cleanupTimer: ReturnType<typeof setInterval> | null = null
 let startupTimer: ReturnType<typeof setTimeout> | null = null
 let isRunning = false
 let pollInProgress = false
+let deliverySweepInProgress = false
 
 function getPollIntervalMs(): number {
   return Math.max(5_000, env.DURABULL_ALERT_POLL_INTERVAL_MS ?? DEFAULT_POLL_INTERVAL_MS)
+}
+
+function getDeliverySweepIntervalMs(): number {
+  return Math.max(5_000, Math.min(getPollIntervalMs(), DEFAULT_DELIVERY_SWEEP_INTERVAL_MS))
 }
 
 function isAlertMonitorEnabled(): boolean {
@@ -136,15 +147,18 @@ export function startAlertMonitor(): void {
 
   isRunning = true
   const pollIntervalMs = getPollIntervalMs()
+  const deliverySweepIntervalMs = getDeliverySweepIntervalMs()
   const jitter = Math.floor(Math.random() * MAX_STARTUP_JITTER_MS)
   console.log(
-    `[alert-monitor] Starting in ${(jitter / 1000).toFixed(0)}s, poll interval ${Math.round(pollIntervalMs / 1000)}s`
+    `[alert-monitor] Starting in ${(jitter / 1000).toFixed(0)}s, poll interval ${Math.round(pollIntervalMs / 1000)}s, delivery sweep interval ${Math.round(deliverySweepIntervalMs / 1000)}s`
   )
 
   startupTimer = setTimeout(() => {
     void runPollCycle()
+    void runDeliverySweepCycle()
     void runCleanup()
     pollTimer = setInterval(() => void runPollCycle(), pollIntervalMs)
+    deliverySweepTimer = setInterval(() => void runDeliverySweepCycle(), deliverySweepIntervalMs)
     cleanupTimer = setInterval(() => void runCleanup(), CLEANUP_INTERVAL_MS)
   }, jitter)
 }
@@ -157,6 +171,10 @@ export function stopAlertMonitor(): void {
   if (pollTimer) {
     clearInterval(pollTimer)
     pollTimer = null
+  }
+  if (deliverySweepTimer) {
+    clearInterval(deliverySweepTimer)
+    deliverySweepTimer = null
   }
   if (cleanupTimer) {
     clearInterval(cleanupTimer)
@@ -172,31 +190,134 @@ async function runPollCycle(): Promise<void> {
 
   try {
     const rules = await alertRuleRepository.findAllEnabled()
-    if (rules.length === 0) return
-
-    const rulesByConnection = new Map<string, AlertRule[]>()
-    for (const rule of rules) {
-      const existing = rulesByConnection.get(rule.connectionId) ?? []
-      existing.push(rule)
-      rulesByConnection.set(rule.connectionId, existing)
-    }
-
-    await processWithConcurrency(
-      Array.from(rulesByConnection.entries()),
-      MAX_CONCURRENT_CONNECTIONS,
-      async ([connectionId, connectionRules]) => {
-        await withTimeout(
-          processConnection(connectionId, connectionRules),
-          CONNECTION_TIMEOUT_MS,
-          `Connection ${connectionId}`
-        )
+    if (rules.length > 0) {
+      const rulesByConnection = new Map<string, AlertRule[]>()
+      for (const rule of rules) {
+        const existing = rulesByConnection.get(rule.connectionId) ?? []
+        existing.push(rule)
+        rulesByConnection.set(rule.connectionId, existing)
       }
-    )
+
+      await processWithConcurrency(
+        Array.from(rulesByConnection.entries()),
+        MAX_CONCURRENT_CONNECTIONS,
+        async ([connectionId, connectionRules]) => {
+          await withTimeout(
+            processConnection(connectionId, connectionRules),
+            CONNECTION_TIMEOUT_MS,
+            `Connection ${connectionId}`
+          )
+        }
+      )
+    }
   } catch (error) {
     console.error('[alert-monitor] Poll cycle failed:', error)
   } finally {
     pollInProgress = false
   }
+}
+
+async function runDeliverySweepCycle(): Promise<void> {
+  if (deliverySweepInProgress) return
+  deliverySweepInProgress = true
+  try {
+    await processDueAlertDeliveries()
+  } catch (error) {
+    console.error('[alert-monitor] Delivery sweep cycle failed:', error)
+  } finally {
+    deliverySweepInProgress = false
+  }
+}
+
+async function processDueAlertDeliveries(): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < DELIVERY_SWEEP_BUDGET_MS) {
+    const deliveries = await alertDeliveryRepository.claimDue(DELIVERY_SWEEP_LIMIT)
+    if (deliveries.length === 0) return
+
+    await processWithConcurrency(
+      deliveries,
+      MAX_CONCURRENT_DELIVERY_SWEEPS,
+      processDueAlertDelivery
+    )
+    if (deliveries.length < DELIVERY_SWEEP_LIMIT) return
+  }
+}
+
+async function processDueAlertDelivery(delivery: AlertDelivery): Promise<void> {
+  try {
+    const event = await alertEventRepository.findById(
+      delivery.alertEventId,
+      delivery.organizationId
+    )
+    if (!event) {
+      await markDeliveryFailedWithoutRetry(delivery, 'Alert event no longer exists.')
+      return
+    }
+
+    const rule = await alertRuleRepository.findById(event.alertRuleId, event.organizationId)
+    if (!rule) {
+      await markDeliveryFailedWithoutRetry(delivery, 'Alert rule no longer exists.')
+      return
+    }
+
+    const connection = await redisConnectionRepository.findByIdUnsafe(event.connectionId)
+    if (!connection) {
+      await markDeliveryFailedWithoutRetry(delivery, 'Redis connection no longer exists.')
+      return
+    }
+
+    await processAlertDeliveries(event, connection, rule.name, {
+      claimedDeliveries: [delivery],
+    })
+    await markLegacyNotificationSentIfComplete(event.id)
+  } catch (error) {
+    console.error('[alert-monitor] Due delivery sweep failed:', {
+      deliveryId: delivery.id,
+      alertEventId: delivery.alertEventId,
+      error,
+    })
+    await markDeliveryFailedForRetry(
+      delivery,
+      error instanceof Error ? error.message : 'Due delivery sweep failed.'
+    )
+  }
+}
+
+async function markDeliveryFailedWithoutRetry(
+  delivery: AlertDelivery,
+  error: string
+): Promise<void> {
+  if (!(delivery.claimedAt instanceof Date)) {
+    console.error(
+      '[alert-monitor] Claimed delivery is missing claimedAt; cannot mark non-retryable.',
+      {
+        deliveryId: delivery.id,
+      }
+    )
+    return
+  }
+  await alertDeliveryRepository.markFailed(delivery.id, {
+    error,
+    retryable: false,
+    expectedClaimedAt: delivery.claimedAt,
+  })
+}
+
+async function markDeliveryFailedForRetry(delivery: AlertDelivery, error: string): Promise<void> {
+  if (!(delivery.claimedAt instanceof Date)) {
+    console.error('[alert-monitor] Claimed delivery is missing claimedAt; cannot mark retryable.', {
+      deliveryId: delivery.id,
+    })
+    return
+  }
+  await alertDeliveryRepository.markFailed(delivery.id, {
+    error,
+    retryable: true,
+    nextRetryAt: new Date(Date.now() + 30_000),
+    expectedClaimedAt: delivery.claimedAt,
+  })
 }
 
 async function processConnection(connectionId: string, rules: AlertRule[]): Promise<void> {
@@ -494,5 +615,6 @@ export const __alertMonitorTestUtils = {
   scanFailedJobsAndMaybeAlert,
   normalizeFailedJob,
   processConnection,
+  processDueAlertDeliveries,
   processWithConcurrency,
 }

--- a/apps/api/src/lib/alert-notifier.test.ts
+++ b/apps/api/src/lib/alert-notifier.test.ts
@@ -1,5 +1,44 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  alertWebhookDestination,
+  alertWebhookDestinationRepository,
+  closeDb,
+  eq,
+  getDb,
+  organization,
+} from '@durabull/dal'
+import { env } from '@durabull/env'
 import { buildAlertAppUrls } from './alert-app-urls'
+import { __alertNotifierTestUtils } from './alert-notifier'
+
+const TEST_ORG_ID = 'alert-notifier-org'
+const TEST_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+const mutableEnv = env as {
+  DATABASE_URL?: string
+  DURABULL_SECRET_ENCRYPTION_KEY?: string
+}
+
+const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalSecretKey = mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY
+const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+
+let tempPgliteDir = ''
+
+async function seedOrganization() {
+  const db = await getDb()
+  const now = new Date()
+  await db.insert(organization).values({
+    id: TEST_ORG_ID,
+    name: 'Alert Notifier Org',
+    slug: 'alert-notifier-org',
+    createdAt: now,
+    updatedAt: now,
+  })
+}
 
 describe('buildAlertAppUrls', () => {
   it('builds app routes that match the current web router', () => {
@@ -67,5 +106,121 @@ describe('buildAlertAppUrls', () => {
     expect(urls.muteUrl).toBe(
       'https://app.durabull.io/acme%20ops/c/conn%2F123/alerts?ruleId=rule%3A456'
     )
+  })
+})
+
+describe('alert notifier webhook delivery inputs', () => {
+  beforeEach(async () => {
+    tempPgliteDir = await mkdtemp(join(tmpdir(), 'durabull-alert-notifier-'))
+    process.env.DURABULL_PGLITE_DIR = tempPgliteDir
+    delete process.env.DATABASE_URL
+    mutableEnv.DATABASE_URL = undefined
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY
+    await closeDb()
+    await seedOrganization()
+  })
+
+  afterEach(async () => {
+    await closeDb()
+    mutableEnv.DATABASE_URL = originalDatabaseUrl
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = originalSecretKey
+
+    if (originalPgliteDir) {
+      process.env.DURABULL_PGLITE_DIR = originalPgliteDir
+    } else {
+      delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (tempPgliteDir) {
+      await rm(tempPgliteDir, { recursive: true, force: true })
+      tempPgliteDir = ''
+    }
+  })
+
+  it('uses destination-scoped targets for saved webhook deliveries', async () => {
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Incident intake',
+      url: 'https://example.com/durabull',
+    })
+
+    const input = await __alertNotifierTestUtils.buildDeliveryInput(
+      { type: 'webhook', destinationId: destination.id },
+      'alert-event-id',
+      TEST_ORG_ID
+    )
+
+    expect(input.target).toBe(`destination:${destination.id}`)
+    expect(input.providerMetadata).toMatchObject({
+      type: 'webhook',
+      destinationId: destination.id,
+      url: 'https://example.com/durabull',
+    })
+  })
+
+  it('turns unreadable destination secrets into retryable delivery metadata', async () => {
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Corrupt secret',
+      url: 'https://example.com/durabull',
+      signingSecret: 'super-secret-webhook-value',
+    })
+    const db = await getDb()
+    await db
+      .update(alertWebhookDestination)
+      .set({ encryptedSigningSecret: 'enc:v1:corrupt' })
+      .where(eq(alertWebhookDestination.id, destination.id))
+
+    const input = await __alertNotifierTestUtils.buildDeliveryInput(
+      { type: 'webhook', destinationId: destination.id },
+      'alert-event-id',
+      TEST_ORG_ID
+    )
+
+    expect(input.target).toBe(`destination:${destination.id}`)
+    expect(input.providerMetadata).toMatchObject({
+      type: 'webhook',
+      destinationId: destination.id,
+      url: 'https://example.com/durabull',
+      secretConfigured: true,
+      deliveryError: 'Webhook destination "Corrupt secret" signing secret could not be decrypted.',
+      deliveryErrorRetryable: true,
+    })
+  })
+
+  it('refreshes enqueue-time delivery errors from the current destination on retry', async () => {
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Retryable destination',
+      url: 'https://example.com/durabull',
+      signingSecret: 'super-secret-webhook-value',
+    })
+    const db = await getDb()
+    await db
+      .update(alertWebhookDestination)
+      .set({ encryptedSigningSecret: 'enc:v1:corrupt' })
+      .where(eq(alertWebhookDestination.id, destination.id))
+    const failedInput = await __alertNotifierTestUtils.buildDeliveryInput(
+      { type: 'webhook', destinationId: destination.id },
+      'alert-event-id',
+      TEST_ORG_ID
+    )
+
+    await alertWebhookDestinationRepository.update(destination.id, TEST_ORG_ID, {
+      signingSecret: 'fixed-secret-webhook-value',
+    })
+    const refreshed = await __alertNotifierTestUtils.resolveWebhookMetadataForDispatch(
+      failedInput.providerMetadata,
+      TEST_ORG_ID
+    )
+
+    expect(refreshed).toMatchObject({
+      type: 'webhook',
+      destinationId: destination.id,
+      url: 'https://example.com/durabull',
+      secretConfigured: true,
+      secretLast4: 'alue',
+    })
+    expect(refreshed).not.toHaveProperty('deliveryError')
   })
 })

--- a/apps/api/src/lib/alert-notifier.ts
+++ b/apps/api/src/lib/alert-notifier.ts
@@ -1,8 +1,11 @@
 import {
   type AlertDelivery,
   type AlertEvent,
+  type AlertWebhookDestination,
   alertDeliveryRepository,
   alertRuleRepository,
+  alertWebhookDestinationRepository,
+  decryptSecret,
   eq,
   getDb,
   linearIntegrationRepository,
@@ -13,7 +16,11 @@ import {
 import { isEmailConfigured } from '@durabull/email'
 import { env } from '@durabull/env'
 import { buildAlertAppUrls } from './alert-app-urls'
-import { findWebhookSecretFromChannels, toWebhookDeliveryMetadata } from './alert-webhook-channels'
+import {
+  findWebhookSecretFromChannels,
+  sanitizeDeliveryProviderMetadata,
+  toWebhookDeliveryMetadata,
+} from './alert-webhook-channels'
 import {
   deliverWebhookOrThrow,
   isWebhookDeliveryExpired,
@@ -63,6 +70,10 @@ export type NotificationChannel =
       url: string
       secret?: string
     }
+  | {
+      type: 'webhook'
+      destinationId: string
+    }
 
 export async function dispatchAlertNotification(
   event: AlertEvent,
@@ -70,21 +81,48 @@ export async function dispatchAlertNotification(
   connection: AlertNotificationConnection,
   ruleName: string
 ): Promise<void> {
-  const deliveries = channels.map((channel) => ({
-    alertEventId: event.id,
-    organizationId: event.organizationId,
-    channelType: channel.type,
-    target: getDeliveryTarget(channel),
-    providerMetadata: getDeliveryProviderMetadata(channel),
-  }))
+  const deliveries = await Promise.all(
+    channels.map((channel) => buildDeliveryInput(channel, event.id, event.organizationId))
+  )
 
   await alertDeliveryRepository.enqueueMany(deliveries)
   await processAlertDeliveries(event, connection, ruleName)
 }
 
+async function buildDeliveryInput(
+  channel: NotificationChannel,
+  alertEventId: string,
+  organizationId: string
+) {
+  if (channel.type === 'webhook' && 'destinationId' in channel) {
+    const destination = await alertWebhookDestinationRepository.findById(
+      channel.destinationId,
+      organizationId
+    )
+
+    return {
+      alertEventId,
+      organizationId,
+      channelType: channel.type,
+      target: getSavedWebhookDeliveryTarget(channel.destinationId),
+      providerMetadata: resolveSavedWebhookDeliveryMetadata(channel.destinationId, destination),
+    }
+  }
+
+  return {
+    alertEventId,
+    organizationId,
+    channelType: channel.type,
+    target: getDeliveryTarget(channel),
+    providerMetadata: getDeliveryProviderMetadata(channel),
+  }
+}
+
 export type ProcessAlertDeliveriesOptions = {
   /** When set, claim and dispatch only this delivery (manual retry). */
   deliveryId?: string
+  /** Used by the monitor sweep after it has already claimed delivery rows. */
+  claimedDeliveries?: AlertDelivery[]
 }
 
 export async function processAlertDeliveries(
@@ -93,9 +131,11 @@ export async function processAlertDeliveries(
   ruleName: string,
   options?: ProcessAlertDeliveriesOptions
 ): Promise<void> {
-  const dueDeliveries = options?.deliveryId
-    ? await alertDeliveryRepository.claimById(options.deliveryId, event.id)
-    : await alertDeliveryRepository.claimDueForEvent(event.id)
+  const dueDeliveries =
+    options?.claimedDeliveries ??
+    (options?.deliveryId
+      ? await alertDeliveryRepository.claimById(options.deliveryId, event.id)
+      : await alertDeliveryRepository.claimDueForEvent(event.id))
   if (dueDeliveries.length === 0) return
 
   const organizationSlug = await getOrganizationSlug(event.organizationId)
@@ -139,16 +179,22 @@ export async function processAlertDeliveries(
   }
 }
 
-function getDeliveryProviderMetadata(channel: NotificationChannel): Record<string, unknown> {
+function getDeliveryProviderMetadata(
+  channel: Exclude<NotificationChannel, { destinationId: string }>
+): Record<string, unknown> {
   if (channel.type === 'webhook') {
     return { ...toWebhookDeliveryMetadata(channel) }
   }
   return channel as Record<string, unknown>
 }
 
-function getDeliveryTarget(channel: NotificationChannel): string {
+function getDeliveryTarget(
+  channel: Exclude<NotificationChannel, { destinationId: string }>
+): string {
   if (channel.type === 'email') return channel.target
-  if (channel.type === 'webhook') return getWebhookDeliveryTarget(channel.url)
+  if (channel.type === 'webhook') {
+    return getWebhookDeliveryTarget(channel.url)
+  }
   return [
     'org-default',
     channel.teamId ?? '',
@@ -158,6 +204,61 @@ function getDeliveryTarget(channel: NotificationChannel): string {
     channel.priority ?? '',
     ...(channel.labelIds ?? []),
   ].join(':')
+}
+
+function getSavedWebhookDeliveryTarget(destinationId: string): string {
+  return `destination:${destinationId}`
+}
+
+function resolveSavedWebhookDeliveryMetadata(
+  destinationId: string,
+  destination: AlertWebhookDestination | null
+): Record<string, unknown> {
+  if (!destination) {
+    return {
+      type: 'webhook',
+      destinationId,
+      deliveryError: 'Webhook destination was deleted before alert delivery was queued.',
+    }
+  }
+  if (!destination.enabled) {
+    return {
+      type: 'webhook',
+      destinationId,
+      destinationName: destination.name,
+      deliveryError: `Webhook destination "${destination.name}" is disabled.`,
+      deliveryErrorRetryable: true,
+    }
+  }
+
+  let secretLast4: string | undefined
+  if (destination.encryptedSigningSecret) {
+    try {
+      const secret = decryptSecret(destination.encryptedSigningSecret)
+      secretLast4 = secret.length >= 4 ? secret.slice(-4) : undefined
+    } catch {
+      return {
+        type: 'webhook',
+        destinationId,
+        destinationName: destination.name,
+        url: destination.url,
+        encryptedSigningSecret: destination.encryptedSigningSecret,
+        secretConfigured: true,
+        deliveryError: `Webhook destination "${destination.name}" signing secret could not be decrypted.`,
+        deliveryErrorRetryable: true,
+      }
+    }
+  }
+
+  return {
+    type: 'webhook',
+    destinationId,
+    destinationName: destination.name,
+    url: destination.url,
+    encryptedSigningSecret: destination.encryptedSigningSecret,
+    secretConfigured: Boolean(destination.encryptedSigningSecret),
+    ...(secretLast4 ? { secretLast4 } : {}),
+  }
 }
 
 async function sendAlertEmail(
@@ -377,8 +478,18 @@ async function sendWebhookAlert(
   ruleName: string,
   organizationSlug: string | null
 ): Promise<void> {
-  const channel = parseWebhookChannel(delivery.providerMetadata)
-  const secret = await resolveWebhookSigningSecret(event, channel.url, delivery.providerMetadata)
+  const metadata = await resolveWebhookMetadataForDispatch(
+    delivery.providerMetadata as Record<string, unknown> | null | undefined,
+    event.organizationId
+  )
+  if (metadata && typeof metadata.deliveryError === 'string') {
+    if (metadata.deliveryErrorRetryable === true) {
+      throw new WebhookDeliveryError(metadata.deliveryError, { retryable: true })
+    }
+    throw new NonRetryableDeliveryError(metadata.deliveryError)
+  }
+  const channel = parseWebhookChannel(metadata)
+  const secret = await resolveWebhookSigningSecret(event, channel.url, metadata)
   const payload = buildAlertWebhookPayloadFromEvent(
     event,
     delivery.id,
@@ -400,12 +511,13 @@ async function sendWebhookAlert(
   const marked = await alertDeliveryRepository.markDelivered(
     delivery.id,
     {
-      providerMetadata: {
+      providerMetadata: sanitizeDeliveryProviderMetadata({
         ...((delivery.providerMetadata ?? {}) as Record<string, unknown>),
+        ...(metadata ?? {}),
         httpStatus: result.httpStatus,
         responseTimeMs: result.durationMs,
         responseBodySnippet: result.responseBodySnippet,
-      },
+      }),
     },
     requireClaimedAt(delivery)
   )
@@ -417,7 +529,23 @@ async function sendWebhookAlert(
   }
 }
 
-function parseWebhookChannel(value: unknown): Extract<NotificationChannel, { type: 'webhook' }> {
+async function resolveWebhookMetadataForDispatch(
+  metadata: Record<string, unknown> | null | undefined,
+  organizationId: string
+): Promise<Record<string, unknown> | null | undefined> {
+  const destinationId = typeof metadata?.destinationId === 'string' ? metadata.destinationId : ''
+  if (!destinationId || typeof metadata?.deliveryError !== 'string') {
+    return metadata
+  }
+
+  const destination = await alertWebhookDestinationRepository.findById(
+    destinationId,
+    organizationId
+  )
+  return resolveSavedWebhookDeliveryMetadata(destinationId, destination)
+}
+
+function parseWebhookChannel(value: unknown): { type: 'webhook'; url: string } {
   const source =
     typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
   const url = typeof source.url === 'string' ? source.url : ''
@@ -437,6 +565,16 @@ async function resolveWebhookSigningSecret(
 ): Promise<string | undefined> {
   const source =
     typeof metadata === 'object' && metadata !== null ? (metadata as Record<string, unknown>) : {}
+  const encryptedSigningSecret =
+    typeof source.encryptedSigningSecret === 'string' ? source.encryptedSigningSecret : ''
+  if (encryptedSigningSecret) {
+    try {
+      return decryptSecret(encryptedSigningSecret)
+    } catch {
+      throw new NonRetryableDeliveryError('Webhook signing secret could not be decrypted.')
+    }
+  }
+
   const legacySecret = typeof source.secret === 'string' ? source.secret.trim() : ''
   if (legacySecret.length > 0) {
     return legacySecret
@@ -589,3 +727,9 @@ async function getOrganizationSlug(organizationId: string): Promise<string | nul
 }
 
 export { buildAlertAppUrls } from './alert-app-urls'
+
+export const __alertNotifierTestUtils = {
+  buildDeliveryInput,
+  getSavedWebhookDeliveryTarget,
+  resolveWebhookMetadataForDispatch,
+}

--- a/apps/api/src/lib/alert-webhook-channels.test.ts
+++ b/apps/api/src/lib/alert-webhook-channels.test.ts
@@ -60,6 +60,14 @@ describe('sanitizeNotificationChannels', () => {
       secretLast4: 'mnop',
     })
   })
+
+  it('preserves saved webhook destination references', () => {
+    const sanitized = sanitizeNotificationChannels([
+      { type: 'webhook', destinationId: 'destination-id' },
+    ])
+
+    expect(sanitized).toEqual([{ type: 'webhook', destinationId: 'destination-id' }])
+  })
 })
 
 describe('toWebhookDeliveryMetadata', () => {
@@ -121,6 +129,25 @@ describe('sanitizeDeliveryProviderMetadata', () => {
       type: 'webhook',
       url: 'https://example.com/hook',
       httpStatus: 200,
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+  })
+
+  it('removes encrypted webhook secrets from delivery metadata', () => {
+    expect(
+      sanitizeDeliveryProviderMetadata({
+        type: 'webhook',
+        destinationId: 'destination-id',
+        url: 'https://example.com/hook',
+        encryptedSigningSecret: 'enc:v1:redacted',
+        secretConfigured: true,
+        secretLast4: 'mnop',
+      })
+    ).toEqual({
+      type: 'webhook',
+      destinationId: 'destination-id',
+      url: 'https://example.com/hook',
       secretConfigured: true,
       secretLast4: 'mnop',
     })

--- a/apps/api/src/lib/alert-webhook-channels.ts
+++ b/apps/api/src/lib/alert-webhook-channels.ts
@@ -6,11 +6,21 @@ export interface WebhookNotificationChannel {
   secret?: string
 }
 
+export interface SavedWebhookNotificationChannel {
+  type: 'webhook'
+  destinationId: string
+}
+
 export interface SanitizedWebhookNotificationChannel {
   type: 'webhook'
   url: string
   secretConfigured: boolean
   secretLast4?: string
+}
+
+export interface SanitizedSavedWebhookNotificationChannel {
+  type: 'webhook'
+  destinationId: string
 }
 
 export function toWebhookDeliveryMetadata(
@@ -55,14 +65,14 @@ export function sanitizeDeliveryProviderMetadata(
 ): Record<string, unknown> {
   if (!metadata || typeof metadata !== 'object') return {}
 
-  const { secret, ...rest } = metadata
-  if (rest.type !== 'webhook' || typeof rest.url !== 'string') {
+  const { secret, encryptedSigningSecret, ...rest } = metadata
+  if (rest.type !== 'webhook') {
     return rest
   }
+  if (typeof rest.url !== 'string') return rest
 
   const secretConfigured =
-    rest.secretConfigured === true ||
-    (typeof secret === 'string' && secret.trim().length > 0)
+    rest.secretConfigured === true || (typeof secret === 'string' && secret.trim().length > 0)
   const secretLast4 =
     typeof rest.secretLast4 === 'string'
       ? rest.secretLast4
@@ -74,6 +84,15 @@ export function sanitizeDeliveryProviderMetadata(
     ...rest,
     secretConfigured,
     ...(secretLast4 ? { secretLast4 } : {}),
+  }
+}
+
+export function sanitizeAlertDeliveryForClient<
+  T extends { providerMetadata?: Record<string, unknown> | null },
+>(delivery: T): T {
+  return {
+    ...delivery,
+    providerMetadata: sanitizeDeliveryProviderMetadata(delivery.providerMetadata),
   }
 }
 
@@ -96,17 +115,24 @@ export function sanitizeNotificationChannels(channels: unknown[]): unknown[] {
       channel !== null &&
       (channel as { type?: string }).type === 'webhook'
     ) {
-      const webhook = channel as WebhookNotificationChannel
-      return sanitizeWebhookChannel(webhook)
+      if (typeof (channel as { url?: string }).url === 'string') {
+        const webhook = channel as WebhookNotificationChannel
+        return sanitizeWebhookChannel(webhook)
+      }
+      if (typeof (channel as { destinationId?: string }).destinationId === 'string') {
+        return {
+          type: 'webhook',
+          destinationId: (channel as SavedWebhookNotificationChannel).destinationId,
+        } satisfies SanitizedSavedWebhookNotificationChannel
+      }
     }
     return channel as Record<string, unknown>
   })
 }
 
-export function mergeWebhookSecretsOnUpdate<T extends { type: string; url?: string; secret?: string }>(
-  incomingChannels: T[],
-  existingChannels: unknown[] | null | undefined
-): T[] {
+export function mergeWebhookSecretsOnUpdate<
+  T extends { type: string; url?: string; secret?: string },
+>(incomingChannels: T[], existingChannels: unknown[] | null | undefined): T[] {
   const existingByUrl = new Map<string, string>()
   for (const channel of existingChannels ?? []) {
     if (

--- a/apps/api/src/routes/alert-webhook-destinations.test.ts
+++ b/apps/api/src/routes/alert-webhook-destinations.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  alertWebhookDestination,
+  alertRuleRepository,
+  closeDb,
+  eq,
+  getDb,
+  organization,
+  redisConnectionRepository,
+} from '@durabull/dal'
+import { env } from '@durabull/env'
+import { Hono } from 'hono'
+
+const TEST_ORG_ID = 'alert-webhook-destination-route-org'
+const TEST_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+const mutableEnv = env as {
+  DATABASE_URL?: string
+  DURABULL_SECRET_ENCRYPTION_KEY?: string
+  DURABULL_REDIS_URL_ENCRYPTION_KEY?: string
+  DURABULL_ENV_CONNECTIONS?: boolean
+}
+
+const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalSecretKey = mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY
+const originalRedisEncryptionKey = mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY
+const originalEnvConnectionsFlag = mutableEnv.DURABULL_ENV_CONNECTIONS
+const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+
+let tempPgliteDir = ''
+
+async function seedOrganization() {
+  const db = await getDb()
+  const now = new Date()
+  await db.insert(organization).values({
+    id: TEST_ORG_ID,
+    name: 'Alert Webhook Destination Route Org',
+    slug: 'alert-webhook-destination-route-org',
+    createdAt: now,
+    updatedAt: now,
+  })
+}
+
+async function createRouteApp() {
+  const { default: webhookDestinationRoutes } = await import('./alert-webhook-destinations')
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    c.set('organizationId', TEST_ORG_ID)
+    await next()
+  })
+  return app.route('/', webhookDestinationRoutes)
+}
+
+describe('alert webhook destination routes', () => {
+  beforeEach(async () => {
+    tempPgliteDir = await mkdtemp(join(tmpdir(), 'durabull-alert-webhook-destination-routes-'))
+    process.env.DURABULL_PGLITE_DIR = tempPgliteDir
+    delete process.env.DATABASE_URL
+    mutableEnv.DATABASE_URL = undefined
+    mutableEnv.DURABULL_ENV_CONNECTIONS = false
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY
+    await closeDb()
+    await seedOrganization()
+  })
+
+  afterEach(async () => {
+    await closeDb()
+    mutableEnv.DATABASE_URL = originalDatabaseUrl
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = originalSecretKey
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = originalRedisEncryptionKey
+    mutableEnv.DURABULL_ENV_CONNECTIONS = originalEnvConnectionsFlag
+
+    if (originalPgliteDir) {
+      process.env.DURABULL_PGLITE_DIR = originalPgliteDir
+    } else {
+      delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (tempPgliteDir) {
+      await rm(tempPgliteDir, { recursive: true, force: true })
+      tempPgliteDir = ''
+    }
+  })
+
+  it('creates and lists sanitized webhook destinations', async () => {
+    const app = await createRouteApp()
+    const createResponse = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Incident intake',
+        url: 'https://example.com/durabull',
+        signingSecret: 'abcdefghijklmnop',
+      }),
+    })
+
+    expect(createResponse.status).toBe(201)
+    const created = (await createResponse.json()) as {
+      destination: { id: string; secretConfigured: boolean; secretLast4?: string }
+    }
+    expect(created.destination.secretConfigured).toBe(true)
+    expect(created.destination.secretLast4).toBe('mnop')
+
+    const listResponse = await app.request('/')
+    expect(listResponse.status).toBe(200)
+    const listed = (await listResponse.json()) as {
+      destinations: Array<{ id: string; name: string; secretConfigured: boolean }>
+    }
+    expect(listed.destinations).toEqual([
+      expect.objectContaining({
+        id: created.destination.id,
+        name: 'Incident intake',
+        secretConfigured: true,
+      }),
+    ])
+  })
+
+  it('lists destinations with unreadable secrets without exposing or throwing', async () => {
+    const app = await createRouteApp()
+    const createResponse = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Corrupt secret',
+        url: 'https://example.com/durabull',
+        signingSecret: 'super-secret-webhook-value',
+      }),
+    })
+    const created = (await createResponse.json()) as { destination: { id: string } }
+    const db = await getDb()
+    await db
+      .update(alertWebhookDestination)
+      .set({ encryptedSigningSecret: 'enc:v1:corrupt' })
+      .where(eq(alertWebhookDestination.id, created.destination.id))
+
+    const listResponse = await app.request('/')
+
+    expect(listResponse.status).toBe(200)
+    const body = (await listResponse.json()) as {
+      destinations: Array<{ secretConfigured: boolean; secretLast4?: string }>
+    }
+    expect(body.destinations[0]).toMatchObject({ secretConfigured: true })
+    expect(body.destinations[0]?.secretLast4).toBeUndefined()
+  })
+
+  it('returns a 400 when testing a destination with an unreadable secret', async () => {
+    const app = await createRouteApp()
+    const createResponse = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Corrupt test secret',
+        url: 'https://example.com/durabull',
+        signingSecret: 'super-secret-webhook-value',
+      }),
+    })
+    const created = (await createResponse.json()) as { destination: { id: string } }
+    const db = await getDb()
+    await db
+      .update(alertWebhookDestination)
+      .set({ encryptedSigningSecret: 'enc:v1:corrupt' })
+      .where(eq(alertWebhookDestination.id, created.destination.id))
+
+    const testResponse = await app.request(`/${created.destination.id}/test`, { method: 'POST' })
+
+    expect(testResponse.status).toBe(400)
+    expect(await testResponse.json()).toEqual({
+      error: 'Webhook destination signing secret could not be decrypted.',
+    })
+  })
+
+  it('blocks deleting destinations that are still referenced by rules', async () => {
+    const app = await createRouteApp()
+    const createResponse = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Incident intake',
+        url: 'https://example.com/durabull',
+      }),
+    })
+    const created = (await createResponse.json()) as { destination: { id: string } }
+    const connection = await redisConnectionRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Primary Redis',
+      url: 'redis://localhost:6379/0',
+      environment: 'development',
+      isDefault: true,
+    })
+    await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: connection.id,
+      queueName: 'email-send',
+      name: 'Failure threshold',
+      type: 'failure_threshold',
+      config: { count: 5, windowMinutes: 5 },
+      notificationChannels: [{ type: 'webhook', destinationId: created.destination.id }],
+      cooldownMinutes: 30,
+    })
+
+    const deleteResponse = await app.request(`/${created.destination.id}`, { method: 'DELETE' })
+
+    expect(deleteResponse.status).toBe(409)
+  })
+
+  it('blocks disabling destinations that are still referenced by rules', async () => {
+    const app = await createRouteApp()
+    const createResponse = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Incident intake',
+        url: 'https://example.com/durabull',
+      }),
+    })
+    const created = (await createResponse.json()) as { destination: { id: string } }
+    const connection = await redisConnectionRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Primary Redis',
+      url: 'redis://localhost:6379/0',
+      environment: 'development',
+      isDefault: true,
+    })
+    await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: connection.id,
+      queueName: 'email-send',
+      name: 'Failure threshold',
+      type: 'failure_threshold',
+      config: { count: 5, windowMinutes: 5 },
+      notificationChannels: [{ type: 'webhook', destinationId: created.destination.id }],
+      cooldownMinutes: 30,
+    })
+
+    const disableResponse = await app.request(`/${created.destination.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    })
+
+    expect(disableResponse.status).toBe(409)
+  })
+})

--- a/apps/api/src/routes/alert-webhook-destinations.ts
+++ b/apps/api/src/routes/alert-webhook-destinations.ts
@@ -1,0 +1,233 @@
+import {
+  type AlertWebhookDestination,
+  alertWebhookDestinationRepository,
+  decryptSecret,
+} from '@durabull/dal'
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { sendRateLimitedTestWebhook } from '../lib/alert-webhook-rate-limit'
+import { validateWebhookUrls } from '../lib/alert-webhook-channels'
+import { requireOrganization } from '../middleware/auth'
+
+const webhookDestinationPayloadSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  url: z.string().trim().url().max(2048),
+  signingSecret: z.string().min(16).max(256).nullable().optional(),
+  enabled: z.boolean().optional(),
+})
+
+const webhookDestinationUpdateSchema = webhookDestinationPayloadSchema.partial()
+
+const app = new Hono()
+  .use('*', requireOrganization)
+  .get('/', async (c) => {
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const destinations = await alertWebhookDestinationRepository.listByOrganization(organizationId)
+    return c.json({ destinations: destinations.map(serializeWebhookDestination) })
+  })
+  .post('/', zValidator('json', webhookDestinationPayloadSchema), async (c) => {
+    const body = c.req.valid('json')
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const urlError = await validateWebhookUrls([{ type: 'webhook', url: body.url }])
+    if (urlError) {
+      return c.json({ error: urlError }, 400)
+    }
+
+    try {
+      const destination = await alertWebhookDestinationRepository.create({
+        organizationId,
+        name: body.name,
+        url: body.url,
+        signingSecret: body.signingSecret,
+        enabled: body.enabled,
+      })
+
+      return c.json({ destination: serializeWebhookDestination(destination) }, 201)
+    } catch (error) {
+      return c.json({ error: normalizeDestinationWriteError(error) }, 400)
+    }
+  })
+  .patch('/:destinationId', zValidator('json', webhookDestinationUpdateSchema), async (c) => {
+    const { destinationId } = c.req.param()
+    const body = c.req.valid('json')
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    if (body.url !== undefined) {
+      const urlError = await validateWebhookUrls([{ type: 'webhook', url: body.url }])
+      if (urlError) {
+        return c.json({ error: urlError }, 400)
+      }
+    }
+
+    if (body.enabled === false) {
+      const references = await alertWebhookDestinationRepository.countRuleReferences(
+        destinationId,
+        organizationId
+      )
+      if (references > 0) {
+        return c.json(
+          {
+            error:
+              'Webhook destination is used by alert rules. Remove it from rules before disabling.',
+          },
+          409
+        )
+      }
+    }
+
+    try {
+      const destination = await alertWebhookDestinationRepository.update(
+        destinationId,
+        organizationId,
+        {
+          name: body.name,
+          url: body.url,
+          signingSecret: body.signingSecret,
+          enabled: body.enabled,
+        }
+      )
+
+      if (!destination) {
+        return c.json({ error: 'Webhook destination not found' }, 404)
+      }
+
+      return c.json({ destination: serializeWebhookDestination(destination) })
+    } catch (error) {
+      return c.json({ error: normalizeDestinationWriteError(error) }, 400)
+    }
+  })
+  .delete('/:destinationId', async (c) => {
+    const { destinationId } = c.req.param()
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const references = await alertWebhookDestinationRepository.countRuleReferences(
+      destinationId,
+      organizationId
+    )
+    if (references > 0) {
+      return c.json(
+        {
+          error:
+            'Webhook destination is used by alert rules. Remove it from rules before deleting.',
+        },
+        409
+      )
+    }
+
+    const deleted = await alertWebhookDestinationRepository.delete(destinationId, organizationId)
+    if (!deleted) {
+      return c.json({ error: 'Webhook destination not found' }, 404)
+    }
+
+    return c.json({ ok: true })
+  })
+  .post('/:destinationId/test', async (c) => {
+    const { destinationId } = c.req.param()
+    const organizationId = c.get('organizationId')
+    if (!organizationId) {
+      return c.json({ error: 'Organization is required' }, 403)
+    }
+
+    const destination = await alertWebhookDestinationRepository.findById(
+      destinationId,
+      organizationId
+    )
+    if (!destination) {
+      return c.json({ error: 'Webhook destination not found' }, 404)
+    }
+
+    if (!destination.enabled) {
+      return c.json({ error: 'Webhook destination is disabled.' }, 400)
+    }
+
+    let secret: string | undefined
+    try {
+      secret = decryptWebhookSecretOrThrow(destination)
+    } catch (error) {
+      return c.json(
+        { error: error instanceof Error ? error.message : 'Invalid signing secret' },
+        400
+      )
+    }
+
+    const result = await sendRateLimitedTestWebhook({
+      url: destination.url,
+      secret,
+      organizationId,
+      organizationSlug: null,
+      connectionId: 'test-connection',
+      connectionName: 'Webhook destination test',
+      ruleName: 'Webhook destination test',
+      ruleType: 'job_failed',
+      queueName: 'example-queue',
+    })
+
+    if (result.error?.includes('rate limit')) {
+      return c.json({ error: result.error }, 429)
+    }
+
+    return c.json({
+      success: result.success,
+      httpStatus: result.httpStatus,
+      durationMs: result.durationMs,
+      error: result.error,
+    })
+  })
+
+function serializeWebhookDestination(destination: AlertWebhookDestination) {
+  const secret = tryDecryptWebhookSecret(destination)
+  return {
+    id: destination.id,
+    organizationId: destination.organizationId,
+    name: destination.name,
+    url: destination.url,
+    enabled: destination.enabled,
+    secretConfigured: Boolean(destination.encryptedSigningSecret),
+    secretLast4: secret && secret.length >= 4 ? secret.slice(-4) : undefined,
+    createdAt: destination.createdAt,
+    updatedAt: destination.updatedAt,
+  }
+}
+
+function tryDecryptWebhookSecret(destination: AlertWebhookDestination): string | undefined {
+  if (!destination.encryptedSigningSecret) return undefined
+  try {
+    return decryptSecret(destination.encryptedSigningSecret)
+  } catch {
+    return undefined
+  }
+}
+
+function decryptWebhookSecretOrThrow(destination: AlertWebhookDestination): string | undefined {
+  if (!destination.encryptedSigningSecret) return undefined
+  try {
+    return decryptSecret(destination.encryptedSigningSecret)
+  } catch {
+    throw new Error('Webhook destination signing secret could not be decrypted.')
+  }
+}
+
+function normalizeDestinationWriteError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message.includes('duplicate') || message.includes('unique')) {
+    return 'A webhook destination with that name already exists.'
+  }
+  return message
+}
+
+export default app

--- a/apps/api/src/routes/alerts-global.test.ts
+++ b/apps/api/src/routes/alerts-global.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  alertDeliveryRepository,
   alertEventRepository,
   alertRuleRepository,
   closeDb,
@@ -235,6 +236,60 @@ describe('global alerts routes', () => {
     })
   })
 
+  it('sanitizes webhook delivery metadata in organization-wide event history', async () => {
+    const rule = await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: FIRST_CONNECTION_ID,
+      queueName: 'email-send',
+      name: 'Webhook metadata',
+      type: 'failure_threshold',
+      config: { count: 5, windowMinutes: 5 },
+      cooldownMinutes: 30,
+    })
+    const event = await alertEventRepository.create({
+      alertRuleId: rule.id,
+      organizationId: TEST_ORG_ID,
+      connectionId: FIRST_CONNECTION_ID,
+      queueName: 'email-send',
+      type: 'failure_threshold',
+      status: 'firing',
+      summary: 'Webhook delivery failed',
+      context: {},
+      firedAt: new Date(),
+    })
+    await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'webhook',
+        target: 'destination:destination-id',
+        providerMetadata: {
+          type: 'webhook',
+          destinationId: 'destination-id',
+          url: 'https://example.com/hook',
+          encryptedSigningSecret: 'enc:v1:redacted',
+          secretConfigured: true,
+          secretLast4: 'mnop',
+        },
+      },
+    ])
+
+    const app = await createGlobalAlertsRouteApp()
+    const response = await app.request('/events')
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      events: Array<{ deliveries: Array<{ providerMetadata: Record<string, unknown> }> }>
+    }
+    expect(body.events[0]?.deliveries[0]?.providerMetadata).toEqual({
+      type: 'webhook',
+      destinationId: 'destination-id',
+      url: 'https://example.com/hook',
+      secretConfigured: true,
+      secretLast4: 'mnop',
+    })
+  })
+
   it('returns open incident counts grouped by connection', async () => {
     const firstRule = await alertRuleRepository.create({
       organizationId: TEST_ORG_ID,
@@ -335,7 +390,9 @@ describe('global alerts routes', () => {
 
     const response = await app.request('/integrations/linear')
     expect(response.status).toBe(200)
-    const body = await response.json()
+    const body = (await response.json()) as {
+      integration: Record<string, unknown>
+    }
     expect(body).toMatchObject({
       integration: {
         connected: true,

--- a/apps/api/src/routes/alerts-global.ts
+++ b/apps/api/src/routes/alerts-global.ts
@@ -10,6 +10,7 @@ import { env } from '@durabull/env'
 import { zValidator } from '@hono/zod-validator'
 import { type Context, Hono } from 'hono'
 import { z } from 'zod'
+import { sanitizeAlertDeliveryForClient } from '../lib/alert-webhook-channels'
 import {
   exchangeLinearOauthCode,
   fetchLinearMetadata,
@@ -347,7 +348,9 @@ async function attachDeliveries<T extends { id: string }>(events: T[]) {
   return Promise.all(
     events.map(async (event) => ({
       ...event,
-      deliveries: await alertDeliveryRepository.listByEvent(event.id),
+      deliveries: (await alertDeliveryRepository.listByEvent(event.id)).map((delivery) =>
+        sanitizeAlertDeliveryForClient(delivery)
+      ),
     }))
   )
 }

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -7,7 +7,10 @@ import {
   alertDeliveryRepository,
   alertEventRepository,
   alertRuleRepository,
+  alertWebhookDestination,
+  alertWebhookDestinationRepository,
   closeDb,
+  eq,
   getDb,
   organization,
   redisConnection,
@@ -158,6 +161,198 @@ describe('alerts routes', () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: 'Only one Linear notification channel is supported per rule.',
+    })
+  })
+
+  it('rejects saved webhook destinations that do not exist', async () => {
+    const app = await createAlertsRouteApp()
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Missing webhook destination',
+        type: 'failure_threshold',
+        queueName: 'email-send',
+        config: { count: 5, windowMinutes: 5 },
+        notificationChannels: [
+          { type: 'webhook', destinationId: '11111111-1111-4111-8111-111111111111' },
+        ],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Webhook destination not found.' })
+  })
+
+  it('rejects disabled saved webhook destinations', async () => {
+    const app = await createAlertsRouteApp()
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Incident intake',
+      url: 'https://example.com/durabull',
+      enabled: false,
+    })
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Disabled webhook destination',
+        type: 'failure_threshold',
+        queueName: 'email-send',
+        config: { count: 5, windowMinutes: 5 },
+        notificationChannels: [{ type: 'webhook', destinationId: destination.id }],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Webhook destination "Incident intake" is disabled.',
+    })
+  })
+
+  it('creates rules with valid saved webhook destinations', async () => {
+    const app = await createAlertsRouteApp()
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Incident intake',
+      url: 'https://example.com/durabull',
+    })
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Saved webhook destination',
+        type: 'failure_threshold',
+        queueName: 'email-send',
+        config: { count: 5, windowMinutes: 5 },
+        notificationChannels: [{ type: 'webhook', destinationId: destination.id }],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(201)
+    expect(await response.json()).toMatchObject({
+      rule: {
+        notificationChannels: [{ type: 'webhook', destinationId: destination.id }],
+      },
+    })
+  })
+
+  it('rejects saved webhook destinations with unreadable signing secrets', async () => {
+    const app = await createAlertsRouteApp()
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Corrupt secret',
+      url: 'https://example.com/durabull',
+      signingSecret: 'super-secret-webhook-value',
+    })
+    const db = await getDb()
+    await db
+      .update(alertWebhookDestination)
+      .set({ encryptedSigningSecret: 'enc:v1:corrupt' })
+      .where(eq(alertWebhookDestination.id, destination.id))
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Corrupt saved webhook destination',
+        type: 'failure_threshold',
+        queueName: 'email-send',
+        config: { count: 5, windowMinutes: 5 },
+        notificationChannels: [{ type: 'webhook', destinationId: destination.id }],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Webhook destination "Corrupt secret" signing secret could not be decrypted.',
+    })
+  })
+
+  it('rejects webhook channels with both custom URL and saved destination fields', async () => {
+    const app = await createAlertsRouteApp()
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Ambiguous webhook channel',
+        type: 'failure_threshold',
+        queueName: 'email-send',
+        config: { count: 5, windowMinutes: 5 },
+        notificationChannels: [
+          {
+            type: 'webhook',
+            url: 'https://example.com/durabull',
+            destinationId: '11111111-1111-4111-8111-111111111111',
+          },
+        ],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects duplicate custom webhook URLs on one rule', async () => {
+    const app = await createAlertsRouteApp()
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Duplicate custom webhooks',
+        type: 'failure_threshold',
+        queueName: 'email-send',
+        config: { count: 5, windowMinutes: 5 },
+        notificationChannels: [
+          { type: 'webhook', url: 'https://example.com/durabull' },
+          { type: 'webhook', url: 'https://example.com/durabull' },
+        ],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Duplicate custom webhook URLs are not allowed on the same alert rule.',
+    })
+  })
+
+  it('rejects duplicate saved webhook destinations on one rule', async () => {
+    const app = await createAlertsRouteApp()
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Incident intake',
+      url: 'https://example.com/durabull',
+    })
+
+    const response = await app.request(
+      '/rules',
+      jsonRequest({
+        name: 'Duplicate saved webhooks',
+        type: 'failure_threshold',
+        queueName: 'email-send',
+        config: { count: 5, windowMinutes: 5 },
+        notificationChannels: [
+          { type: 'webhook', destinationId: destination.id },
+          { type: 'webhook', destinationId: destination.id },
+        ],
+        cooldownMinutes: 30,
+        enabled: true,
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Duplicate saved webhook destinations are not allowed on the same alert rule.',
     })
   })
 

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -3,6 +3,8 @@ import {
   alertDeliveryRepository,
   alertEventRepository,
   alertRuleRepository,
+  alertWebhookDestinationRepository,
+  decryptSecret,
   eq,
   getDb,
   linearIntegrationRepository,
@@ -17,7 +19,7 @@ import { processAlertDeliveries } from '../lib/alert-notifier'
 import {
   mergeWebhookSecretsOnUpdate,
   resolveWebhookTestSecret,
-  sanitizeDeliveryProviderMetadata,
+  sanitizeAlertDeliveryForClient,
   sanitizeNotificationChannels,
   validateWebhookUrls,
 } from '../lib/alert-webhook-channels'
@@ -42,15 +44,24 @@ const linearNotificationChannelSchema = z.object({
   stateId: z.string().min(1).optional(),
   priority: z.number().int().min(0).max(4).optional(),
 })
-const webhookNotificationChannelSchema = z.object({
-  type: z.literal('webhook'),
-  url: z.string().url().max(2048),
-  secret: z.string().min(16).max(256).optional(),
-})
-const notificationChannelSchema = z.discriminatedUnion('type', [
+const webhookNotificationChannelSchema = z
+  .object({
+    type: z.literal('webhook'),
+    url: z.string().url().max(2048),
+    secret: z.string().min(16).max(256).optional(),
+  })
+  .strict()
+const savedWebhookNotificationChannelSchema = z
+  .object({
+    type: z.literal('webhook'),
+    destinationId: z.string().uuid(),
+  })
+  .strict()
+const notificationChannelSchema = z.union([
   emailNotificationChannelSchema,
   linearNotificationChannelSchema,
   webhookNotificationChannelSchema,
+  savedWebhookNotificationChannelSchema,
 ])
 
 const testWebhookSchema = z.object({
@@ -223,124 +234,140 @@ const app = new Hono()
       })
     ),
     async (c) => {
-    const { ruleId } = c.req.param()
-    const { deliver: deliverQuery } = c.req.valid('query')
-    const deliver = deliverQuery === 'true'
-    const connectionId = c.get('connectionId')
-    const connectionUrl = c.get('connectionUrl')
-    const connectionPrefix = c.get('connectionPrefix')
-    const redisOptions = getConnectionRedisOptions(c)
-    const connectionName = c.get('connectionName')
-    const organizationId = c.get('organizationId')
-    if (!organizationId) {
-      return c.json({ error: 'Organization is required' }, 403)
-    }
+      const { ruleId } = c.req.param()
+      const { deliver: deliverQuery } = c.req.valid('query')
+      const deliver = deliverQuery === 'true'
+      const connectionId = c.get('connectionId')
+      const connectionUrl = c.get('connectionUrl')
+      const connectionPrefix = c.get('connectionPrefix')
+      const redisOptions = getConnectionRedisOptions(c)
+      const connectionName = c.get('connectionName')
+      const organizationId = c.get('organizationId')
+      if (!organizationId) {
+        return c.json({ error: 'Organization is required' }, 403)
+      }
 
-    const rule = await alertRuleRepository.findById(ruleId, organizationId)
-    if (!rule) {
-      return c.json({ error: 'Rule not found' }, 404)
-    }
+      const rule = await alertRuleRepository.findById(ruleId, organizationId)
+      if (!rule) {
+        return c.json({ error: 'Rule not found' }, 404)
+      }
 
-    let queueName = rule.queueName
-    if (!queueName) {
-      const discovered = await redisDiscoveredQueueRepository.listByConnection(connectionId, {
-        offset: 0,
-        limit: 1,
-      })
-      queueName = discovered[0]?.name ?? null
-    }
-    if (!queueName) {
-      return c.json({ error: 'No queue available to test this rule yet' }, 400)
-    }
-
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
-    const [jobCountsRaw, failedMetricsRaw, completedMetricsRaw] = await Promise.all([
-      queue.getJobCounts('failed', 'waiting', 'active', 'completed'),
-      queue.getMetrics('failed', 0, 60),
-      queue.getMetrics('completed', 0, 60),
-    ])
-
-    const snapshot: QueueSnapshot = {
-      queueName,
-      connectionName,
-      jobCounts: {
-        failed: jobCountsRaw.failed ?? 0,
-        waiting: jobCountsRaw.waiting ?? 0,
-        active: jobCountsRaw.active ?? 0,
-        completed: jobCountsRaw.completed ?? 0,
-      },
-      failedMetrics: {
-        count: failedMetricsRaw.meta.count,
-        dataPoints: failedMetricsRaw.data,
-      },
-      completedMetrics: {
-        count: completedMetricsRaw.meta.count,
-        dataPoints: completedMetricsRaw.data,
-      },
-    }
-
-    const cursorRow = await alertCheckCursorRepository.findByConnectionQueue(
-      connectionId,
-      queueName
-    )
-    const cursor: CursorState | null = cursorRow
-      ? {
-          lastCheckedAt: cursorRow.lastCheckedAt,
-          lastFailedCount: cursorRow.lastFailedCount,
-          lastCompletedCount: cursorRow.lastCompletedCount,
-        }
-      : null
-
-    const evaluation = evaluateRule(rule, snapshot, cursor)
-
-    const webhookChannels = (Array.isArray(rule.notificationChannels) ? rule.notificationChannels : [])
-      .filter(
-        (channel): channel is { type: 'webhook'; url: string; secret?: string } =>
-          typeof channel === 'object' &&
-          channel !== null &&
-          (channel as { type?: string }).type === 'webhook' &&
-          typeof (channel as { url?: string }).url === 'string'
-      )
-
-    let webhookTests:
-      | Array<{
-          url: string
-          success: boolean
-          httpStatus: number | null
-          durationMs: number
-          error?: string
-        }>
-      | undefined
-
-    if (deliver && webhookChannels.length > 0) {
-      const organizationSlug = await getOrganizationSlug(organizationId)
-      webhookTests = await Promise.all(
-        webhookChannels.map(async (channel) => {
-          const result = await sendRateLimitedTestWebhook({
-            url: channel.url,
-            secret: channel.secret,
-            organizationId,
-            organizationSlug,
-            connectionId,
-            connectionName,
-            ruleId: rule.id,
-            ruleName: rule.name,
-            ruleType: rule.type,
-            queueName,
-          })
-          return {
-            url: channel.url,
-            success: result.success,
-            httpStatus: result.httpStatus,
-            durationMs: result.durationMs,
-            error: result.error,
-          }
+      let queueName = rule.queueName
+      if (!queueName) {
+        const discovered = await redisDiscoveredQueueRepository.listByConnection(connectionId, {
+          offset: 0,
+          limit: 1,
         })
-      )
-    }
+        queueName = discovered[0]?.name ?? null
+      }
+      if (!queueName) {
+        return c.json({ error: 'No queue available to test this rule yet' }, 400)
+      }
 
-    return c.json({ evaluation, snapshot, webhookTests })
-  })
+      const queue = await getQueue(
+        connectionId,
+        connectionUrl,
+        queueName,
+        connectionPrefix,
+        redisOptions
+      )
+      const [jobCountsRaw, failedMetricsRaw, completedMetricsRaw] = await Promise.all([
+        queue.getJobCounts('failed', 'waiting', 'active', 'completed'),
+        queue.getMetrics('failed', 0, 60),
+        queue.getMetrics('completed', 0, 60),
+      ])
+
+      const snapshot: QueueSnapshot = {
+        queueName,
+        connectionName,
+        jobCounts: {
+          failed: jobCountsRaw.failed ?? 0,
+          waiting: jobCountsRaw.waiting ?? 0,
+          active: jobCountsRaw.active ?? 0,
+          completed: jobCountsRaw.completed ?? 0,
+        },
+        failedMetrics: {
+          count: failedMetricsRaw.meta.count,
+          dataPoints: failedMetricsRaw.data,
+        },
+        completedMetrics: {
+          count: completedMetricsRaw.meta.count,
+          dataPoints: completedMetricsRaw.data,
+        },
+      }
+
+      const cursorRow = await alertCheckCursorRepository.findByConnectionQueue(
+        connectionId,
+        queueName
+      )
+      const cursor: CursorState | null = cursorRow
+        ? {
+            lastCheckedAt: cursorRow.lastCheckedAt,
+            lastFailedCount: cursorRow.lastFailedCount,
+            lastCompletedCount: cursorRow.lastCompletedCount,
+          }
+        : null
+
+      const evaluation = evaluateRule(rule, snapshot, cursor)
+
+      const notificationChannels = Array.isArray(rule.notificationChannels)
+        ? rule.notificationChannels
+        : []
+
+      let webhookTests:
+        | Array<{
+            url: string
+            success: boolean
+            httpStatus: number | null
+            durationMs: number
+            error?: string
+          }>
+        | undefined
+
+      if (deliver) {
+        const webhookChannels = await resolveWebhookTestChannels(
+          notificationChannels,
+          organizationId
+        )
+        const organizationSlug = await getOrganizationSlug(organizationId)
+        webhookTests = await Promise.all(
+          webhookChannels.map(async (channel) => {
+            if ('error' in channel) {
+              return {
+                url: channel.url,
+                success: false,
+                httpStatus: null,
+                durationMs: 0,
+                error: channel.error,
+              }
+            }
+
+            const result = await sendRateLimitedTestWebhook({
+              url: channel.url,
+              secret: channel.secret,
+              organizationId,
+              organizationSlug,
+              connectionId,
+              connectionName,
+              ruleId: rule.id,
+              ruleName: rule.name,
+              ruleType: rule.type,
+              queueName,
+            })
+            return {
+              url: channel.url,
+              success: result.success,
+              httpStatus: result.httpStatus,
+              durationMs: result.durationMs,
+              error: result.error,
+            }
+          })
+        )
+      }
+
+      return c.json({ evaluation, snapshot, webhookTests })
+    }
+  )
   .post('/webhooks/test', zValidator('json', testWebhookSchema), async (c) => {
     const body = c.req.valid('json')
     const connectionId = c.get('connectionId')
@@ -476,12 +503,9 @@ async function attachDeliveries<T extends { id: string }>(events: T[]) {
   return Promise.all(
     events.map(async (event) => ({
       ...event,
-      deliveries: (await alertDeliveryRepository.listByEvent(event.id)).map((delivery) => ({
-        ...delivery,
-        providerMetadata: sanitizeDeliveryProviderMetadata(
-          delivery.providerMetadata as Record<string, unknown> | null | undefined
-        ),
-      })),
+      deliveries: (await alertDeliveryRepository.listByEvent(event.id)).map((delivery) =>
+        sanitizeAlertDeliveryForClient(delivery)
+      ),
     }))
   )
 }
@@ -528,10 +552,46 @@ async function validateNotificationChannels(
   channels: z.infer<typeof notificationChannelSchema>[],
   organizationId: string
 ): Promise<string | null> {
-  const webhookError = await validateWebhookUrls(
-    channels.filter((channel) => channel.type === 'webhook')
+  const inlineWebhookChannels = channels.filter(
+    (channel): channel is z.infer<typeof webhookNotificationChannelSchema> =>
+      channel.type === 'webhook' && 'url' in channel
   )
+  const inlineWebhookTargets = new Set<string>()
+  for (const channel of inlineWebhookChannels) {
+    if (inlineWebhookTargets.has(channel.url)) {
+      return 'Duplicate custom webhook URLs are not allowed on the same alert rule.'
+    }
+    inlineWebhookTargets.add(channel.url)
+  }
+  const webhookError = await validateWebhookUrls(inlineWebhookChannels)
   if (webhookError) return webhookError
+
+  const savedWebhookDestinationIds = new Set<string>()
+  for (const channel of channels) {
+    if (channel.type !== 'webhook' || !('destinationId' in channel)) continue
+    if (savedWebhookDestinationIds.has(channel.destinationId)) {
+      return 'Duplicate saved webhook destinations are not allowed on the same alert rule.'
+    }
+    savedWebhookDestinationIds.add(channel.destinationId)
+
+    const destination = await alertWebhookDestinationRepository.findById(
+      channel.destinationId,
+      organizationId
+    )
+    if (!destination) {
+      return 'Webhook destination not found.'
+    }
+    if (!destination.enabled) {
+      return `Webhook destination "${destination.name}" is disabled.`
+    }
+    if (destination.encryptedSigningSecret) {
+      try {
+        decryptSecret(destination.encryptedSigningSecret)
+      } catch {
+        return `Webhook destination "${destination.name}" signing secret could not be decrypted.`
+      }
+    }
+  }
 
   const linearChannels = channels.filter((channel) => channel.type === 'linear')
   if (linearChannels.length > 1) {
@@ -548,6 +608,83 @@ async function validateNotificationChannels(
     (channel) => !channel.teamId && !integration.defaultTeamId
   )
   return missingTeam ? 'Linear alert routing requires a teamId or organization default team.' : null
+}
+
+type WebhookTestChannel =
+  | {
+      url: string
+      secret?: string
+    }
+  | {
+      url: string
+      error: string
+    }
+
+async function resolveWebhookTestChannels(
+  channels: unknown[],
+  organizationId: string
+): Promise<WebhookTestChannel[]> {
+  const results: WebhookTestChannel[] = []
+
+  for (const channel of channels) {
+    if (
+      typeof channel !== 'object' ||
+      channel === null ||
+      (channel as { type?: string }).type !== 'webhook'
+    ) {
+      continue
+    }
+
+    const url = (channel as { url?: unknown }).url
+    if (typeof url === 'string') {
+      results.push({
+        url,
+        secret:
+          typeof (channel as { secret?: unknown }).secret === 'string'
+            ? (channel as { secret: string }).secret
+            : undefined,
+      })
+      continue
+    }
+
+    const destinationId = (channel as { destinationId?: unknown }).destinationId
+    if (typeof destinationId !== 'string') continue
+
+    const destination = await alertWebhookDestinationRepository.findById(
+      destinationId,
+      organizationId
+    )
+    if (!destination) {
+      results.push({
+        url: `destination:${destinationId}`,
+        error: 'Webhook destination not found.',
+      })
+      continue
+    }
+    if (!destination.enabled) {
+      results.push({
+        url: destination.url,
+        error: `Webhook destination "${destination.name}" is disabled.`,
+      })
+      continue
+    }
+
+    try {
+      results.push({
+        url: destination.url,
+        secret: destination.encryptedSigningSecret
+          ? decryptSecret(destination.encryptedSigningSecret)
+          : undefined,
+      })
+    } catch {
+      results.push({
+        url: destination.url,
+        error: `Webhook destination "${destination.name}" signing secret could not be decrypted.`,
+      })
+    }
+  }
+
+  return results
 }
 
 async function getOrganizationSlug(organizationId: string): Promise<string | null> {

--- a/apps/docs/content/documentation/integrations/webhooks.mdx
+++ b/apps/docs/content/documentation/integrations/webhooks.mdx
@@ -9,12 +9,22 @@ that forwards alerts into Slack or PagerDuty.
 
 ## Setup
 
-1. Open a connection's alert rule builder.
-2. Add a **Webhook route** with your endpoint URL.
-3. Optionally add a signing secret (minimum 16 characters).
-4. Use **Send test webhook** to verify delivery before enabling the rule.
+You can configure webhooks in two ways:
 
-Webhook routes are configured per alert rule, alongside email and Linear destinations.
+- **Saved webhook destinations**: reusable organization-level endpoints managed from settings.
+- **Custom webhook URLs**: one-off endpoints configured directly on an alert rule.
+
+For reusable destinations:
+
+1. Open **Settings → Integrations**.
+2. Add a **Webhook alert destination** with a name and endpoint URL.
+3. Optionally add a signing secret (minimum 16 characters).
+4. Use **Test** to verify delivery.
+5. Open a connection's alert rule builder and choose the saved destination from a **Webhook route**.
+
+For one-off endpoints, open a connection's alert rule builder, add a **Webhook route**, switch it to **Custom URL**, and enter the endpoint URL and optional signing secret.
+
+Webhook routes are configured per alert rule, alongside email and Linear destinations. Saved destination edits apply to future alert deliveries only; deliveries already queued use the URL and signing secret snapshot captured when the alert was enqueued.
 
 ## Payload format
 
@@ -96,12 +106,14 @@ function verifyDurabullWebhook(rawBody: string, headers: Headers, secret: string
 - `408`, `429`, and `5xx` responses are retried.
 - Most other `4xx` responses are treated as permanent failures.
 - Requests time out after 10 seconds.
+- Due retry attempts are swept by the existing alert monitor, so retries can continue even after the original alert is no longer actively firing.
 - Retry attempts stop after **7 days** from the first delivery enqueue. The delivery row is marked permanently failed so dead endpoints do not retry forever.
 
 ## Security notes
 
 - Production webhook URLs must use HTTPS.
 - Durabull blocks private and localhost targets (SSRF protection).
-- Signing secrets are stored on the alert rule and masked in API responses after save.
+- Saved destination signing secrets are encrypted at rest and masked in API responses.
+- Custom per-rule webhook signing secrets remain scoped to that alert rule and are masked in API responses after save.
 
 For local development only, set `DURABULL_WEBHOOK_ALLOW_HTTP=true` to permit HTTP webhook URLs.

--- a/apps/web/src/components/alerts/alert-event-details-dialog.tsx
+++ b/apps/web/src/components/alerts/alert-event-details-dialog.tsx
@@ -155,6 +155,12 @@ function DeliveryRow({
 }) {
   const httpStatus = delivery.providerMetadata?.httpStatus
   const responseSnippet = delivery.providerMetadata?.responseBodySnippet
+  const deliveryTarget =
+    typeof delivery.providerMetadata?.destinationName === 'string'
+      ? delivery.providerMetadata.destinationName
+      : typeof delivery.providerMetadata?.url === 'string'
+        ? delivery.providerMetadata.url
+        : delivery.target
 
   return (
     <li className="rounded-lg border border-border/70 bg-background/70 p-3">
@@ -171,8 +177,8 @@ function DeliveryRow({
               </span>
             ) : null}
           </div>
-          {delivery.target ? (
-            <p className="truncate font-mono text-xs text-muted-foreground">{delivery.target}</p>
+          {deliveryTarget ? (
+            <p className="truncate font-mono text-xs text-muted-foreground">{deliveryTarget}</p>
           ) : null}
         </div>
         {isRetryable(delivery.status) ? (

--- a/apps/web/src/components/alerts/alert-rule-builder-page.test.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.test.tsx
@@ -33,6 +33,12 @@ vi.mock('sonner', () => ({
   },
 }))
 
+vi.mock('@/hooks/use-alerts', () => ({
+  useTestWebhook: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useTestWebhookDestination: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useWebhookDestinations: () => ({ data: { destinations: [] } }),
+}))
+
 function createRule(overrides: Partial<AlertRuleRecord> = {}): AlertRuleRecord {
   return {
     id: 'rule-1',

--- a/apps/web/src/components/alerts/alert-rule-builder-page.tsx
+++ b/apps/web/src/components/alerts/alert-rule-builder-page.tsx
@@ -21,6 +21,7 @@ import {
   createAlertRuleDraft,
   createLinearNotificationRouteDraft,
   createNotificationRouteDraft,
+  createSavedWebhookNotificationRouteDraft,
   createWebhookNotificationRouteDraft,
   normalizeNotificationEmails,
   serializeAlertRuleDraftsForMode,
@@ -32,13 +33,19 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Select } from '@/components/ui/select'
 import type {
+  AlertWebhookDestinationRecord,
   AlertRuleMutationInput,
   AlertRuleRecord,
   AlertRuleType,
   AlertTestResult,
 } from '@/hooks/use-alerts'
-import { useTestWebhook } from '@/hooks/use-alerts'
+import {
+  useTestWebhook,
+  useTestWebhookDestination,
+  useWebhookDestinations,
+} from '@/hooks/use-alerts'
 import { cn, formatNumber } from '@/lib/utils'
 
 interface AlertRuleBuilderPageProps {
@@ -60,18 +67,50 @@ function NotificationRouteFields({
   index,
   ruleId,
   connectionId,
+  webhookDestinations,
   onUpdate,
 }: {
   route: AlertRuleDraft['notificationRoutes'][number]
   index: number
   ruleId?: string
   connectionId: string
+  webhookDestinations: AlertWebhookDestinationRecord[]
   onUpdate: (nextRoute: AlertRuleDraft['notificationRoutes'][number]) => void
 }) {
   const testWebhookMutation = useTestWebhook(connectionId)
+  const testWebhookDestinationMutation = useTestWebhookDestination()
   const [testingRouteId, setTestingRouteId] = useState<string | null>(null)
 
   async function handleTestWebhook() {
+    if (route.webhookMode === 'saved') {
+      const destinationId = route.webhookDestinationId?.trim()
+      if (!destinationId) {
+        toast.error('Choose a webhook destination before testing.')
+        return
+      }
+
+      setTestingRouteId(route.id)
+      try {
+        const result = await testWebhookDestinationMutation.mutateAsync(destinationId)
+        if (result.success) {
+          toast.success('Test webhook delivered', {
+            description: `HTTP ${result.httpStatus ?? 'unknown'} in ${result.durationMs}ms`,
+          })
+        } else {
+          toast.error('Test webhook failed', {
+            description: result.error ?? `HTTP ${result.httpStatus ?? 'unknown'}`,
+          })
+        }
+      } catch (error) {
+        toast.error('Test webhook failed', {
+          description: error instanceof Error ? error.message : 'Unable to send test webhook.',
+        })
+      } finally {
+        setTestingRouteId(null)
+      }
+      return
+    }
+
     const url = route.webhookUrl?.trim() ?? route.target.trim()
     if (!url) {
       toast.error('Webhook URL is required before testing.')
@@ -121,6 +160,7 @@ function NotificationRouteFields({
   }
 
   if (route.type === 'webhook') {
+    const webhookMode = route.webhookMode ?? 'custom'
     return (
       <>
         <div className="inline-flex items-center gap-2 text-sm font-medium">
@@ -128,38 +168,88 @@ function NotificationRouteFields({
           Webhook
         </div>
         <div className="grid gap-2">
-          <Input
-            aria-label={`Webhook URL ${index + 1}`}
-            value={route.webhookUrl ?? route.target}
-            onChange={(event) =>
-              onUpdate({
-                ...route,
-                target: event.target.value,
-                webhookUrl: event.target.value,
-              })
-            }
-            placeholder="https://example.com/webhooks/durabull"
-            data-testid={`alert-rule-webhook-url-${index}`}
-          />
-          <Input
-            aria-label={`Webhook signing secret ${index + 1}`}
-            type="password"
-            value={route.webhookSecret ?? ''}
-            onChange={(event) => onUpdate({ ...route, webhookSecret: event.target.value })}
-            placeholder={
-              route.secretConfigured
-                ? `Optional — leave blank to keep existing (…${route.secretLast4 ?? ''})`
-                : 'Optional signing secret (min 16 characters)'
-            }
-            data-testid={`alert-rule-webhook-secret-${index}`}
-          />
+          <Select
+            aria-label={`Webhook mode ${index + 1}`}
+            value={webhookMode}
+            onChange={(event) => {
+              const nextMode = event.target.value === 'saved' ? 'saved' : 'custom'
+              if (nextMode === 'saved') {
+                const firstDestination = webhookDestinations.find(
+                  (destination) => destination.enabled
+                )
+                onUpdate(
+                  createSavedWebhookNotificationRouteDraft(index + 1, firstDestination?.id ?? '')
+                )
+                return
+              }
+              onUpdate(createWebhookNotificationRouteDraft(index + 1))
+            }}
+          >
+            <option value="saved">Saved destination</option>
+            <option value="custom">Custom URL</option>
+          </Select>
+
+          {webhookMode === 'saved' ? (
+            <Select
+              aria-label={`Saved webhook destination ${index + 1}`}
+              value={route.webhookDestinationId ?? route.target}
+              onChange={(event) =>
+                onUpdate({
+                  ...route,
+                  target: event.target.value,
+                  webhookDestinationId: event.target.value,
+                })
+              }
+              data-testid={`alert-rule-webhook-destination-${index}`}
+            >
+              <option value="">Choose a saved destination</option>
+              {webhookDestinations.map((destination) => (
+                <option key={destination.id} value={destination.id} disabled={!destination.enabled}>
+                  {destination.name}
+                  {destination.enabled ? '' : ' (disabled)'}
+                </option>
+              ))}
+            </Select>
+          ) : (
+            <>
+              <Input
+                aria-label={`Webhook URL ${index + 1}`}
+                value={route.webhookUrl ?? route.target}
+                onChange={(event) =>
+                  onUpdate({
+                    ...route,
+                    target: event.target.value,
+                    webhookUrl: event.target.value,
+                  })
+                }
+                placeholder="https://example.com/webhooks/durabull"
+                data-testid={`alert-rule-webhook-url-${index}`}
+              />
+              <Input
+                aria-label={`Webhook signing secret ${index + 1}`}
+                type="password"
+                value={route.webhookSecret ?? ''}
+                onChange={(event) => onUpdate({ ...route, webhookSecret: event.target.value })}
+                placeholder={
+                  route.secretConfigured
+                    ? `Optional — leave blank to keep existing (…${route.secretLast4 ?? ''})`
+                    : 'Optional signing secret (min 16 characters)'
+                }
+                data-testid={`alert-rule-webhook-secret-${index}`}
+              />
+            </>
+          )}
           <Button
             type="button"
             variant="outline"
             size="sm"
             className="justify-self-start"
             onClick={() => void handleTestWebhook()}
-            disabled={testingRouteId === route.id || testWebhookMutation.isPending}
+            disabled={
+              testingRouteId === route.id ||
+              testWebhookMutation.isPending ||
+              testWebhookDestinationMutation.isPending
+            }
           >
             {testingRouteId === route.id ? 'Sending test...' : 'Send test webhook'}
           </Button>
@@ -269,6 +359,8 @@ export function AlertRuleBuilderPage({
   const [draft, setDraft] = useState<AlertRuleDraft>(() => createAlertRuleDraft(rule))
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [lastTestResult, setLastTestResult] = useState<AlertTestResult | null>(null)
+  const webhookDestinationsQuery = useWebhookDestinations()
+  const webhookDestinations = webhookDestinationsQuery.data?.destinations ?? []
   const typeMeta = getAlertTypeMeta(draft.type)
   const exampleMeta = RULE_TYPE_EXAMPLES[draft.type]
 
@@ -603,6 +695,7 @@ export function AlertRuleBuilderPage({
                   index={index}
                   ruleId={rule?.id}
                   connectionId={connectionId}
+                  webhookDestinations={webhookDestinations}
                   onUpdate={(nextRoute) => {
                     const notificationRoutes = draft.notificationRoutes.slice()
                     notificationRoutes[index] = nextRoute
@@ -812,6 +905,30 @@ export function AlertRuleBuilderPage({
                 {lastTestResult.evaluation.summary ||
                   'The live queue snapshot did not trigger this rule.'}
               </p>
+              {lastTestResult.webhookTests && lastTestResult.webhookTests.length > 0 ? (
+                <div className="space-y-2">
+                  <div className="font-medium text-foreground">Webhook delivery tests</div>
+                  <div className="space-y-2">
+                    {lastTestResult.webhookTests.map((test) => (
+                      <div
+                        key={test.url}
+                        className="border border-border/70 bg-muted/20 px-3 py-2 text-xs"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="truncate font-mono">{test.url}</span>
+                          <Badge variant={test.success ? 'success' : 'destructive'}>
+                            {test.success ? 'Sent' : 'Failed'}
+                          </Badge>
+                        </div>
+                        <div className="mt-1 text-muted-foreground">
+                          HTTP {test.httpStatus ?? 'n/a'} in {test.durationMs}ms
+                          {test.error ? ` - ${test.error}` : ''}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
             </div>
           </FlatPanel>
         ) : null}

--- a/apps/web/src/components/alerts/alert-rule-form.test.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createAlertRuleDraft,
   createLinearNotificationRouteDraft,
+  createSavedWebhookNotificationRouteDraft,
   normalizeNotificationEmails,
   normalizeQueueNames,
   serializeAlertRuleDraft,
@@ -280,6 +281,33 @@ describe('alert rule form helpers', () => {
         { type: 'linear', target: 'org-default' },
       ],
     })
+  })
+
+  it('serializes saved webhook destination routes', () => {
+    const payload = serializeAlertRuleDraft({
+      ...createAlertRuleDraft(),
+      name: 'Reusable webhook',
+      queueFilterMode: 'exclude',
+      notificationRoutes: [createSavedWebhookNotificationRouteDraft(1, 'destination-id')],
+    })
+
+    expect(payload.notificationChannels).toEqual([
+      {
+        type: 'webhook',
+        destinationId: 'destination-id',
+      },
+    ])
+  })
+
+  it('requires a destination for saved webhook routes', () => {
+    const error = validateAlertRuleDraft({
+      ...createAlertRuleDraft(),
+      name: 'Missing destination',
+      queueFilterMode: 'exclude',
+      notificationRoutes: [createSavedWebhookNotificationRouteDraft(1, '')],
+    })
+
+    expect(error).toBe('Choose a saved webhook destination.')
   })
 
   it('serializes Linear priority zero as an explicit value', () => {

--- a/apps/web/src/components/alerts/alert-rule-form.ts
+++ b/apps/web/src/components/alerts/alert-rule-form.ts
@@ -18,6 +18,8 @@ export interface NotificationRouteDraft {
   assigneeId?: string
   stateId?: string
   priority?: string
+  webhookMode?: 'saved' | 'custom'
+  webhookDestinationId?: string
   webhookUrl?: string
   webhookSecret?: string
   secretConfigured?: boolean
@@ -101,13 +103,20 @@ function extractNotificationRoutes(rule?: AlertRuleRecord | null): NotificationR
         },
       ]
     }
-    if (channel.type === 'webhook' && typeof channel.url === 'string') {
+    if (channel.type === 'webhook' && 'url' in channel && typeof channel.url === 'string') {
       return [
         createWebhookNotificationRouteDraft(index + 1, channel.url, {
           secretConfigured: channel.secretConfigured === true,
           secretLast4: channel.secretLast4,
         }),
       ]
+    }
+    if (
+      channel.type === 'webhook' &&
+      'destinationId' in channel &&
+      typeof channel.destinationId === 'string'
+    ) {
+      return [createSavedWebhookNotificationRouteDraft(index + 1, channel.destinationId)]
     }
     return []
   })
@@ -138,9 +147,26 @@ export function createWebhookNotificationRouteDraft(
         : `webhook-route-${Math.random().toString(36).slice(2, 10)}`,
     type: 'webhook',
     target: webhookUrl,
+    webhookMode: 'custom',
     webhookUrl,
     secretConfigured: options?.secretConfigured,
     secretLast4: options?.secretLast4,
+  }
+}
+
+export function createSavedWebhookNotificationRouteDraft(
+  sequence = 0,
+  destinationId = ''
+): NotificationRouteDraft {
+  return {
+    id:
+      sequence > 0
+        ? `webhook-destination-route-${sequence}`
+        : `webhook-destination-route-${Math.random().toString(36).slice(2, 10)}`,
+    type: 'webhook',
+    target: destinationId,
+    webhookMode: 'saved',
+    webhookDestinationId: destinationId,
   }
 }
 
@@ -211,6 +237,13 @@ export function validateAlertRuleDraft(draft: AlertRuleDraft): string | null {
   }
 
   for (const route of draft.notificationRoutes.filter((item) => item.type === 'webhook')) {
+    if (route.webhookMode === 'saved') {
+      if (!route.webhookDestinationId?.trim()) {
+        return 'Choose a saved webhook destination.'
+      }
+      continue
+    }
+
     const url = route.webhookUrl?.trim() ?? route.target.trim()
     if (!url) {
       return 'Webhook URL is required.'
@@ -323,6 +356,13 @@ export function serializeAlertRuleDraft(draft: AlertRuleDraft): AlertRuleMutatio
     ...draft.notificationRoutes
       .filter((route) => route.type === 'webhook')
       .map((route) => {
+        if (route.webhookMode === 'saved') {
+          return {
+            type: 'webhook' as const,
+            destinationId: route.webhookDestinationId?.trim() ?? route.target.trim(),
+          }
+        }
+
         const url = route.webhookUrl?.trim() ?? route.target.trim()
         const secret = route.webhookSecret?.trim()
         return {

--- a/apps/web/src/components/settings/integrations-settings-panel.tsx
+++ b/apps/web/src/components/settings/integrations-settings-panel.tsx
@@ -1,15 +1,22 @@
-import { Link2 } from 'lucide-react'
+import { Link2, Webhook } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import type { AlertWebhookDestinationRecord } from '@/hooks/use-alerts'
 import {
   useConnectLinearIntegration,
+  useCreateWebhookDestination,
   useDeleteLinearIntegration,
+  useDeleteWebhookDestination,
   useLinearIntegration,
   useSaveLinearIntegration,
   useTestLinearIntegration,
+  useTestWebhookDestination,
+  useUpdateWebhookDestination,
+  useWebhookDestinations,
 } from '@/hooks/use-alerts'
 
 export function IntegrationsSettingsPanel() {
@@ -18,8 +25,17 @@ export function IntegrationsSettingsPanel() {
   const saveLinearIntegration = useSaveLinearIntegration()
   const deleteLinearIntegration = useDeleteLinearIntegration()
   const testLinearIntegration = useTestLinearIntegration()
+  const webhookDestinationsQuery = useWebhookDestinations()
+  const createWebhookDestination = useCreateWebhookDestination()
+  const updateWebhookDestination = useUpdateWebhookDestination()
+  const deleteWebhookDestination = useDeleteWebhookDestination()
+  const testWebhookDestination = useTestWebhookDestination()
   const [linearTeamId, setLinearTeamId] = useState('')
+  const [newWebhookName, setNewWebhookName] = useState('')
+  const [newWebhookUrl, setNewWebhookUrl] = useState('')
+  const [newWebhookSecret, setNewWebhookSecret] = useState('')
   const linearIntegration = linearIntegrationQuery.data?.integration ?? null
+  const webhookDestinations = webhookDestinationsQuery.data?.destinations ?? []
 
   useEffect(() => {
     setLinearTeamId(linearIntegration?.defaultTeamId ?? '')
@@ -42,8 +58,95 @@ export function IntegrationsSettingsPanel() {
         <CardContent className="space-y-4 p-4">
           <div className="rounded-lg border border-border/70 bg-muted/20 p-4">
             <div className="mb-2 flex items-center gap-2">
+              <Webhook className="h-4 w-4 text-muted-foreground" />
+              <h3 className="text-sm font-semibold">Webhook alert destinations</h3>
+              <Badge variant={webhookDestinations.length > 0 ? 'success' : 'secondary'}>
+                {webhookDestinations.length > 0
+                  ? `${webhookDestinations.length} configured`
+                  : 'Not configured'}
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Save reusable HTTPS endpoints for alert rules. Signing secrets are encrypted at rest
+              and never returned by the API.
+            </p>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-[1fr_2fr_1fr_auto]">
+              <Input
+                value={newWebhookName}
+                onChange={(event) => setNewWebhookName(event.target.value)}
+                placeholder="Name"
+                aria-label="Webhook destination name"
+              />
+              <Input
+                value={newWebhookUrl}
+                onChange={(event) => setNewWebhookUrl(event.target.value)}
+                placeholder="https://example.com/webhooks/durabull"
+                aria-label="Webhook destination URL"
+              />
+              <Input
+                value={newWebhookSecret}
+                onChange={(event) => setNewWebhookSecret(event.target.value)}
+                placeholder="Optional signing secret"
+                aria-label="Webhook destination signing secret"
+                type="password"
+              />
+              <Button
+                type="button"
+                onClick={async () => {
+                  try {
+                    await createWebhookDestination.mutateAsync({
+                      name: newWebhookName.trim(),
+                      url: newWebhookUrl.trim(),
+                      signingSecret: newWebhookSecret.trim() || undefined,
+                    })
+                    setNewWebhookName('')
+                    setNewWebhookUrl('')
+                    setNewWebhookSecret('')
+                    toast.success('Webhook destination saved')
+                  } catch (error) {
+                    toast.error('Failed to save webhook destination', {
+                      description: getErrorMessage(error, 'Please check the URL and try again.'),
+                    })
+                  }
+                }}
+                disabled={createWebhookDestination.isPending}
+              >
+                {createWebhookDestination.isPending ? 'Saving...' : 'Add'}
+              </Button>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {webhookDestinations.map((destination) => (
+                <WebhookDestinationRow
+                  key={destination.id}
+                  destination={destination}
+                  onSave={async (input) => {
+                    await updateWebhookDestination.mutateAsync({
+                      destinationId: destination.id,
+                      input,
+                    })
+                  }}
+                  onDelete={async () => {
+                    await deleteWebhookDestination.mutateAsync(destination.id)
+                  }}
+                  onTest={() => testWebhookDestination.mutateAsync(destination.id)}
+                  isBusy={
+                    updateWebhookDestination.isPending ||
+                    deleteWebhookDestination.isPending ||
+                    testWebhookDestination.isPending
+                  }
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border/70 bg-muted/20 p-4">
+            <div className="mb-2 flex items-center gap-2">
               <h3 className="text-sm font-semibold">Linear alerts</h3>
-              <Badge variant={linearIntegration?.validationStatus === 'valid' ? 'success' : 'secondary'}>
+              <Badge
+                variant={linearIntegration?.validationStatus === 'valid' ? 'success' : 'secondary'}
+              >
                 {linearIntegration
                   ? linearIntegration.validationStatus === 'valid'
                     ? 'Valid'
@@ -175,6 +278,184 @@ export function IntegrationsSettingsPanel() {
           </p>
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+function WebhookDestinationRow({
+  destination,
+  onSave,
+  onDelete,
+  onTest,
+  isBusy,
+}: {
+  destination: AlertWebhookDestinationRecord
+  onSave: (input: {
+    name?: string
+    url?: string
+    signingSecret?: string | null
+    enabled?: boolean
+  }) => Promise<void>
+  onDelete: () => Promise<void>
+  onTest: () => Promise<{
+    success: boolean
+    httpStatus: number | null
+    durationMs: number
+    error?: string
+  }>
+  isBusy: boolean
+}) {
+  const [name, setName] = useState(destination.name)
+  const [url, setUrl] = useState(destination.url)
+  const [secret, setSecret] = useState('')
+
+  useEffect(() => {
+    setName(destination.name)
+    setUrl(destination.url)
+    setSecret('')
+  }, [destination.name, destination.url])
+
+  return (
+    <div className="rounded-md border border-border/70 bg-background/70 p-3">
+      <div className="grid gap-3 md:grid-cols-[1fr_2fr_1fr_auto]">
+        <Input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          aria-label={`Webhook destination ${destination.name} name`}
+        />
+        <Input
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+          aria-label={`Webhook destination ${destination.name} URL`}
+        />
+        <Input
+          value={secret}
+          onChange={(event) => setSecret(event.target.value)}
+          placeholder={
+            destination.secretConfigured
+              ? `Leave blank to keep secret (…${destination.secretLast4 ?? ''})`
+              : 'Optional secret'
+          }
+          aria-label={`Webhook destination ${destination.name} signing secret`}
+          type="password"
+        />
+        <Badge
+          variant={destination.enabled ? 'success' : 'secondary'}
+          className="justify-self-start"
+        >
+          {destination.enabled ? 'Enabled' : 'Disabled'}
+        </Badge>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={async () => {
+            try {
+              await onSave({
+                name: name.trim(),
+                url: url.trim(),
+                ...(secret.trim() ? { signingSecret: secret.trim() } : {}),
+              })
+              setSecret('')
+              toast.success('Webhook destination updated')
+            } catch (error) {
+              toast.error('Failed to update webhook destination', {
+                description: getErrorMessage(error, 'Please try again.'),
+              })
+            }
+          }}
+          disabled={isBusy}
+        >
+          Save
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={async () => {
+            try {
+              await onSave({ enabled: !destination.enabled })
+              toast.success(
+                destination.enabled ? 'Webhook destination disabled' : 'Webhook destination enabled'
+              )
+            } catch (error) {
+              toast.error('Failed to update webhook destination', {
+                description: getErrorMessage(error, 'Please try again.'),
+              })
+            }
+          }}
+          disabled={isBusy}
+        >
+          {destination.enabled ? 'Disable' : 'Enable'}
+        </Button>
+        {destination.secretConfigured ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={async () => {
+              try {
+                await onSave({ signingSecret: null })
+                setSecret('')
+                toast.success('Webhook signing secret removed')
+              } catch (error) {
+                toast.error('Failed to remove webhook signing secret', {
+                  description: getErrorMessage(error, 'Please try again.'),
+                })
+              }
+            }}
+            disabled={isBusy}
+          >
+            Remove secret
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={async () => {
+            try {
+              const result = await onTest()
+              if (result.success) {
+                toast.success('Webhook destination test sent', {
+                  description: `HTTP ${result.httpStatus ?? 'unknown'} in ${result.durationMs}ms`,
+                })
+              } else {
+                toast.error('Webhook destination test failed', {
+                  description: result.error ?? `HTTP ${result.httpStatus ?? 'unknown'}`,
+                })
+              }
+            } catch (error) {
+              toast.error('Webhook destination test failed', {
+                description: getErrorMessage(error, 'Please try again.'),
+              })
+            }
+          }}
+          disabled={isBusy || !destination.enabled}
+        >
+          Test
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          onClick={async () => {
+            try {
+              await onDelete()
+              toast.success('Webhook destination deleted')
+            } catch (error) {
+              toast.error('Failed to delete webhook destination', {
+                description: getErrorMessage(error, 'Remove it from alert rules first.'),
+              })
+            }
+          }}
+          disabled={isBusy}
+        >
+          Delete
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/hooks/use-alerts.ts
+++ b/apps/web/src/hooks/use-alerts.ts
@@ -48,6 +48,18 @@ type LinearMetadataResponse = InferResponseType<
   (typeof api.alerts.integrations.linear.metadata)['$get'],
   200
 >
+type WebhookDestinationsResponse = InferResponseType<
+  (typeof api.alerts)['webhook-destinations']['$get'],
+  200
+>
+type WebhookDestinationResponse = InferResponseType<
+  (typeof api.alerts)['webhook-destinations']['$post'],
+  201
+>
+type TestWebhookDestinationResponse = InferResponseType<
+  (typeof api.alerts)['webhook-destinations'][':destinationId']['test']['$post'],
+  200
+>
 
 export type AlertSummaryConnection = AlertSummaryResponse['connections'][number]
 export type AlertRuleType = 'failure_threshold' | 'failure_rate' | 'queue_stalled' | 'job_failed'
@@ -72,6 +84,10 @@ export type AlertNotificationChannel =
       secret?: string
       secretConfigured?: boolean
       secretLast4?: string
+    }
+  | {
+      type: 'webhook'
+      destinationId: string
     }
 
 export interface AlertDeliveryRecord {
@@ -143,6 +159,25 @@ export interface LinearMetadataRecord {
   states: Array<{ id: string; name: string; teamId: string }>
 }
 
+export interface AlertWebhookDestinationRecord {
+  id: string
+  organizationId: string
+  name: string
+  url: string
+  enabled: boolean
+  secretConfigured: boolean
+  secretLast4?: string
+  createdAt?: string | Date
+  updatedAt?: string | Date
+}
+
+export interface AlertWebhookDestinationInput {
+  name: string
+  url: string
+  signingSecret?: string | null
+  enabled?: boolean
+}
+
 export interface AlertTestResult {
   evaluation: {
     triggered: boolean
@@ -201,6 +236,8 @@ export const alertKeys = {
     ['alerts', 'integrations', 'linear', organizationId ?? 'unknown'] as const,
   linearMetadata: (organizationId?: string | null) =>
     ['alerts', 'integrations', 'linear', organizationId ?? 'unknown', 'metadata'] as const,
+  webhookDestinations: (organizationId?: string | null) =>
+    ['alerts', 'webhook-destinations', organizationId ?? 'unknown'] as const,
   connectionRules: (connectionId: string) =>
     ['alerts', 'connection', connectionId, 'rules'] as const,
   connectionEvents: (connectionId: string, filters: AlertEventFilterOptions = {}) =>
@@ -253,9 +290,38 @@ function normalizeNotificationChannels(value: unknown): AlertNotificationChannel
         },
       ]
     }
+    if (entry.type === 'webhook' && typeof entry.destinationId === 'string') {
+      return [
+        {
+          type: 'webhook',
+          destinationId: entry.destinationId,
+        },
+      ]
+    }
     if (entry.type !== 'email' || typeof entry.target !== 'string') return []
     return [{ type: 'email', target: entry.target }]
   })
+}
+
+function normalizeWebhookDestination(value: unknown): AlertWebhookDestinationRecord {
+  const source = isRecord(value) ? value : {}
+  return {
+    id: typeof source.id === 'string' ? source.id : '',
+    organizationId: typeof source.organizationId === 'string' ? source.organizationId : '',
+    name: typeof source.name === 'string' ? source.name : 'Webhook destination',
+    url: typeof source.url === 'string' ? source.url : '',
+    enabled: source.enabled !== false,
+    secretConfigured: source.secretConfigured === true,
+    secretLast4: typeof source.secretLast4 === 'string' ? source.secretLast4 : undefined,
+    createdAt:
+      typeof source.createdAt === 'string' || source.createdAt instanceof Date
+        ? source.createdAt
+        : undefined,
+    updatedAt:
+      typeof source.updatedAt === 'string' || source.updatedAt instanceof Date
+        ? source.updatedAt
+        : undefined,
+  }
 }
 
 function toNumber(value: unknown, fallback = 0): number {
@@ -583,6 +649,96 @@ export function useTestWebhook(connectionId: string | undefined) {
         json: input,
       })
       return handleRes<WebhookTestResult>(res)
+    },
+  })
+}
+
+export function useWebhookDestinations() {
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
+
+  return useQuery({
+    queryKey: alertKeys.webhookDestinations(organizationId),
+    queryFn: async () => {
+      const res = await api.alerts['webhook-destinations'].$get()
+      const data = await handleRes<WebhookDestinationsResponse>(res)
+      return {
+        destinations: Array.isArray(data.destinations)
+          ? data.destinations.map(normalizeWebhookDestination)
+          : [],
+      }
+    },
+    enabled: !!organizationId,
+  })
+}
+
+export function useCreateWebhookDestination() {
+  const queryClient = useQueryClient()
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
+
+  return useMutation({
+    mutationFn: async (input: AlertWebhookDestinationInput) => {
+      const res = await api.alerts['webhook-destinations'].$post({ json: input })
+      const data = await handleRes<WebhookDestinationResponse>(res)
+      return { destination: normalizeWebhookDestination(data.destination) }
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: alertKeys.webhookDestinations(organizationId) }),
+  })
+}
+
+export function useUpdateWebhookDestination() {
+  const queryClient = useQueryClient()
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
+
+  return useMutation({
+    mutationFn: async ({
+      destinationId,
+      input,
+    }: {
+      destinationId: string
+      input: Partial<AlertWebhookDestinationInput>
+    }) => {
+      const res = await api.alerts['webhook-destinations'][':destinationId'].$patch({
+        param: { destinationId },
+        json: input,
+      })
+      const data = await handleRes<WebhookDestinationResponse>(res)
+      return { destination: normalizeWebhookDestination(data.destination) }
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: alertKeys.webhookDestinations(organizationId) }),
+  })
+}
+
+export function useDeleteWebhookDestination() {
+  const queryClient = useQueryClient()
+  const { data: activeOrganization } = useActiveOrganization()
+  const organizationId = activeOrganization?.id
+
+  return useMutation({
+    mutationFn: async (destinationId: string) => {
+      const res = await api.alerts['webhook-destinations'][':destinationId'].$delete({
+        param: { destinationId },
+      })
+      return handleRes<{ ok: boolean }>(res)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: alertKeys.webhookDestinations(organizationId) })
+      queryClient.invalidateQueries({ queryKey: ['alerts', 'connection'] })
+    },
+  })
+}
+
+export function useTestWebhookDestination() {
+  return useMutation({
+    mutationFn: async (destinationId: string) => {
+      const res = await api.alerts['webhook-destinations'][':destinationId'].test.$post({
+        param: { destinationId },
+      })
+      return handleRes<TestWebhookDestinationResponse>(res)
     },
   })
 }

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.test.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.alerts.$ruleId.test.tsx
@@ -230,7 +230,7 @@ describe('EditAlertRuleRoute', () => {
     expect(screen.getByText('builder-mode:edit')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Test from builder' }))
-    expect(testRuleMutateAsyncMock).toHaveBeenCalledWith('rule-1')
+    expect(testRuleMutateAsyncMock).toHaveBeenCalledWith({ ruleId: 'rule-1', deliver: false })
 
     await user.click(screen.getByRole('button', { name: 'Save from builder' }))
 

--- a/packages/dal/src/db/migrations/20260609120000_alert_webhook_destinations/migration.sql
+++ b/packages/dal/src/db/migrations/20260609120000_alert_webhook_destinations/migration.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "alert_webhook_destination" (
+	"id" uuid PRIMARY KEY,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"organization_id" text NOT NULL,
+	"name" text NOT NULL,
+	"url" text NOT NULL,
+	"encrypted_signing_secret" text,
+	"enabled" boolean DEFAULT true NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "alert_webhook_destination_org_idx" ON "alert_webhook_destination" ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "alert_webhook_destination_org_name_idx" ON "alert_webhook_destination" ("organization_id","name");--> statement-breakpoint
+ALTER TABLE "alert_webhook_destination" ADD CONSTRAINT "alert_webhook_destination_organization_id_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE;--> statement-breakpoint
+CREATE INDEX "alert_delivery_pending_created_idx" ON "alert_delivery" ("created_at") WHERE "status" = 'pending';--> statement-breakpoint
+CREATE INDEX "alert_delivery_failed_retry_created_idx" ON "alert_delivery" ("next_retry_at","created_at") WHERE "status" = 'failed' AND "next_retry_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "alert_delivery_claimed_stale_idx" ON "alert_delivery" ("claimed_at") WHERE "status" = 'claimed';

--- a/packages/dal/src/db/schemas/alert-delivery/schema.ts
+++ b/packages/dal/src/db/schemas/alert-delivery/schema.ts
@@ -8,6 +8,7 @@ import {
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
 import { alertEvent } from '../alert-event/schema'
 import { baseColumns } from '../common'
 import { organization } from '../organization/schema'
@@ -47,6 +48,15 @@ export const alertDelivery = pgTable(
       table.status,
       table.nextRetryAt
     ),
+    pendingCreatedIdx: index('alert_delivery_pending_created_idx')
+      .on(table.createdAt)
+      .where(sql`${table.status} = 'pending'`),
+    failedRetryCreatedIdx: index('alert_delivery_failed_retry_created_idx')
+      .on(table.nextRetryAt, table.createdAt)
+      .where(sql`${table.status} = 'failed' AND ${table.nextRetryAt} IS NOT NULL`),
+    claimedStaleIdx: index('alert_delivery_claimed_stale_idx')
+      .on(table.claimedAt)
+      .where(sql`${table.status} = 'claimed'`),
     eventChannelTargetIdx: uniqueIndex('alert_delivery_event_channel_target_idx').on(
       table.alertEventId,
       table.channelType,

--- a/packages/dal/src/db/schemas/alert-webhook-destination/schema.ts
+++ b/packages/dal/src/db/schemas/alert-webhook-destination/schema.ts
@@ -1,0 +1,24 @@
+import { index, pgTable, text, uniqueIndex, boolean } from 'drizzle-orm/pg-core'
+import { baseColumns } from '../common'
+import { organization } from '../organization/schema'
+
+export const alertWebhookDestination = pgTable(
+  'alert_webhook_destination',
+  {
+    ...baseColumns,
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    url: text('url').notNull(),
+    encryptedSigningSecret: text('encrypted_signing_secret'),
+    enabled: boolean('enabled').notNull().default(true),
+  },
+  (table) => ({
+    organizationIdx: index('alert_webhook_destination_org_idx').on(table.organizationId),
+    organizationNameIdx: uniqueIndex('alert_webhook_destination_org_name_idx').on(
+      table.organizationId,
+      table.name
+    ),
+  })
+)

--- a/packages/dal/src/db/schemas/alert-webhook-destination/types.ts
+++ b/packages/dal/src/db/schemas/alert-webhook-destination/types.ts
@@ -1,0 +1,4 @@
+import type { alertWebhookDestination } from './schema'
+
+export type AlertWebhookDestination = typeof alertWebhookDestination.$inferSelect
+export type NewAlertWebhookDestination = typeof alertWebhookDestination.$inferInsert

--- a/packages/dal/src/db/schemas/index.ts
+++ b/packages/dal/src/db/schemas/index.ts
@@ -18,6 +18,11 @@ export type { AlertEvent, NewAlertEvent } from './alert-event/types'
 // Alert Rule schema exports
 export { type AlertRuleType, alertRule, alertRuleTypes } from './alert-rule/schema'
 export type { AlertRule, NewAlertRule } from './alert-rule/types'
+export { alertWebhookDestination } from './alert-webhook-destination/schema'
+export type {
+  AlertWebhookDestination,
+  NewAlertWebhookDestination,
+} from './alert-webhook-destination/types'
 // Auth schema exports
 export { authAccount, authSession, authVerification } from './auth/schema'
 export type {

--- a/packages/dal/src/db/schemas/relations.ts
+++ b/packages/dal/src/db/schemas/relations.ts
@@ -89,6 +89,7 @@ export const relations = defineRelations(tables, (r) => ({
     redisConnections: r.many.redisConnection(),
     alertRules: r.many.alertRule(),
     alertEvents: r.many.alertEvent(),
+    alertWebhookDestinations: r.many.alertWebhookDestination(),
     linearIntegration: r.one.linearIntegration(),
     linearOauthStates: r.many.linearOauthState(),
     linearJobIssues: r.many.linearJobIssue(),
@@ -171,6 +172,12 @@ export const relations = defineRelations(tables, (r) => ({
     }),
     organization: r.one.organization({
       from: r.alertDelivery.organizationId,
+      to: r.organization.id,
+    }),
+  },
+  alertWebhookDestination: {
+    organization: r.one.organization({
+      from: r.alertWebhookDestination.organizationId,
       to: r.organization.id,
     }),
   },

--- a/packages/dal/src/db/schemas/tables.ts
+++ b/packages/dal/src/db/schemas/tables.ts
@@ -8,6 +8,7 @@ export { alertCheckCursor } from './alert-check-cursor/schema'
 export { alertDelivery } from './alert-delivery/schema'
 export { alertEvent } from './alert-event/schema'
 export { alertRule } from './alert-rule/schema'
+export { alertWebhookDestination } from './alert-webhook-destination/schema'
 // Auth schema tables
 export { authAccount, authSession, authVerification } from './auth/schema'
 export { linearIntegration } from './linear-integration/schema'

--- a/packages/dal/src/index.ts
+++ b/packages/dal/src/index.ts
@@ -56,6 +56,11 @@ export {
   queueFilterModes,
 } from './db/schemas/alert-rule/schema'
 export type { AlertRule, NewAlertRule } from './db/schemas/alert-rule/types'
+export { alertWebhookDestination } from './db/schemas/alert-webhook-destination/schema'
+export type {
+  AlertWebhookDestination,
+  NewAlertWebhookDestination,
+} from './db/schemas/alert-webhook-destination/types'
 export * as authSchema from './db/schemas/auth/schema'
 // Auth schema exports for Better Auth integration
 export { authAccount, authSession, authVerification } from './db/schemas/auth/schema'
@@ -159,6 +164,7 @@ export { alertCheckCursorRepository } from './repositories/alert-check-cursor'
 export { alertDeliveryRepository } from './repositories/alert-delivery'
 export { alertEventRepository } from './repositories/alert-event'
 export { alertRuleRepository } from './repositories/alert-rule'
+export { alertWebhookDestinationRepository } from './repositories/alert-webhook-destination'
 export { linearIntegrationRepository } from './repositories/linear-integration'
 export { linearJobIssueRepository } from './repositories/linear-job-issue'
 export { linearOauthStateRepository } from './repositories/linear-oauth-state'

--- a/packages/dal/src/repositories/alert-delivery.test.ts
+++ b/packages/dal/src/repositories/alert-delivery.test.ts
@@ -181,6 +181,43 @@ describe('alertDeliveryRepository', () => {
     expect(claimed).toHaveLength(0)
   })
 
+  it('claims due deliveries across events for the monitor sweep', async () => {
+    const event = await seedAlertEvent()
+    await alertDeliveryRepository.enqueueMany([
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'webhook',
+        target: 'https://example.com/hook',
+      },
+      {
+        alertEventId: event.id,
+        organizationId: TEST_ORG_ID,
+        channelType: 'email',
+        target: 'ops@example.com',
+      },
+    ])
+
+    const [retryable, permanent] = await alertDeliveryRepository.claimDueForEvent(event.id)
+    expect(retryable).toBeDefined()
+    expect(permanent).toBeDefined()
+
+    await alertDeliveryRepository.markFailed(retryable!.id, {
+      error: 'HTTP 500',
+      retryable: true,
+      nextRetryAt: new Date(Date.now() - 1000),
+      expectedClaimedAt: retryable!.claimedAt!,
+    })
+    await alertDeliveryRepository.markFailed(permanent!.id, {
+      error: 'HTTP 400',
+      retryable: false,
+      expectedClaimedAt: permanent!.claimedAt!,
+    })
+
+    const due = await alertDeliveryRepository.claimDue()
+    expect(due.map((delivery) => delivery.id)).toEqual([retryable!.id])
+  })
+
   it('only lets the current claim complete or fail a delivery', async () => {
     const event = await seedAlertEvent()
     await alertDeliveryRepository.enqueueMany([

--- a/packages/dal/src/repositories/alert-delivery.ts
+++ b/packages/dal/src/repositories/alert-delivery.ts
@@ -190,6 +190,61 @@ export const alertDeliveryRepository = {
     return rowsFromExecute<AlertDelivery>(result).map(normalizeAlertDeliveryRow)
   },
 
+  async claimDue(limit = 50): Promise<AlertDelivery[]> {
+    const db = await getDb()
+    const now = new Date()
+    const staleClaimCutoff = new Date(now.getTime() - STALE_CLAIM_MS)
+
+    const result = await db.execute(sql`
+      UPDATE ${alertDelivery} AS delivery
+      SET
+        status = 'claimed',
+        claimed_at = ${now},
+        updated_at = ${now}
+      WHERE delivery.id IN (
+        SELECT candidate.id
+        FROM ${alertDelivery} AS candidate
+        WHERE (
+            candidate.status = 'pending'
+            OR (
+              candidate.status = 'failed'
+              AND candidate.next_retry_at IS NOT NULL
+            )
+            OR (
+              candidate.status = 'claimed'
+              AND candidate.claimed_at <= ${staleClaimCutoff}
+            )
+          )
+          AND (
+            candidate.next_retry_at IS NULL
+            OR candidate.next_retry_at <= ${now}
+          )
+        ORDER BY candidate.created_at
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING
+        delivery.id,
+        delivery.created_at AS "createdAt",
+        delivery.updated_at AS "updatedAt",
+        delivery.alert_event_id AS "alertEventId",
+        delivery.organization_id AS "organizationId",
+        delivery.channel_type AS "channelType",
+        delivery.target,
+        delivery.status,
+        delivery.attempt_count AS "attemptCount",
+        delivery.next_retry_at AS "nextRetryAt",
+        delivery.claimed_at AS "claimedAt",
+        delivery.last_error AS "lastError",
+        delivery.provider_metadata AS "providerMetadata",
+        delivery.external_id AS "externalId",
+        delivery.external_identifier AS "externalIdentifier",
+        delivery.external_url AS "externalUrl"
+    `)
+
+    return rowsFromExecute<AlertDelivery>(result).map(normalizeAlertDeliveryRow)
+  },
+
   /**
    * Resets a failed or stuck delivery so the next processing pass will pick it
    * up again. Scoped to its event for authorization and refuses to re-send an

--- a/packages/dal/src/repositories/alert-webhook-destination.test.ts
+++ b/packages/dal/src/repositories/alert-webhook-destination.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { env } from '@durabull/env'
+import { closeDb, getDb } from '../db/client'
+import { organization } from '../db/schemas/organization/schema'
+import { decryptSecret } from '../db/secret-encryption'
+import { alertRuleRepository } from './alert-rule'
+import { alertWebhookDestinationRepository } from './alert-webhook-destination'
+import { redisConnectionRepository } from './redis-connection'
+
+const TEST_ORG_ID = 'alert-webhook-destination-org'
+const TEST_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+const mutableEnv = env as {
+  DATABASE_URL?: string
+  DURABULL_ENV_CONNECTIONS?: boolean
+  DURABULL_REDIS_URL_ENCRYPTION_KEY?: string
+  DURABULL_SECRET_ENCRYPTION_KEY?: string
+}
+
+const originalDatabaseUrl = mutableEnv.DATABASE_URL
+const originalEnvConnectionsFlag = mutableEnv.DURABULL_ENV_CONNECTIONS
+const originalRedisEncryptionKey = mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY
+const originalSecretEncryptionKey = mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY
+const originalPgliteDir = process.env.DURABULL_PGLITE_DIR
+
+let tempPgliteDir = ''
+
+async function seedOrganization() {
+  const db = await getDb()
+  const now = new Date()
+  await db.insert(organization).values({
+    id: TEST_ORG_ID,
+    name: 'Alert Webhook Destination Org',
+    slug: 'alert-webhook-destination-org',
+    createdAt: now,
+    updatedAt: now,
+  })
+}
+
+describe('alertWebhookDestinationRepository', () => {
+  beforeEach(async () => {
+    tempPgliteDir = await mkdtemp(join(tmpdir(), 'durabull-alert-webhook-destination-'))
+    process.env.DURABULL_PGLITE_DIR = tempPgliteDir
+    delete process.env.DATABASE_URL
+    mutableEnv.DATABASE_URL = undefined
+    mutableEnv.DURABULL_ENV_CONNECTIONS = false
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY
+    await closeDb()
+  })
+
+  afterEach(async () => {
+    await closeDb()
+    mutableEnv.DATABASE_URL = originalDatabaseUrl
+    mutableEnv.DURABULL_ENV_CONNECTIONS = originalEnvConnectionsFlag
+    mutableEnv.DURABULL_REDIS_URL_ENCRYPTION_KEY = originalRedisEncryptionKey
+    mutableEnv.DURABULL_SECRET_ENCRYPTION_KEY = originalSecretEncryptionKey
+
+    if (originalPgliteDir) {
+      process.env.DURABULL_PGLITE_DIR = originalPgliteDir
+    } else {
+      delete process.env.DURABULL_PGLITE_DIR
+    }
+
+    if (tempPgliteDir) {
+      await rm(tempPgliteDir, { recursive: true, force: true })
+      tempPgliteDir = ''
+    }
+  })
+
+  it('stores signing secrets encrypted and preserves them when omitted on update', async () => {
+    await seedOrganization()
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Pager',
+      url: 'https://example.com/hook',
+      signingSecret: 'abcdefghijklmnop',
+    })
+
+    expect(destination.encryptedSigningSecret).toMatch(/^enc:v1:/)
+    expect(decryptSecret(destination.encryptedSigningSecret!)).toBe('abcdefghijklmnop')
+
+    const updated = await alertWebhookDestinationRepository.update(destination.id, TEST_ORG_ID, {
+      name: 'Pager alerts',
+    })
+
+    expect(updated?.encryptedSigningSecret).toBe(destination.encryptedSigningSecret)
+  })
+
+  it('counts alert rules that reference a saved destination', async () => {
+    await seedOrganization()
+    const destination = await alertWebhookDestinationRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Incident intake',
+      url: 'https://example.com/hook',
+    })
+    const connection = await redisConnectionRepository.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Primary Redis',
+      url: 'redis://localhost:6379/0',
+      environment: 'development',
+      isDefault: true,
+    })
+
+    await alertRuleRepository.create({
+      organizationId: TEST_ORG_ID,
+      connectionId: connection.id,
+      queueName: 'email-send',
+      name: 'Failure threshold',
+      type: 'failure_threshold',
+      config: { count: 5, windowMinutes: 5 },
+      notificationChannels: [{ type: 'webhook', destinationId: destination.id }],
+      cooldownMinutes: 30,
+    })
+
+    await expect(
+      alertWebhookDestinationRepository.countRuleReferences(destination.id, TEST_ORG_ID)
+    ).resolves.toBe(1)
+  })
+})

--- a/packages/dal/src/repositories/alert-webhook-destination.ts
+++ b/packages/dal/src/repositories/alert-webhook-destination.ts
@@ -1,0 +1,143 @@
+import { and, asc, eq, sql } from 'drizzle-orm'
+import { getDb } from '../db/client'
+import { alertRule } from '../db/schemas/alert-rule/schema'
+import { alertWebhookDestination } from '../db/schemas/alert-webhook-destination/schema'
+import type { AlertWebhookDestination } from '../db/schemas/alert-webhook-destination/types'
+import { encryptSecret } from '../db/secret-encryption'
+
+export interface CreateAlertWebhookDestinationInput {
+  organizationId: string
+  name: string
+  url: string
+  signingSecret?: string | null
+  enabled?: boolean
+}
+
+export interface UpdateAlertWebhookDestinationInput {
+  name?: string
+  url?: string
+  signingSecret?: string | null
+  enabled?: boolean
+}
+
+function encryptedSigningSecretFromInput(signingSecret: string | null | undefined): string | null {
+  if (signingSecret === undefined || signingSecret === null) return null
+  const trimmed = signingSecret.trim()
+  return trimmed ? encryptSecret(trimmed) : null
+}
+
+export const alertWebhookDestinationRepository = {
+  async listByOrganization(organizationId: string): Promise<AlertWebhookDestination[]> {
+    const db = await getDb()
+    return db
+      .select()
+      .from(alertWebhookDestination)
+      .where(eq(alertWebhookDestination.organizationId, organizationId))
+      .orderBy(asc(alertWebhookDestination.name))
+  },
+
+  async findById(id: string, organizationId: string): Promise<AlertWebhookDestination | null> {
+    const db = await getDb()
+    const rows = await db
+      .select()
+      .from(alertWebhookDestination)
+      .where(
+        and(
+          eq(alertWebhookDestination.id, id),
+          eq(alertWebhookDestination.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+
+    return rows[0] ?? null
+  },
+
+  async create(input: CreateAlertWebhookDestinationInput): Promise<AlertWebhookDestination> {
+    const db = await getDb()
+    const [row] = await db
+      .insert(alertWebhookDestination)
+      .values({
+        organizationId: input.organizationId,
+        name: input.name,
+        url: input.url,
+        encryptedSigningSecret:
+          input.signingSecret === undefined
+            ? null
+            : encryptedSigningSecretFromInput(input.signingSecret),
+        enabled: input.enabled ?? true,
+      })
+      .returning()
+
+    return row
+  },
+
+  async update(
+    id: string,
+    organizationId: string,
+    input: UpdateAlertWebhookDestinationInput
+  ): Promise<AlertWebhookDestination | null> {
+    const db = await getDb()
+    const update: Partial<AlertWebhookDestination> = { updatedAt: new Date() }
+
+    if (input.name !== undefined) update.name = input.name
+    if (input.url !== undefined) update.url = input.url
+    if (input.enabled !== undefined) update.enabled = input.enabled
+    if (input.signingSecret !== undefined) {
+      update.encryptedSigningSecret = encryptedSigningSecretFromInput(input.signingSecret)
+    }
+
+    const [row] = await db
+      .update(alertWebhookDestination)
+      .set(update)
+      .where(
+        and(
+          eq(alertWebhookDestination.id, id),
+          eq(alertWebhookDestination.organizationId, organizationId)
+        )
+      )
+      .returning()
+
+    return row ?? null
+  },
+
+  async delete(id: string, organizationId: string): Promise<boolean> {
+    const db = await getDb()
+    const rows = await db
+      .delete(alertWebhookDestination)
+      .where(
+        and(
+          eq(alertWebhookDestination.id, id),
+          eq(alertWebhookDestination.organizationId, organizationId)
+        )
+      )
+      .returning({ id: alertWebhookDestination.id })
+
+    return rows.length > 0
+  },
+
+  async countRuleReferences(id: string, organizationId: string): Promise<number> {
+    const db = await getDb()
+    const result = await db.execute(sql`
+      SELECT count(*)::int AS count
+      FROM ${alertRule}
+      WHERE ${alertRule.organizationId} = ${organizationId}
+        AND EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements(${alertRule.notificationChannels}) AS channel
+          WHERE channel->>'type' = 'webhook'
+            AND channel->>'destinationId' = ${id}
+        )
+    `)
+
+    const rows = Array.isArray(result)
+      ? result
+      : typeof result === 'object' &&
+          result !== null &&
+          Array.isArray((result as { rows?: unknown[] }).rows)
+        ? (result as { rows: Array<{ count?: number | string | bigint }> }).rows
+        : []
+
+    const count = rows[0]?.count
+    return count === undefined ? 0 : Number(count)
+  },
+}


### PR DESCRIPTION
## Summary
- Add organization-level saved webhook destinations for alert routing, including CRUD/test APIs and settings UI management.
- Support saved destination references in alert rules while preserving inline webhook URLs and snapshotting delivery metadata at enqueue time.
- Add retry-sweep handling, delivery metadata sanitization, and regression coverage for saved webhook delivery behavior.

## Test plan
- `bun test apps/api/src/lib/alert-monitor.test.ts apps/api/src/lib/alert-notifier.test.ts apps/api/src/routes/alerts.test.ts apps/api/src/routes/alert-webhook-destinations.test.ts apps/api/src/routes/alerts-global.test.ts apps/api/src/lib/alert-webhook-channels.test.ts packages/dal/src/repositories/alert-delivery.test.ts packages/dal/src/repositories/alert-webhook-destination.test.ts`
- `bun run --filter @durabull/dal typecheck`
- `bun run --filter @durabull/web typecheck`
- Parallel code review loop returned no material issues on final pass.

## Notes
- No Linear issue was provided for this change.
- `@durabull/api` typecheck still has a pre-existing unrelated blocker in `src/mcp/tools/shared.test.ts`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Saved webhook alert destinations—create and reuse webhooks at the organization level instead of configuring them individually per alert rule.
* Active webhook delivery retry mechanism with automatic retries for up to 7 days.
* Test webhook destinations directly from integrations settings.

**Documentation**
* Updated webhooks guide with saved destinations setup and retry behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->