### PR TITLE
feat(web): add fullscreen toggle button to app top bar

### DIFF
--- a/apps/web/src/components/app-top-bar.tsx
+++ b/apps/web/src/components/app-top-bar.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { FullscreenToggle } from '@/components/fullscreen-toggle'
 import { useIsElectronShell } from '@/hooks/use-electron-shell'
 import { cn } from '@/lib/utils'
 
@@ -138,12 +139,17 @@ export function AppTopBar({
           )}
         >
           {actions}
+          <FullscreenToggle />
         </div>
 
-        {mobileActions ? (
-          <div
-            className={cn('md:hidden', isElectronShell && 'pointer-events-auto app-region-no-drag')}
-          >
+        <div
+          className={cn(
+            'flex items-center md:hidden',
+            isElectronShell && 'pointer-events-auto app-region-no-drag'
+          )}
+        >
+          <FullscreenToggle />
+          {mobileActions ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" aria-label="Open page actions">
@@ -154,8 +160,8 @@ export function AppTopBar({
                 {mobileActions}
               </DropdownMenuContent>
             </DropdownMenu>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
     </header>
   )

--- a/apps/web/src/components/fullscreen-toggle.tsx
+++ b/apps/web/src/components/fullscreen-toggle.tsx
@@ -1,0 +1,56 @@
+import { Maximize, Minimize } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+function isFullscreenSupported() {
+  return typeof document !== 'undefined' && document.fullscreenEnabled
+}
+
+/**
+ * Toggles true browser fullscreen for the whole application
+ * using the Fullscreen API. Renders nothing when unsupported.
+ */
+export function FullscreenToggle() {
+  const [isFullscreen, setIsFullscreen] = useState(
+    () => typeof document !== 'undefined' && document.fullscreenElement !== null
+  )
+
+  useEffect(() => {
+    const handleChange = () => {
+      setIsFullscreen(document.fullscreenElement !== null)
+    }
+    document.addEventListener('fullscreenchange', handleChange)
+    return () => document.removeEventListener('fullscreenchange', handleChange)
+  }, [])
+
+  if (!isFullscreenSupported()) {
+    return null
+  }
+
+  const toggleFullscreen = async () => {
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen()
+      } else {
+        await document.documentElement.requestFullscreen()
+      }
+    } catch {
+      // Request can be rejected (e.g. permissions); state stays in sync via fullscreenchange
+    }
+  }
+
+  const label = isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={toggleFullscreen}
+      aria-label={label}
+      title={label}
+    >
+      {isFullscreen ? <Minimize className="h-5 w-5" /> : <Maximize className="h-5 w-5" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a `FullscreenToggle` component using the native Fullscreen API (`requestFullscreen` / `exitFullscreen`), syncing state with `fullscreenchange` and hiding itself when unsupported
- Render it persistently in the app top bar on both desktop and mobile layouts

## Test plan
- [ ] Click the fullscreen button in the top bar — app goes truly fullscreen, icon switches to minimize
- [ ] Press Esc — icon syncs back to maximize
- [ ] Verify mobile layout still shows the page-actions menu when a page registers mobile actions

Made with [Cursor](https://cursor.com)