### PR TITLE
feat(queues): server-side sort/filter and saved default view

### DIFF
--- a/apps/api/src/routes/queues.test.ts
+++ b/apps/api/src/routes/queues.test.ts
@@ -164,4 +164,124 @@ describe('queues routes', () => {
     const emails = body.queues.find((q) => q.name === 'emails')
     expect(emails?.jobCounts.prioritized).toBe(4)
   })
+
+  describe('sorting and filtering', () => {
+    const countsByQueue: Record<string, Record<string, number>> = {
+      emails: {
+        waiting: 10,
+        active: 1,
+        delayed: 0,
+        completed: 5,
+        failed: 2,
+        paused: 0,
+        prioritized: 4,
+      },
+      reports: {
+        waiting: 3,
+        active: 0,
+        delayed: 1,
+        completed: 9,
+        failed: 0,
+        paused: 0,
+        prioritized: 6,
+      },
+      webhooks: {
+        waiting: 7,
+        active: 2,
+        delayed: 0,
+        completed: 1,
+        failed: 8,
+        paused: 0,
+        prioritized: 0,
+      },
+    }
+    const pausedQueues = new Set(['reports'])
+
+    async function seedThreeQueues() {
+      mock.module('../lib/queue-discovery', () => ({
+        getQueueDiscoveryStatus: async () => ({
+          running: false,
+          startedAt: null,
+          completedAt: Date.now(),
+          lastError: null,
+          indexed: { total: 3, confirmed: 3, pending: 0, lastDiscoveredAt: Date.now() },
+        }),
+        startQueueDiscovery: async () => ({}),
+        waitForQueueDiscovery: async () => ({}),
+      }))
+      mock.module('../lib/redis', () => ({
+        getQueue: async (_connId: string, _url: string, name: string) => ({
+          getJobCounts: async () => countsByQueue[name] ?? {},
+          isPaused: async () => pausedQueues.has(name),
+        }),
+        safeGetWorkers: async () => [],
+        debugGetBullKeys: async () => [],
+      }))
+
+      await seedDiscoveredQueue('emails')
+      await seedDiscoveredQueue('reports')
+      await seedDiscoveredQueue('webhooks')
+
+      return createQueuesRouteApp()
+    }
+
+    type ListBody = {
+      queues: Array<{ name: string; status: string }>
+      total: number
+      totalUnfiltered: number
+      totalJobCounts: { waiting: number }
+    }
+
+    it('sorts by a numeric job count column descending', async () => {
+      const app = await seedThreeQueues()
+      const response = await app.request('/?sortBy=failed&sortOrder=desc')
+
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as ListBody
+      expect(body.queues.map((q) => q.name)).toEqual(['webhooks', 'emails', 'reports'])
+    })
+
+    it('sorts by name descending', async () => {
+      const app = await seedThreeQueues()
+      const response = await app.request('/?sortBy=name&sortOrder=desc')
+
+      const body = (await response.json()) as ListBody
+      expect(body.queues.map((q) => q.name)).toEqual(['webhooks', 'reports', 'emails'])
+    })
+
+    it('filters by name search, case-insensitively', async () => {
+      const app = await seedThreeQueues()
+      const response = await app.request('/?search=RePoRt')
+
+      const body = (await response.json()) as ListBody
+      expect(body.queues.map((q) => q.name)).toEqual(['reports'])
+      expect(body.total).toBe(1)
+      expect(body.totalUnfiltered).toBe(3)
+    })
+
+    it('filters by status', async () => {
+      const app = await seedThreeQueues()
+      const response = await app.request('/?status=paused')
+
+      const body = (await response.json()) as ListBody
+      expect(body.queues.map((q) => q.name)).toEqual(['reports'])
+      expect(body.queues[0]?.status).toBe('paused')
+    })
+
+    it('keeps connection-wide totals independent of filters', async () => {
+      const app = await seedThreeQueues()
+      const response = await app.request('/?search=emails')
+
+      const body = (await response.json()) as ListBody
+      expect(body.total).toBe(1)
+      expect(body.totalJobCounts.waiting).toBe(20)
+    })
+
+    it('rejects an invalid sort column', async () => {
+      const app = await seedThreeQueues()
+      const response = await app.request('/?sortBy=bogus')
+
+      expect(response.status).toBe(400)
+    })
+  })
 })

--- a/apps/api/src/routes/queues.ts
+++ b/apps/api/src/routes/queues.ts
@@ -38,6 +38,54 @@ const PURGEABLE_QUEUE_STATUSES = [
 type PurgeableQueueStatus = (typeof PURGEABLE_QUEUE_STATUSES)[number]
 
 const PURGE_STATUS_OPTIONS = ['all', ...PURGEABLE_QUEUE_STATUSES] as const
+const QUEUE_SORT_FIELDS = [
+  'name',
+  'status',
+  'waiting',
+  'prioritized',
+  'active',
+  'delayed',
+  'completed',
+  'failed',
+] as const
+type QueueSortField = (typeof QUEUE_SORT_FIELDS)[number]
+
+const listQueuesQuerySchema = z.object({
+  page: z.string().optional(),
+  pageSize: z.string().optional(),
+  sortBy: z.enum(QUEUE_SORT_FIELDS).optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+  search: z.string().optional(),
+  status: z.enum(['active', 'paused']).optional(),
+})
+
+interface QueueListEntry {
+  name: string
+  status: 'active' | 'paused'
+  jobCounts: {
+    waiting: number
+    active: number
+    delayed: number
+    completed: number
+    failed: number
+    paused: number
+    prioritized: number
+  }
+  isPaused: boolean
+  discoveryState: 'pending' | 'confirmed'
+}
+
+function compareQueueEntries(a: QueueListEntry, b: QueueListEntry, sortBy: QueueSortField): number {
+  switch (sortBy) {
+    case 'name':
+      return a.name.localeCompare(b.name)
+    case 'status':
+      return a.status.localeCompare(b.status)
+    default:
+      return a.jobCounts[sortBy] - b.jobCounts[sortBy]
+  }
+}
+
 const queueMetricsQuerySchema = z.object({
   windowMinutes: z.string().optional(),
   start: z.string().optional(),
@@ -244,53 +292,44 @@ const app = new Hono()
 
     return c.json(status, 202)
   })
-  // List all queues (paginated)
-  .get('/', async (c) => {
+  // List all queues (paginated, sortable, filterable)
+  .get('/', zValidator('query', listQueuesQuerySchema), async (c) => {
     const connectionId = c.get('connectionId')
     const connectionUrl = c.get('connectionUrl')
     const connectionPrefix = c.get('connectionPrefix')
     const redisOptions = getConnectionRedisOptions(c)
-    const page = Math.max(1, parseInteger(c.req.query('page')) ?? 1)
-    const pageSize = Math.min(
-      parseInteger(c.req.query('pageSize')) ?? DEFAULT_PAGE_SIZE,
-      MAX_PAGE_SIZE
-    )
-
-    // Paginate the queue names BEFORE fetching details
-    const start = (page - 1) * pageSize
-    const end = start + pageSize
+    const query = c.req.valid('query')
+    const page = Math.max(1, parseInteger(query.page) ?? 1)
+    const pageSize = Math.min(parseInteger(query.pageSize) ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE)
+    const sortBy: QueueSortField = query.sortBy ?? 'name'
+    const sortOrder = query.sortOrder ?? 'asc'
+    const search = query.search?.trim().toLowerCase() ?? ''
+    const statusFilter = query.status
 
     let discovery = await getQueueDiscoveryStatus(connectionId)
-    let total = discovery.indexed.total
+    let indexedTotal = discovery.indexed.total
     const hasDiscoveryAttempt =
       discovery.running ||
       discovery.startedAt !== null ||
       discovery.completedAt !== null ||
       discovery.lastError !== null
 
-    if (total === 0 && !hasDiscoveryAttempt) {
+    if (indexedTotal === 0 && !hasDiscoveryAttempt) {
       await startQueueDiscovery(connectionId, connectionUrl, {
         prefix: connectionPrefix,
         allowSelfSignedCerts: redisOptions.allowSelfSignedCerts,
       })
       discovery = await getQueueDiscoveryStatus(connectionId)
-      total = discovery.indexed.total
+      indexedTotal = discovery.indexed.total
     }
 
+    // Sorting and filtering must happen BEFORE pagination, so fetch live
+    // counts for every indexed queue (also required to aggregate totals).
     const indexedQueues = await redisDiscoveredQueueRepository.listByConnection(connectionId, {
-      offset: start,
-      limit: pageSize,
+      offset: 0,
+      limit: Math.max(indexedTotal, pageSize),
     })
 
-    const allIndexedQueues =
-      total > pageSize
-        ? await redisDiscoveredQueueRepository.listByConnection(connectionId, {
-            offset: 0,
-            limit: total,
-          })
-        : indexedQueues
-
-    const pageQueueNames = new Set(indexedQueues.map((q) => q.name))
     const totalJobCounts = {
       waiting: 0,
       active: 0,
@@ -300,29 +339,21 @@ const app = new Hono()
       prioritized: 0,
     }
 
-    function accumulateCounts(counts: Record<string, number>) {
-      totalJobCounts.waiting += counts.waiting ?? 0
-      totalJobCounts.active += counts.active ?? 0
-      totalJobCounts.delayed += counts.delayed ?? 0
-      totalJobCounts.completed += counts.completed ?? 0
-      totalJobCounts.failed += counts.failed ?? 0
-      totalJobCounts.prioritized += counts.prioritized ?? 0
-    }
+    const allQueues: QueueListEntry[] = await Promise.all(
+      indexedQueues.map(async (indexedQueue) => {
+        const queue = await getQueue(
+          connectionId,
+          connectionUrl,
+          indexedQueue.name,
+          connectionPrefix,
+          redisOptions
+        )
+        const [counts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()])
 
-    const [queuesData] = await Promise.all([
-      Promise.all(
-        indexedQueues.map(async (indexedQueue) => {
-          const queue = await getQueue(
-            connectionId,
-            connectionUrl,
-            indexedQueue.name,
-            connectionPrefix,
-            redisOptions
-          )
-          const [counts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()])
-
-          const status: 'paused' | 'active' = isPaused ? 'paused' : 'active'
-          const jobCounts = {
+        return {
+          name: indexedQueue.name,
+          status: isPaused ? ('paused' as const) : ('active' as const),
+          jobCounts: {
             waiting: counts.waiting ?? 0,
             active: counts.active ?? 0,
             delayed: counts.delayed ?? 0,
@@ -330,41 +361,48 @@ const app = new Hono()
             failed: counts.failed ?? 0,
             paused: counts.paused ?? 0,
             prioritized: counts.prioritized ?? 0,
-          }
+          },
+          isPaused,
+          discoveryState: indexedQueue.state,
+        }
+      })
+    )
 
-          accumulateCounts(jobCounts)
+    // Connection-wide totals always reflect ALL queues, independent of filters
+    for (const queue of allQueues) {
+      totalJobCounts.waiting += queue.jobCounts.waiting
+      totalJobCounts.active += queue.jobCounts.active
+      totalJobCounts.delayed += queue.jobCounts.delayed
+      totalJobCounts.completed += queue.jobCounts.completed
+      totalJobCounts.failed += queue.jobCounts.failed
+      totalJobCounts.prioritized += queue.jobCounts.prioritized
+    }
 
-          return {
-            name: indexedQueue.name,
-            status,
-            jobCounts,
-            isPaused,
-            discoveryState: indexedQueue.state,
-          }
-        })
-      ),
-      Promise.all(
-        allIndexedQueues
-          .filter((iq) => !pageQueueNames.has(iq.name))
-          .map(async (iq) => {
-            const queue = await getQueue(
-              connectionId,
-              connectionUrl,
-              iq.name,
-              connectionPrefix,
-              redisOptions
-            )
-            accumulateCounts(await queue.getJobCounts())
-          })
-      ),
-    ])
+    const filteredQueues = allQueues.filter((queue) => {
+      if (search && !queue.name.toLowerCase().includes(search)) return false
+      if (statusFilter && queue.status !== statusFilter) return false
+      return true
+    })
+
+    const direction = sortOrder === 'desc' ? -1 : 1
+    filteredQueues.sort((a, b) => {
+      const diff = compareQueueEntries(a, b, sortBy)
+      if (diff !== 0) return direction * diff
+      // Stable, predictable tiebreaker regardless of sort direction
+      return a.name.localeCompare(b.name)
+    })
+
+    const total = filteredQueues.length
+    const start = (page - 1) * pageSize
+    const end = start + pageSize
 
     return c.json({
-      queues: queuesData,
+      queues: filteredQueues.slice(start, end),
       total,
+      totalUnfiltered: Math.max(indexedTotal, allQueues.length),
       page,
       pageSize,
-      totalPages: Math.ceil(total / pageSize),
+      totalPages: Math.max(1, Math.ceil(total / pageSize)),
       hasMore: end < total,
       totalJobCounts,
       discovery,

--- a/apps/web/src/components/queue-table.test.tsx
+++ b/apps/web/src/components/queue-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { QueueTable } from '@/components/queue-table'
 
@@ -21,6 +21,8 @@ vi.mock('@durabull/analytics/browser', () => ({
 vi.mock('@durabull/analytics/events', () => ({
   AnalyticsEvents: {
     QUEUE_EMPTY_TOGGLE: 'QUEUE_EMPTY_TOGGLE',
+    QUEUE_LIST_SORTED: 'QUEUE_LIST_SORTED',
+    QUEUE_LIST_FILTERED: 'QUEUE_LIST_FILTERED',
   },
 }))
 
@@ -98,5 +100,101 @@ describe('QueueTable prioritized column', () => {
     // so the "Hide empty" toggle should not appear.
     expect(screen.queryByRole('button', { name: /hide empty/i })).not.toBeInTheDocument()
     expect(screen.getByTestId('queue-row-only-prioritized')).toBeInTheDocument()
+  })
+})
+
+describe('QueueTable sorting', () => {
+  it('marks the active sort column with aria-sort', () => {
+    render(<QueueTable queues={[makeQueue()]} sortBy="failed" sortOrder="desc" />)
+
+    expect(screen.getByRole('columnheader', { name: /failed/i })).toHaveAttribute(
+      'aria-sort',
+      'descending'
+    )
+    expect(screen.getByRole('columnheader', { name: /queue/i })).toHaveAttribute(
+      'aria-sort',
+      'none'
+    )
+  })
+
+  it('requests descending order on first click of a numeric column', () => {
+    const onSortChange = vi.fn()
+    render(
+      <QueueTable
+        queues={[makeQueue()]}
+        sortBy="name"
+        sortOrder="asc"
+        onSortChange={onSortChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Waiting' }))
+    expect(onSortChange).toHaveBeenCalledWith('waiting', 'desc')
+  })
+
+  it('toggles the order when clicking the active sort column', () => {
+    const onSortChange = vi.fn()
+    render(
+      <QueueTable
+        queues={[makeQueue()]}
+        sortBy="name"
+        sortOrder="asc"
+        onSortChange={onSortChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Queue' }))
+    expect(onSortChange).toHaveBeenCalledWith('name', 'desc')
+  })
+})
+
+describe('QueueTable filtering', () => {
+  it('debounces search input changes before notifying', () => {
+    vi.useFakeTimers()
+    try {
+      const onSearchChange = vi.fn()
+      render(<QueueTable queues={[makeQueue()]} onSearchChange={onSearchChange} />)
+
+      fireEvent.change(screen.getByRole('searchbox', { name: /filter queues by name/i }), {
+        target: { value: 'email' },
+      })
+      expect(onSearchChange).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(400)
+      expect(onSearchChange).toHaveBeenCalledTimes(1)
+      expect(onSearchChange).toHaveBeenCalledWith('email')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('notifies when the status filter changes', () => {
+    const onStatusFilterChange = vi.fn()
+    render(<QueueTable queues={[makeQueue()]} onStatusFilterChange={onStatusFilterChange} />)
+
+    fireEvent.change(screen.getByRole('combobox', { name: /filter queues by status/i }), {
+      target: { value: 'paused' },
+    })
+    expect(onStatusFilterChange).toHaveBeenCalledWith('paused')
+  })
+
+  it('shows a no-results message when filters match nothing', () => {
+    render(<QueueTable queues={[]} search="nope" />)
+    expect(screen.getByText('No queues match the current filters.')).toBeInTheDocument()
+  })
+})
+
+describe('QueueTable default view', () => {
+  it('shows the save-as-default action when the current view is not saved', () => {
+    const onSaveDefaultView = vi.fn()
+    render(<QueueTable queues={[makeQueue()]} onSaveDefaultView={onSaveDefaultView} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /save as default/i }))
+    expect(onSaveDefaultView).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the save-as-default action when the current view is already saved', () => {
+    render(<QueueTable queues={[makeQueue()]} />)
+    expect(screen.queryByRole('button', { name: /save as default/i })).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/queue-table.tsx
+++ b/apps/web/src/components/queue-table.tsx
@@ -3,8 +3,12 @@ import { AnalyticsEvents } from '@durabull/analytics/events'
 import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import {
   AlertCircle,
+  ArrowDown,
+  ArrowUp,
+  Bookmark,
   ChevronLeft,
   ChevronRight,
+  ChevronsUpDown,
   ExternalLink,
   Eye,
   EyeOff,
@@ -13,14 +17,18 @@ import {
   Pause,
   Play,
   Rocket,
+  Search,
+  X,
 } from 'lucide-react'
 import {
+  type ChangeEvent,
   type KeyboardEvent,
   type MouseEvent,
   memo,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import { useConnection } from '@/components/connection-provider'
@@ -34,6 +42,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
 import {
   Table,
   TableBody,
@@ -43,7 +53,13 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { usePauseQueue, useResumeQueue } from '@/hooks/use-queues'
+import {
+  type QueueSortField,
+  type QueueSortOrder,
+  type QueueStatusFilter,
+  usePauseQueue,
+  useResumeQueue,
+} from '@/hooks/use-queues'
 import { QUEUE_STATUS } from '@/lib/constants'
 import { cn, formatNumber } from '@/lib/utils'
 
@@ -72,6 +88,86 @@ interface QueueTableProps {
   total?: number
   isPlaceholderData?: boolean
   onPageChange?: (page: number) => void
+  sortBy?: QueueSortField
+  sortOrder?: QueueSortOrder
+  onSortChange?: (sortBy: QueueSortField, sortOrder: QueueSortOrder) => void
+  search?: string
+  onSearchChange?: (search: string) => void
+  statusFilter?: QueueStatusFilter | ''
+  onStatusFilterChange?: (status: QueueStatusFilter | '') => void
+  /** When provided, renders a "Save as default" action for the current view */
+  onSaveDefaultView?: () => void
+}
+
+const SEARCH_DEBOUNCE_MS = 300
+
+interface SortableColumn {
+  field: QueueSortField
+  label: string
+  align?: 'right'
+  /** Numeric columns sort descending on first click (largest values first) */
+  defaultOrder: QueueSortOrder
+}
+
+const SORTABLE_COLUMNS: SortableColumn[] = [
+  { field: 'name', label: 'Queue', defaultOrder: 'asc' },
+  { field: 'status', label: 'Status', defaultOrder: 'asc' },
+  { field: 'waiting', label: 'Waiting', align: 'right', defaultOrder: 'desc' },
+  { field: 'prioritized', label: 'Prioritized', align: 'right', defaultOrder: 'desc' },
+  { field: 'active', label: 'Active', align: 'right', defaultOrder: 'desc' },
+  { field: 'delayed', label: 'Delayed', align: 'right', defaultOrder: 'desc' },
+  { field: 'completed', label: 'Completed', align: 'right', defaultOrder: 'desc' },
+  { field: 'failed', label: 'Failed', align: 'right', defaultOrder: 'desc' },
+]
+
+interface SortableHeadProps {
+  column: SortableColumn
+  sortBy: QueueSortField
+  sortOrder: QueueSortOrder
+  onSortChange?: (sortBy: QueueSortField, sortOrder: QueueSortOrder) => void
+}
+
+function SortableHead({ column, sortBy, sortOrder, onSortChange }: SortableHeadProps) {
+  const isActive = sortBy === column.field
+  const ariaSort = isActive ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'
+
+  const handleClick = () => {
+    const nextOrder: QueueSortOrder = isActive
+      ? sortOrder === 'asc'
+        ? 'desc'
+        : 'asc'
+      : column.defaultOrder
+    trackEvent(AnalyticsEvents.QUEUE_LIST_SORTED, {
+      sort_by: column.field,
+      sort_order: nextOrder,
+    })
+    onSortChange?.(column.field, nextOrder)
+  }
+
+  return (
+    <TableHead aria-sort={ariaSort} className={column.align === 'right' ? 'text-right' : undefined}>
+      <button
+        type="button"
+        onClick={handleClick}
+        className={cn(
+          'inline-flex items-center gap-1 -mx-1 rounded px-1 py-0.5 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
+          column.align === 'right' && 'flex-row-reverse',
+          isActive ? 'text-foreground font-medium' : 'text-muted-foreground'
+        )}
+      >
+        {column.label}
+        {isActive ? (
+          sortOrder === 'asc' ? (
+            <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )
+        ) : (
+          <ChevronsUpDown className="h-3.5 w-3.5 opacity-50" aria-hidden="true" />
+        )}
+      </button>
+    </TableHead>
+  )
 }
 
 /**
@@ -97,13 +193,33 @@ export function QueueTable({
   total = 0,
   isPlaceholderData,
   onPageChange,
+  sortBy = 'name',
+  sortOrder = 'asc',
+  onSortChange,
+  search = '',
+  onSearchChange,
+  statusFilter = '',
+  onStatusFilterChange,
+  onSaveDefaultView,
 }: QueueTableProps) {
   const [hideEmpty, setHideEmpty] = useState(false)
+  const [searchInput, setSearchInput] = useState(search)
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const hasPagination = totalPages > 1
+  const hasServerFilters = search !== '' || statusFilter !== ''
 
   useEffect(() => {
     setHideEmpty(false)
   }, [page])
+
+  // Keep the input in sync when search is changed externally (e.g. URL navigation)
+  useEffect(() => {
+    setSearchInput(search)
+  }, [search])
+
+  useEffect(() => {
+    return () => clearTimeout(searchDebounceRef.current)
+  }, [])
 
   // Memoize filtered queues to avoid recalculating on unrelated re-renders
   const { filteredQueues, emptyCount } = useMemo(() => {
@@ -122,6 +238,42 @@ export function QueueTable({
     })
   }, [])
 
+  const handleSearchInput = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+      setSearchInput(value)
+      clearTimeout(searchDebounceRef.current)
+      searchDebounceRef.current = setTimeout(() => {
+        trackEvent(AnalyticsEvents.QUEUE_LIST_FILTERED, { filter: 'search' })
+        onSearchChange?.(value)
+      }, SEARCH_DEBOUNCE_MS)
+    },
+    [onSearchChange]
+  )
+
+  const handleClearSearch = useCallback(() => {
+    clearTimeout(searchDebounceRef.current)
+    setSearchInput('')
+    onSearchChange?.('')
+  }, [onSearchChange])
+
+  const handleStatusFilterChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value as QueueStatusFilter | ''
+      trackEvent(AnalyticsEvents.QUEUE_LIST_FILTERED, {
+        filter: 'status',
+        status: value || 'all',
+      })
+      onStatusFilterChange?.(value)
+    },
+    [onStatusFilterChange]
+  )
+
+  const handleClearFilters = useCallback(() => {
+    handleClearSearch()
+    onStatusFilterChange?.('')
+  }, [handleClearSearch, onStatusFilterChange])
+
   return (
     <TooltipProvider delayDuration={200}>
       <div
@@ -130,25 +282,93 @@ export function QueueTable({
           className
         )}
       >
+        {/* Toolbar: search + status filter */}
+        <div className="flex flex-wrap items-center gap-2 border-b px-4 py-3">
+          <div className="relative w-full max-w-xs">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              value={searchInput}
+              onChange={handleSearchInput}
+              placeholder="Filter queues by name…"
+              aria-label="Filter queues by name"
+              className="h-9 pl-8 [&::-webkit-search-cancel-button]:hidden"
+            />
+            {searchInput !== '' && (
+              <button
+                type="button"
+                onClick={handleClearSearch}
+                aria-label="Clear search"
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+          <Select
+            value={statusFilter}
+            onChange={handleStatusFilterChange}
+            aria-label="Filter queues by status"
+            className="w-36"
+          >
+            <option value="">All statuses</option>
+            <option value="active">Active</option>
+            <option value="paused">Paused</option>
+          </Select>
+          {hasServerFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClearFilters}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <X className="mr-1.5 h-4 w-4" />
+              Clear filters
+            </Button>
+          )}
+          {onSaveDefaultView && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={onSaveDefaultView} className="ml-auto">
+                  <Bookmark className="mr-1.5 h-4 w-4" />
+                  Save as default
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Use the current sorting and filters as your default view
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+
         <div className="flex-1 overflow-auto min-h-0 [&>div]:overflow-visible">
           <Table>
             <TableHeader className="sticky top-0 z-10 bg-card">
               <TableRow className="hover:bg-transparent">
-                <TableHead>Queue</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="text-right">Waiting</TableHead>
-                <TableHead className="text-right">Prioritized</TableHead>
-                <TableHead className="text-right">Active</TableHead>
-                <TableHead className="text-right">Delayed</TableHead>
-                <TableHead className="text-right">Completed</TableHead>
-                <TableHead className="text-right">Failed</TableHead>
+                {SORTABLE_COLUMNS.map((column) => (
+                  <SortableHead
+                    key={column.field}
+                    column={column}
+                    sortBy={sortBy}
+                    sortOrder={sortOrder}
+                    onSortChange={onSortChange}
+                  />
+                ))}
                 <TableHead className="w-[60px]"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredQueues.map((queue) => (
-                <QueueTableRow key={queue.name} queue={queue} />
-              ))}
+              {filteredQueues.length === 0 ? (
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={9} className="h-32 text-center text-muted-foreground">
+                    {hasServerFilters
+                      ? 'No queues match the current filters.'
+                      : 'No queues to display.'}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filteredQueues.map((queue) => <QueueTableRow key={queue.name} queue={queue} />)
+              )}
             </TableBody>
           </Table>
         </div>

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -203,10 +203,33 @@ export type {
  * Query key factory for queue-related queries
  * Includes connection ID for proper cache isolation
  */
+export const QUEUE_SORT_FIELDS = [
+  'name',
+  'status',
+  'waiting',
+  'prioritized',
+  'active',
+  'delayed',
+  'completed',
+  'failed',
+] as const
+export type QueueSortField = (typeof QUEUE_SORT_FIELDS)[number]
+export type QueueSortOrder = 'asc' | 'desc'
+export type QueueStatusFilter = 'active' | 'paused'
+
+export interface UseQueuesOptions {
+  page?: number
+  pageSize?: number
+  sortBy?: QueueSortField
+  sortOrder?: QueueSortOrder
+  search?: string
+  status?: QueueStatusFilter
+}
+
 export const queryKeys = {
-  queues: (connectionId: string, page?: number, pageSize?: number) =>
-    page !== undefined || pageSize !== undefined
-      ? (['queues', connectionId, { page, pageSize }] as const)
+  queues: (connectionId: string, options?: UseQueuesOptions) =>
+    options && Object.values(options).some((value) => value !== undefined)
+      ? (['queues', connectionId, options] as const)
       : (['queues', connectionId] as const),
   queueDiscovery: (connectionId: string) => ['queues', connectionId, 'discovery'] as const,
   queue: (connectionId: string, name: string) => ['queue', connectionId, name] as const,
@@ -239,17 +262,20 @@ function useConnectionIdFromContextOrRoute(): string | undefined {
 }
 
 // Queue Queries
-export function useQueues(options?: { page?: number; pageSize?: number }) {
+export function useQueues(options?: UseQueuesOptions) {
   const connectionId = useConnectionIdFromContextOrRoute()
-  const page = options?.page
-  const pageSize = options?.pageSize
+  const { page, pageSize, sortBy, sortOrder, search, status } = options ?? {}
 
   return useQuery({
-    queryKey: queryKeys.queues(connectionId ?? '', page, pageSize),
+    queryKey: queryKeys.queues(connectionId ?? '', options),
     queryFn: async () => {
       const params = new URLSearchParams()
       if (page !== undefined) params.set('page', String(page))
       if (pageSize !== undefined) params.set('pageSize', String(pageSize))
+      if (sortBy !== undefined) params.set('sortBy', sortBy)
+      if (sortOrder !== undefined) params.set('sortOrder', sortOrder)
+      if (search) params.set('search', search)
+      if (status !== undefined) params.set('status', status)
       const query = params.toString()
 
       return fetchApi<ListQueuesResponse>(

--- a/apps/web/src/lib/queues-default-view.test.ts
+++ b/apps/web/src/lib/queues-default-view.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { QueuesDefaultView } from '@/lib/queues-default-view'
+
+const STORAGE_KEY = 'durabull:queues-default-view:v1'
+
+async function importFresh() {
+  vi.resetModules()
+  return import('@/lib/queues-default-view')
+}
+
+describe('queues default view storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('falls back to the standard view when nothing is saved', async () => {
+    const { FALLBACK_QUEUES_VIEW, getDefaultQueuesView } = await importFresh()
+    expect(getDefaultQueuesView()).toEqual(FALLBACK_QUEUES_VIEW)
+  })
+
+  it('round-trips a saved view through localStorage', async () => {
+    const view: QueuesDefaultView = {
+      q: 'email',
+      status: 'paused',
+      sortBy: 'failed',
+      sortOrder: 'desc',
+    }
+
+    const first = await importFresh()
+    first.saveDefaultQueuesView(view)
+
+    const second = await importFresh()
+    expect(second.getDefaultQueuesView()).toEqual(view)
+  })
+
+  it('ignores corrupted or invalid stored values', async () => {
+    localStorage.setItem(STORAGE_KEY, '{not json')
+    const first = await importFresh()
+    expect(first.getDefaultQueuesView()).toEqual(first.FALLBACK_QUEUES_VIEW)
+
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ q: '', status: 'bogus', sortBy: 'nope', sortOrder: 'desc' })
+    )
+    const second = await importFresh()
+    expect(second.getDefaultQueuesView()).toEqual(second.FALLBACK_QUEUES_VIEW)
+  })
+
+  it('compares views field by field', async () => {
+    const { isSameQueuesView, FALLBACK_QUEUES_VIEW } = await importFresh()
+    expect(isSameQueuesView(FALLBACK_QUEUES_VIEW, { ...FALLBACK_QUEUES_VIEW })).toBe(true)
+    expect(
+      isSameQueuesView(FALLBACK_QUEUES_VIEW, { ...FALLBACK_QUEUES_VIEW, sortOrder: 'desc' })
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/lib/queues-default-view.ts
+++ b/apps/web/src/lib/queues-default-view.ts
@@ -1,0 +1,88 @@
+import {
+  QUEUE_SORT_FIELDS,
+  type QueueSortField,
+  type QueueSortOrder,
+  type QueueStatusFilter,
+} from '@/hooks/use-queues'
+
+/**
+ * User-saved default view for the queues list (sorting + filters).
+ * Persisted to localStorage and applied whenever the dashboard is opened
+ * without explicit search params in the URL.
+ */
+export interface QueuesDefaultView {
+  q: string
+  status: QueueStatusFilter | ''
+  sortBy: QueueSortField
+  sortOrder: QueueSortOrder
+}
+
+const STORAGE_KEY = 'durabull:queues-default-view:v1'
+
+export const FALLBACK_QUEUES_VIEW: QueuesDefaultView = {
+  q: '',
+  status: '',
+  sortBy: 'name',
+  sortOrder: 'asc',
+}
+
+const STATUS_VALUES = new Set(['', 'active', 'paused'])
+const SORT_FIELD_VALUES = new Set<string>(QUEUE_SORT_FIELDS)
+const SORT_ORDER_VALUES = new Set(['asc', 'desc'])
+
+// localStorage reads are synchronous and relatively expensive; cache in memory.
+let cachedView: QueuesDefaultView | undefined
+
+function parseView(raw: string): QueuesDefaultView | null {
+  const parsed: unknown = JSON.parse(raw)
+  if (typeof parsed !== 'object' || parsed === null) return null
+
+  const view = parsed as Record<string, unknown>
+  if (
+    typeof view.q !== 'string' ||
+    typeof view.status !== 'string' ||
+    !STATUS_VALUES.has(view.status) ||
+    typeof view.sortBy !== 'string' ||
+    !SORT_FIELD_VALUES.has(view.sortBy) ||
+    typeof view.sortOrder !== 'string' ||
+    !SORT_ORDER_VALUES.has(view.sortOrder)
+  ) {
+    return null
+  }
+
+  return {
+    q: view.q,
+    status: view.status as QueuesDefaultView['status'],
+    sortBy: view.sortBy as QueueSortField,
+    sortOrder: view.sortOrder as QueueSortOrder,
+  }
+}
+
+export function getDefaultQueuesView(): QueuesDefaultView {
+  if (cachedView !== undefined) return cachedView
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    cachedView = (raw ? parseView(raw) : null) ?? FALLBACK_QUEUES_VIEW
+  } catch {
+    // Throws in private browsing or when storage is disabled
+    cachedView = FALLBACK_QUEUES_VIEW
+  }
+
+  return cachedView
+}
+
+export function saveDefaultQueuesView(view: QueuesDefaultView): void {
+  cachedView = view
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(view))
+  } catch {
+    // Best effort: the in-memory cache still applies for this session
+  }
+}
+
+export function isSameQueuesView(a: QueuesDefaultView, b: QueuesDefaultView): boolean {
+  return (
+    a.q === b.q && a.status === b.status && a.sortBy === b.sortBy && a.sortOrder === b.sortOrder
+  )
+}

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.index.tsx
@@ -1,4 +1,7 @@
-import { createFileRoute, useParams } from '@tanstack/react-router'
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents } from '@durabull/analytics/events'
+import { createFileRoute, useNavigate, useParams } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
 import {
   Activity,
   AlertCircle,
@@ -11,16 +14,30 @@ import {
   Timer,
   Zap,
 } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { z } from 'zod'
 import { useAppTopBar } from '@/components/app-top-bar'
 import { QueueTable } from '@/components/queue-table'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { useDiscoverQueues, useQueueDiscoveryStatus, useQueues } from '@/hooks/use-queues'
+import {
+  QUEUE_SORT_FIELDS,
+  type QueueSortField,
+  type QueueSortOrder,
+  type QueueStatusFilter,
+  useDiscoverQueues,
+  useQueueDiscoveryStatus,
+  useQueues,
+} from '@/hooks/use-queues'
 import { REDIS_CONNECTION_ERROR_MESSAGE } from '@/lib/api'
 import { PAGINATION } from '@/lib/constants'
+import {
+  getDefaultQueuesView,
+  isSameQueuesView,
+  saveDefaultQueuesView,
+} from '@/lib/queues-default-view'
 import { cn, formatNumber } from '@/lib/utils'
 
 const AUTO_DISCOVERY_MIN_INTERVAL_MS = 5 * 60 * 1000
@@ -42,17 +59,81 @@ function isRedisConnectionFailure(message: string): boolean {
   ].some((indicator) => normalized.includes(indicator))
 }
 
+// Missing/invalid params fall back to the user's saved default view
+const dashboardSearchSchema = z.object({
+  page: z.number().int().positive().catch(1),
+  q: z.string().catch(() => getDefaultQueuesView().q),
+  status: z.enum(['', 'active', 'paused']).catch(() => getDefaultQueuesView().status),
+  sortBy: z.enum(QUEUE_SORT_FIELDS).catch(() => getDefaultQueuesView().sortBy),
+  sortOrder: z.enum(['asc', 'desc']).catch(() => getDefaultQueuesView().sortOrder),
+})
+
 export const Route = createFileRoute('/$orgSlug/c/$connectionId/')({
+  validateSearch: zodValidator(dashboardSearchSchema),
   component: Dashboard,
 })
 
 function Dashboard() {
   const routeParams = useParams({ strict: false }) as { connectionId?: string }
   const connectionId = routeParams.connectionId ?? ''
-  const [page, setPage] = useState(1)
+  const { page, q, status, sortBy, sortOrder } = Route.useSearch()
+  const navigate = useNavigate()
+
+  const updateSearch = useCallback(
+    (patch: Partial<z.infer<typeof dashboardSearchSchema>>) => {
+      void navigate({
+        from: Route.fullPath,
+        search: (prev) => ({ ...prev, ...patch }),
+        replace: true,
+      })
+    },
+    [navigate]
+  )
+
+  const setPage = useCallback(
+    (nextPage: number) => updateSearch({ page: nextPage }),
+    [updateSearch]
+  )
+
+  // Any change to filters or sorting invalidates the current page offset
+  const handleSortChange = useCallback(
+    (nextSortBy: QueueSortField, nextSortOrder: QueueSortOrder) =>
+      updateSearch({ sortBy: nextSortBy, sortOrder: nextSortOrder, page: 1 }),
+    [updateSearch]
+  )
+  const handleSearchChange = useCallback(
+    (nextSearch: string) => updateSearch({ q: nextSearch, page: 1 }),
+    [updateSearch]
+  )
+  const handleStatusFilterChange = useCallback(
+    (nextStatus: QueueStatusFilter | '') => updateSearch({ status: nextStatus, page: 1 }),
+    [updateSearch]
+  )
+
+  const [savedView, setSavedView] = useState(getDefaultQueuesView)
+  const currentView = useMemo(
+    () => ({ q, status, sortBy, sortOrder }),
+    [q, status, sortBy, sortOrder]
+  )
+  const isCurrentViewSaved = isSameQueuesView(currentView, savedView)
+  const handleSaveDefaultView = useCallback(() => {
+    trackEvent(AnalyticsEvents.QUEUE_LIST_DEFAULT_VIEW_SAVED, {
+      sort_by: currentView.sortBy,
+      sort_order: currentView.sortOrder,
+      status: currentView.status || 'all',
+      has_search: currentView.q !== '',
+    })
+    saveDefaultQueuesView(currentView)
+    setSavedView(currentView)
+  }, [currentView])
+
   const { data, isLoading, error, isPlaceholderData } = useQueues({
     page,
     pageSize: PAGINATION.QUEUES_PAGE_SIZE,
+    sortBy,
+    sortOrder,
+    search: q || undefined,
+    status: status || undefined,
   })
   const discoveryQuery = useQueueDiscoveryStatus()
   const discoverMutation = useDiscoverQueues()
@@ -83,7 +164,7 @@ function Dashboard() {
     if (!connectionId) return
     hasAutoTriggeredDiscovery.current = false
     setPage(1)
-  }, [connectionId])
+  }, [connectionId, setPage])
 
   useEffect(() => {
     if (hasAutoTriggeredDiscovery.current) return
@@ -139,7 +220,7 @@ function Dashboard() {
   const shouldShowConnectionFailure =
     !error &&
     !isLoading &&
-    (data?.total ?? 0) === 0 &&
+    (data?.totalUnfiltered ?? data?.total ?? 0) === 0 &&
     !discoveryRunning &&
     !!discoveryErrorMessage &&
     isRedisConnectionFailure(discoveryErrorMessage)
@@ -279,7 +360,7 @@ function Dashboard() {
                 ))}
               </div>
             </div>
-          ) : (data?.total ?? 0) === 0 ? (
+          ) : (data?.totalUnfiltered ?? data?.total ?? 0) === 0 ? (
             <EmptyState />
           ) : (
             <QueueTable
@@ -289,6 +370,14 @@ function Dashboard() {
               total={data?.total ?? 0}
               isPlaceholderData={isPlaceholderData}
               onPageChange={setPage}
+              sortBy={sortBy}
+              sortOrder={sortOrder}
+              onSortChange={handleSortChange}
+              search={q}
+              onSearchChange={handleSearchChange}
+              statusFilter={status}
+              onStatusFilterChange={handleStatusFilterChange}
+              onSaveDefaultView={isCurrentViewSaved ? undefined : handleSaveDefaultView}
             />
           )}
         </div>

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -56,6 +56,9 @@ export const AnalyticsEvents = {
   QUEUE_VIEWED: 'queue_viewed',
   QUEUE_LIST_VIEWED: 'queue_list_viewed',
   QUEUE_EMPTY_TOGGLE: 'queue_empty_toggle',
+  QUEUE_LIST_SORTED: 'queue_list_sorted',
+  QUEUE_LIST_FILTERED: 'queue_list_filtered',
+  QUEUE_LIST_DEFAULT_VIEW_SAVED: 'queue_list_default_view_saved',
 
   // Job Events
   JOB_VIEWED: 'job_viewed',


### PR DESCRIPTION
## Summary
- Add server-side column sorting and name/status filtering to the queues list API, applied before pagination so results stay correct across pages.
- Wire sort/filter state into URL search params on the dashboard and add sortable column headers plus a search/status toolbar in `QueueTable`.
- Let users save their current sort/filter layout as a default view in localStorage, with a "Save as default" button shown only when the current view differs from the saved one.

## Test plan
- [x] API: `bun test src/routes/queues.test.ts` (7 tests)
- [x] Web: `bunx vitest run src/components/queue-table.test.tsx src/lib/queues-default-view.test.ts` (15 tests)
- [x] Web typecheck passes
- [ ] Manual: sort by Failed desc and paginate — order holds across pages
- [ ] Manual: filter by name/status — pagination reflects filtered total
- [ ] Manual: change sort/filter, click "Save as default", reload — saved view restores
- [ ] Manual: when current view matches saved default, button is hidden


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sort queues by name and job counts (e.g., failed jobs)
  * Search queues by name in real-time
  * Filter queues by status (paused or active)
  * Save and restore custom queue view preferences as default
  * Clear all active filters with a single action

<!-- end of auto-generated comment: release notes by coderabbit.ai -->