### PR TITLE
Show retry status modal on job retry

### DIFF
--- a/.agents/skills/pr-review-comments/SKILL.md
+++ b/.agents/skills/pr-review-comments/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: pr-review-comments
+description: Triage unresolved GitHub PR review threads — assess merit, apply fixes when warranted, reply on each thread, and resolve it. Use when the user types `/pr-comments`, asks to address PR feedback, resolve review comments, or clear unaddressed inline review threads before merge.
+user-invocable: true
+argument-hint: "Optional: PR number, branch name, or GitHub PR URL"
+---
+
+# PR Review Comments
+
+Workflow for **unresolved inline review threads** on a GitHub PR: collect them, judge merit, fix when warranted, push, reply, resolve.
+
+Use `gh` (and GitHub GraphQL when needed — there is no `gh` subcommand to resolve inline threads). No custom scripts.
+
+## When to use
+
+- Open inline review threads before merge.
+- After Bugbot, Copilot, or human inline comments.
+- User asks to address PR feedback or `/pr-comments`.
+
+## Workflow
+
+### 1. Set up
+
+- Confirm `gh auth status`.
+- Resolve the PR from the skill argument, `gh pr view` on the current branch, or ask.
+- `gh pr checkout <n>` and `git pull --ff-only`.
+
+### 2. List open threads
+
+Fetch unresolved inline review threads for the PR. Filter to `isResolved == false`.
+
+Inline threads are not the same as PR timeline comments (`gh pr view --comments`) — only threads can be resolved in the GitHub UI.
+
+For bot comments (Bugbot, etc.), ignore HTML and "Fix in Cursor" links; read the title and description body.
+
+### 3. Triage each thread
+
+Read the cited file on `HEAD` (use `originalLine` when the thread is outdated).
+
+| Merit | Action |
+| --- | --- |
+| `fix` | Valid bug, security, correctness, or repo rule violation → code change |
+| `already-fixed` | Valid but already on `HEAD` → cite file:line |
+| `explain` | False positive, intentional, or below-threshold nit → reply with evidence |
+| `defer` | Valid but out of this PR's scope → reply; link/create Linear issue if needed |
+| `needs-human` | Design/product disagreement → reply with options; **do not resolve** |
+
+Bias: fix Critical/High findings; treat linked Bugbot learned rules as team policy unless clearly wrong on inspection.
+
+For many threads (>4), optional read-only `explore` subagents by directory, then merge triage in the main agent.
+
+### 4. Fix, commit, push
+
+Minimal scoped changes per `AGENTS.md`. Group related review points into one commit. Push before replying so you can cite the SHA.
+
+Run targeted tests for code you change.
+
+### 5. Reply and resolve
+
+Reply on each thread (plain markdown): what you did, short SHA if fixed, tests run.
+
+Resolve the thread when the loop is closed (fixed, explained, or verified on `HEAD`).
+
+Do **not** resolve `needs-human` threads or unanswered reviewer questions.
+
+Timeline-only PR comments: reply with `gh pr comment` — they cannot be resolved like inline threads.
+
+### 6. Summarize
+
+Short table for the user: thread, file, merit, action, resolved?, commits, tests, anything still open.
+
+## Guardrails
+
+- Never resolve without reading current code.
+- Push before replying when you landed a fix.
+- Do not greenwash the PR by resolving threads you did not evaluate.
+
+## Related skills
+
+- `parallel-code-review` — proactive review before feedback arrives.
+- `react-doctor` — after web UI fixes.

--- a/.claude/skills/pr-review-comments
+++ b/.claude/skills/pr-review-comments
@@ -1,0 +1,1 @@
+../../.agents/skills/pr-review-comments

--- a/.cursor/skills/pr-review-comments
+++ b/.cursor/skills/pr-review-comments
@@ -1,0 +1,1 @@
+../../.agents/skills/pr-review-comments

--- a/apps/web/e2e/pages.spec.ts
+++ b/apps/web/e2e/pages.spec.ts
@@ -291,7 +291,7 @@ test.describe("Pages", () => {
     ).toBeVisible();
   });
 
-  test("failed job retry returns job to queue", async ({ page }) => {
+  test("failed job retry shows success modal and requeues job", async ({ page }) => {
     const { connectionId } = await getConnectionAndQueue(page);
     const failedJob = await findJobByStatus(page, connectionId, "failed");
 
@@ -302,8 +302,16 @@ test.describe("Pages", () => {
     await expect(retryButton).toBeVisible();
     await retryButton.click();
 
-    await page.waitForURL(
-      new RegExp(`/${TEST_ORG_SLUG}/c/${connectionId}/queues/${failedJob.queueName}`)
+    await expect(page.getByRole("heading", { name: "Job Retried" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText(/Retry succeeded/i)).toBeVisible();
+
+    await page.getByRole("button", { name: "Done" }).click();
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/${TEST_ORG_SLUG}/c/${connectionId}/queues/${failedJob.queueName}/jobs/${failedJob.jobId}`
+      )
     );
 
     await expect

--- a/apps/web/src/components/retry-job-dialog.test.tsx
+++ b/apps/web/src/components/retry-job-dialog.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { RetryJobDialog, RetryJobPhase } from '@/components/retry-job-dialog'
+import { RetryJobDialog } from '@/components/retry-job-dialog'
+import { RetryJobPhase } from '@/components/retry-job-phase'
 
 const { trackEventMock } = vi.hoisted(() => ({
   trackEventMock: vi.fn(),

--- a/apps/web/src/components/retry-job-dialog.test.tsx
+++ b/apps/web/src/components/retry-job-dialog.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RetryJobDialog } from '@/components/retry-job-dialog'
+
+const { mutateAsyncMock, trackEventMock } = vi.hoisted(() => ({
+  mutateAsyncMock: vi.fn(),
+  trackEventMock: vi.fn(),
+}))
+
+vi.mock('@durabull/analytics/browser', () => ({
+  trackEvent: trackEventMock,
+}))
+
+vi.mock('@durabull/analytics/events', () => ({
+  AnalyticsEvents: {
+    DIALOG_OPENED: 'DIALOG_OPENED',
+    DIALOG_CLOSED: 'DIALOG_CLOSED',
+  },
+  AnalyticsProperties: {
+    DIALOG_TYPE: 'dialog_type',
+  },
+  DialogType: {
+    RETRY_JOB: 'retry_job',
+  },
+}))
+
+vi.mock('@/hooks/use-queues', () => ({
+  useRetryJobs: () => ({
+    mutateAsync: mutateAsyncMock,
+    isPending: false,
+  }),
+}))
+
+describe('RetryJobDialog', () => {
+  beforeEach(() => {
+    mutateAsyncMock.mockReset()
+    trackEventMock.mockReset()
+  })
+
+  it('shows success state when retry succeeds', async () => {
+    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+
+    render(
+      <RetryJobDialog
+        open
+        onOpenChange={vi.fn()}
+        queueName="emails"
+        jobId="job-123"
+        jobName="send-email"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Job Retried')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(/Retry succeeded/i)).toBeInTheDocument()
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      queueName: 'emails',
+      jobIds: ['job-123'],
+    })
+  })
+
+  it('shows error state when retry fails', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      success: 0,
+      failed: 1,
+      errors: [{ jobId: 'job-123', error: 'Job is locked' }],
+    })
+
+    render(
+      <RetryJobDialog
+        open
+        onOpenChange={vi.fn()}
+        queueName="emails"
+        jobId="job-123"
+        jobName="send-email"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Retry Failed')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Job is locked')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument()
+  })
+
+  it('retries again when Try Again is clicked', async () => {
+    const user = userEvent.setup()
+    mutateAsyncMock
+      .mockResolvedValueOnce({
+        success: 0,
+        failed: 1,
+        errors: [{ jobId: 'job-123', error: 'Temporary failure' }],
+      })
+      .mockResolvedValueOnce({ success: 1, failed: 0, errors: [] })
+
+    render(
+      <RetryJobDialog
+        open
+        onOpenChange={vi.fn()}
+        queueName="emails"
+        jobId="job-123"
+        jobName="send-email"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Temporary failure')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Try Again' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Job Retried')).toBeInTheDocument()
+    })
+
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('closes when Done is clicked after success', async () => {
+    const user = userEvent.setup()
+    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+    const onOpenChange = vi.fn()
+
+    render(
+      <RetryJobDialog
+        open
+        onOpenChange={onOpenChange}
+        queueName="emails"
+        jobId="job-123"
+        jobName="send-email"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/web/src/components/retry-job-dialog.test.tsx
+++ b/apps/web/src/components/retry-job-dialog.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { RetryJobDialog } from '@/components/retry-job-dialog'
+import { RetryJobDialog, RetryJobPhase } from '@/components/retry-job-dialog'
 
 const { trackEventMock } = vi.hoisted(() => ({
   trackEventMock: vi.fn(),
@@ -30,7 +30,7 @@ const defaultProps = {
   queueName: 'emails',
   jobId: 'job-123',
   jobName: 'send-email',
-  phase: 'retrying' as const,
+  phase: RetryJobPhase.RETRYING,
   errorMessage: null,
   onRetry: vi.fn(),
 }
@@ -43,7 +43,7 @@ describe('RetryJobDialog', () => {
   })
 
   it('shows success state', () => {
-    render(<RetryJobDialog {...defaultProps} phase="success" />)
+    render(<RetryJobDialog {...defaultProps} phase={RetryJobPhase.SUCCESS} />)
 
     expect(screen.getByText('Job Retried')).toBeInTheDocument()
     expect(screen.getByText(/Retry succeeded/i)).toBeInTheDocument()
@@ -51,7 +51,7 @@ describe('RetryJobDialog', () => {
 
   it('shows error state with message', () => {
     render(
-      <RetryJobDialog {...defaultProps} phase="error" errorMessage="Job is locked" />
+      <RetryJobDialog {...defaultProps} phase={RetryJobPhase.ERROR} errorMessage="Job is locked" />
     )
 
     expect(screen.getByText('Retry Failed')).toBeInTheDocument()
@@ -66,7 +66,7 @@ describe('RetryJobDialog', () => {
     render(
       <RetryJobDialog
         {...defaultProps}
-        phase="error"
+        phase={RetryJobPhase.ERROR}
         errorMessage="Temporary failure"
         onRetry={onRetry}
       />
@@ -81,7 +81,7 @@ describe('RetryJobDialog', () => {
     const user = userEvent.setup()
     const onOpenChange = vi.fn()
 
-    render(<RetryJobDialog {...defaultProps} phase="success" onOpenChange={onOpenChange} />)
+    render(<RetryJobDialog {...defaultProps} phase={RetryJobPhase.SUCCESS} onOpenChange={onOpenChange} />)
 
     await user.click(screen.getByRole('button', { name: 'Done' }))
 
@@ -89,7 +89,7 @@ describe('RetryJobDialog', () => {
   })
 
   it('shows retrying state while in progress', () => {
-    render(<RetryJobDialog {...defaultProps} phase="retrying" />)
+    render(<RetryJobDialog {...defaultProps} phase={RetryJobPhase.RETRYING} />)
 
     expect(screen.getByText('Retrying Job')).toBeInTheDocument()
     expect(screen.getByText('Retry in progress...')).toBeInTheDocument()

--- a/apps/web/src/components/retry-job-dialog.test.tsx
+++ b/apps/web/src/components/retry-job-dialog.test.tsx
@@ -1,10 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RetryJobDialog } from '@/components/retry-job-dialog'
 
-const { mutateAsyncMock, trackEventMock } = vi.hoisted(() => ({
-  mutateAsyncMock: vi.fn(),
+const { trackEventMock } = vi.hoisted(() => ({
   trackEventMock: vi.fn(),
 }))
 
@@ -25,122 +24,74 @@ vi.mock('@durabull/analytics/events', () => ({
   },
 }))
 
-vi.mock('@/hooks/use-queues', () => ({
-  useRetryJobs: () => ({
-    mutateAsync: mutateAsyncMock,
-    isPending: false,
-  }),
-}))
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  queueName: 'emails',
+  jobId: 'job-123',
+  jobName: 'send-email',
+  phase: 'retrying' as const,
+  errorMessage: null,
+  onRetry: vi.fn(),
+}
 
 describe('RetryJobDialog', () => {
   beforeEach(() => {
-    mutateAsyncMock.mockReset()
     trackEventMock.mockReset()
+    defaultProps.onOpenChange.mockReset()
+    defaultProps.onRetry.mockReset()
   })
 
-  it('shows success state when retry succeeds', async () => {
-    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+  it('shows success state', () => {
+    render(<RetryJobDialog {...defaultProps} phase="success" />)
 
-    render(
-      <RetryJobDialog
-        open
-        onOpenChange={vi.fn()}
-        queueName="emails"
-        jobId="job-123"
-        jobName="send-email"
-      />
-    )
-
-    await waitFor(() => {
-      expect(screen.getByText('Job Retried')).toBeInTheDocument()
-    })
-
+    expect(screen.getByText('Job Retried')).toBeInTheDocument()
     expect(screen.getByText(/Retry succeeded/i)).toBeInTheDocument()
-    expect(mutateAsyncMock).toHaveBeenCalledWith({
-      queueName: 'emails',
-      jobIds: ['job-123'],
-    })
   })
 
-  it('shows error state when retry fails', async () => {
-    mutateAsyncMock.mockResolvedValue({
-      success: 0,
-      failed: 1,
-      errors: [{ jobId: 'job-123', error: 'Job is locked' }],
-    })
-
+  it('shows error state with message', () => {
     render(
-      <RetryJobDialog
-        open
-        onOpenChange={vi.fn()}
-        queueName="emails"
-        jobId="job-123"
-        jobName="send-email"
-      />
+      <RetryJobDialog {...defaultProps} phase="error" errorMessage="Job is locked" />
     )
 
-    await waitFor(() => {
-      expect(screen.getByText('Retry Failed')).toBeInTheDocument()
-    })
-
+    expect(screen.getByText('Retry Failed')).toBeInTheDocument()
     expect(screen.getByText('Job is locked')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument()
   })
 
-  it('retries again when Try Again is clicked', async () => {
+  it('calls onRetry when Try Again is clicked', async () => {
     const user = userEvent.setup()
-    mutateAsyncMock
-      .mockResolvedValueOnce({
-        success: 0,
-        failed: 1,
-        errors: [{ jobId: 'job-123', error: 'Temporary failure' }],
-      })
-      .mockResolvedValueOnce({ success: 1, failed: 0, errors: [] })
+    const onRetry = vi.fn()
 
     render(
       <RetryJobDialog
-        open
-        onOpenChange={vi.fn()}
-        queueName="emails"
-        jobId="job-123"
-        jobName="send-email"
+        {...defaultProps}
+        phase="error"
+        errorMessage="Temporary failure"
+        onRetry={onRetry}
       />
     )
 
-    await waitFor(() => {
-      expect(screen.getByText('Temporary failure')).toBeInTheDocument()
-    })
-
     await user.click(screen.getByRole('button', { name: 'Try Again' }))
 
-    await waitFor(() => {
-      expect(screen.getByText('Job Retried')).toBeInTheDocument()
-    })
-
-    expect(mutateAsyncMock).toHaveBeenCalledTimes(2)
+    expect(onRetry).toHaveBeenCalledTimes(1)
   })
 
   it('closes when Done is clicked after success', async () => {
     const user = userEvent.setup()
-    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
     const onOpenChange = vi.fn()
 
-    render(
-      <RetryJobDialog
-        open
-        onOpenChange={onOpenChange}
-        queueName="emails"
-        jobId="job-123"
-        jobName="send-email"
-      />
-    )
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
-    })
+    render(<RetryJobDialog {...defaultProps} phase="success" onOpenChange={onOpenChange} />)
 
     await user.click(screen.getByRole('button', { name: 'Done' }))
 
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows retrying state while in progress', () => {
+    render(<RetryJobDialog {...defaultProps} phase="retrying" />)
+
+    expect(screen.getByText('Retrying Job')).toBeInTheDocument()
+    expect(screen.getByText('Retry in progress...')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/retry-job-dialog.tsx
+++ b/apps/web/src/components/retry-job-dialog.tsx
@@ -11,7 +11,13 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 
-export type RetryJobPhase = 'retrying' | 'success' | 'error'
+export const RetryJobPhase = {
+  RETRYING: 'retrying',
+  SUCCESS: 'success',
+  ERROR: 'error',
+} as const
+
+export type RetryJobPhase = (typeof RetryJobPhase)[keyof typeof RetryJobPhase]
 
 interface RetryJobDialogProps {
   open: boolean
@@ -42,16 +48,16 @@ export function RetryJobDialog({
   }
 
   const title =
-    phase === 'retrying'
+    phase === RetryJobPhase.RETRYING
       ? 'Retrying Job'
-      : phase === 'success'
+      : phase === RetryJobPhase.SUCCESS
         ? 'Job Retried'
         : 'Retry Failed'
 
   const description =
-    phase === 'retrying'
+    phase === RetryJobPhase.RETRYING
       ? 'Sending this job back to the queue. This usually takes just a moment.'
-      : phase === 'success'
+      : phase === RetryJobPhase.SUCCESS
         ? 'The job was requeued successfully and should start processing again soon.'
         : 'We could not retry this job. Review the details below and try again if needed.'
 
@@ -59,16 +65,16 @@ export function RetryJobDialog({
     <Dialog
       open={open}
       onOpenChange={(nextOpen) => {
-        if (!nextOpen && phase === 'retrying') return
+        if (!nextOpen && phase === RetryJobPhase.RETRYING) return
         handleOpenChange(nextOpen)
       }}
     >
       <DialogContent className="sm:max-w-[480px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            {phase === 'retrying' ? (
+            {phase === RetryJobPhase.RETRYING ? (
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-            ) : phase === 'success' ? (
+            ) : phase === RetryJobPhase.SUCCESS ? (
               <CheckCircle2 className="h-5 w-5 text-status-success" />
             ) : (
               <AlertCircle className="h-5 w-5 text-status-danger" />
@@ -91,14 +97,14 @@ export function RetryJobDialog({
             </div>
           </div>
 
-          {phase === 'retrying' && (
+          {phase === RetryJobPhase.RETRYING && (
             <div className="flex items-center gap-3 rounded-lg border border-border/70 bg-background/60 px-4 py-3">
               <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
               <p className="text-sm text-muted-foreground">Retry in progress...</p>
             </div>
           )}
 
-          {phase === 'success' && (
+          {phase === RetryJobPhase.SUCCESS && (
             <div className="rounded-lg border border-status-success/30 bg-status-success/10 px-4 py-3">
               <p className="text-sm text-status-success">
                 Retry succeeded. The job status on this page will update shortly.
@@ -106,7 +112,7 @@ export function RetryJobDialog({
             </div>
           )}
 
-          {phase === 'error' && errorMessage && (
+          {phase === RetryJobPhase.ERROR && errorMessage && (
             <div className="rounded-lg border border-status-danger/30 bg-status-danger/10 px-4 py-3">
               <p className="text-sm text-status-danger">{errorMessage}</p>
             </div>
@@ -114,12 +120,12 @@ export function RetryJobDialog({
         </div>
 
         <DialogFooter>
-          {phase === 'retrying' ? (
+          {phase === RetryJobPhase.RETRYING ? (
             <Button variant="outline" disabled>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               Retrying...
             </Button>
-          ) : phase === 'success' ? (
+          ) : phase === RetryJobPhase.SUCCESS ? (
             <Button onClick={() => handleOpenChange(false)}>Done</Button>
           ) : (
             <>

--- a/apps/web/src/components/retry-job-dialog.tsx
+++ b/apps/web/src/components/retry-job-dialog.tsx
@@ -1,0 +1,184 @@
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
+import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useRetryJobs } from '@/hooks/use-queues'
+
+type RetryPhase = 'retrying' | 'success' | 'error'
+
+interface RetryJobDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  queueName: string
+  jobId: string
+  jobName: string
+}
+
+export function RetryJobDialog({
+  open,
+  onOpenChange,
+  queueName,
+  jobId,
+  jobName,
+}: RetryJobDialogProps) {
+  const { mutateAsync: retryJobs } = useRetryJobs()
+  const [phase, setPhase] = useState<RetryPhase>('retrying')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const previousOpenRef = useRef(false)
+
+  const runRetry = useCallback(async () => {
+    setPhase('retrying')
+    setErrorMessage(null)
+
+    try {
+      const result = await retryJobs({
+        queueName,
+        jobIds: [jobId],
+      })
+
+      if (result.success > 0 && result.failed === 0) {
+        setPhase('success')
+        return
+      }
+
+      const apiError =
+        result.errors.find((entry) => entry.jobId === jobId)?.error ??
+        (result.failed > 0
+          ? 'The job could not be retried.'
+          : 'The job was not in a failed state and could not be retried.')
+
+      setErrorMessage(apiError)
+      setPhase('error')
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'An unexpected error occurred while retrying.'
+      )
+      setPhase('error')
+    }
+  }, [jobId, queueName, retryJobs])
+
+  useEffect(() => {
+    const didOpen = open && !previousOpenRef.current
+
+    if (!open) {
+      setPhase('retrying')
+      setErrorMessage(null)
+    } else if (didOpen) {
+      void runRetry()
+    }
+
+    previousOpenRef.current = open
+  }, [open, runRetry])
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    trackEvent(nextOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
+      [AnalyticsProperties.DIALOG_TYPE]: DialogType.RETRY_JOB,
+    })
+    onOpenChange(nextOpen)
+  }
+
+  const title =
+    phase === 'retrying'
+      ? 'Retrying Job'
+      : phase === 'success'
+        ? 'Job Retried'
+        : 'Retry Failed'
+
+  const description =
+    phase === 'retrying'
+      ? 'Sending this job back to the queue. This usually takes just a moment.'
+      : phase === 'success'
+        ? 'The job was requeued successfully and should start processing again soon.'
+        : 'We could not retry this job. Review the details below and try again if needed.'
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && phase === 'retrying') return
+        handleOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {phase === 'retrying' ? (
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            ) : phase === 'success' ? (
+              <CheckCircle2 className="h-5 w-5 text-status-success" />
+            ) : (
+              <AlertCircle className="h-5 w-5 text-status-danger" />
+            )}
+            {title}
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="rounded-lg border bg-muted/20 p-4 space-y-3">
+            <div>
+              <p className="text-xs text-muted-foreground mb-1">Queue</p>
+              <p className="font-mono text-sm break-all">{queueName}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground mb-1">Job</p>
+              <p className="text-sm font-medium">{jobName}</p>
+              <p className="font-mono text-xs text-muted-foreground break-all mt-1">{jobId}</p>
+            </div>
+          </div>
+
+          {phase === 'retrying' && (
+            <div className="flex items-center gap-3 rounded-lg border border-border/70 bg-background/60 px-4 py-3">
+              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">Retry in progress...</p>
+            </div>
+          )}
+
+          {phase === 'success' && (
+            <div className="rounded-lg border border-status-success/30 bg-status-success/10 px-4 py-3">
+              <p className="text-sm text-status-success">
+                Retry succeeded. The job status on this page will update shortly.
+              </p>
+            </div>
+          )}
+
+          {phase === 'error' && errorMessage && (
+            <div className="rounded-lg border border-status-danger/30 bg-status-danger/10 px-4 py-3">
+              <p className="text-sm text-status-danger">{errorMessage}</p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {phase === 'retrying' ? (
+            <Button variant="outline" disabled>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Retrying...
+            </Button>
+          ) : phase === 'success' ? (
+            <Button onClick={() => handleOpenChange(false)}>Done</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+              <Button onClick={() => void runRetry()}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Try Again
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/retry-job-dialog.tsx
+++ b/apps/web/src/components/retry-job-dialog.tsx
@@ -1,7 +1,6 @@
 import { trackEvent } from '@durabull/analytics/browser'
 import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,9 +10,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { useRetryJobs } from '@/hooks/use-queues'
 
-type RetryPhase = 'retrying' | 'success' | 'error'
+export type RetryJobPhase = 'retrying' | 'success' | 'error'
 
 interface RetryJobDialogProps {
   open: boolean
@@ -21,6 +19,9 @@ interface RetryJobDialogProps {
   queueName: string
   jobId: string
   jobName: string
+  phase: RetryJobPhase
+  errorMessage: string | null
+  onRetry: () => void
 }
 
 export function RetryJobDialog({
@@ -29,56 +30,10 @@ export function RetryJobDialog({
   queueName,
   jobId,
   jobName,
+  phase,
+  errorMessage,
+  onRetry,
 }: RetryJobDialogProps) {
-  const { mutateAsync: retryJobs } = useRetryJobs()
-  const [phase, setPhase] = useState<RetryPhase>('retrying')
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const previousOpenRef = useRef(false)
-
-  const runRetry = useCallback(async () => {
-    setPhase('retrying')
-    setErrorMessage(null)
-
-    try {
-      const result = await retryJobs({
-        queueName,
-        jobIds: [jobId],
-      })
-
-      if (result.success > 0 && result.failed === 0) {
-        setPhase('success')
-        return
-      }
-
-      const apiError =
-        result.errors.find((entry) => entry.jobId === jobId)?.error ??
-        (result.failed > 0
-          ? 'The job could not be retried.'
-          : 'The job was not in a failed state and could not be retried.')
-
-      setErrorMessage(apiError)
-      setPhase('error')
-    } catch (error) {
-      setErrorMessage(
-        error instanceof Error ? error.message : 'An unexpected error occurred while retrying.'
-      )
-      setPhase('error')
-    }
-  }, [jobId, queueName, retryJobs])
-
-  useEffect(() => {
-    const didOpen = open && !previousOpenRef.current
-
-    if (!open) {
-      setPhase('retrying')
-      setErrorMessage(null)
-    } else if (didOpen) {
-      void runRetry()
-    }
-
-    previousOpenRef.current = open
-  }, [open, runRetry])
-
   const handleOpenChange = (nextOpen: boolean) => {
     trackEvent(nextOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
       [AnalyticsProperties.DIALOG_TYPE]: DialogType.RETRY_JOB,
@@ -171,7 +126,7 @@ export function RetryJobDialog({
               <Button variant="outline" onClick={() => handleOpenChange(false)}>
                 Close
               </Button>
-              <Button onClick={() => void runRetry()}>
+              <Button onClick={onRetry}>
                 <RefreshCw className="mr-2 h-4 w-4" />
                 Try Again
               </Button>

--- a/apps/web/src/components/retry-job-dialog.tsx
+++ b/apps/web/src/components/retry-job-dialog.tsx
@@ -1,6 +1,7 @@
 import { trackEvent } from '@durabull/analytics/browser'
 import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react'
+import { RetryJobPhase } from '@/components/retry-job-phase'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -10,14 +11,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-
-export const RetryJobPhase = {
-  RETRYING: 'retrying',
-  SUCCESS: 'success',
-  ERROR: 'error',
-} as const
-
-export type RetryJobPhase = (typeof RetryJobPhase)[keyof typeof RetryJobPhase]
 
 interface RetryJobDialogProps {
   open: boolean

--- a/apps/web/src/components/retry-job-phase.ts
+++ b/apps/web/src/components/retry-job-phase.ts
@@ -1,0 +1,7 @@
+export const RetryJobPhase = {
+  RETRYING: 'retrying',
+  SUCCESS: 'success',
+  ERROR: 'error',
+} as const
+
+export type RetryJobPhase = (typeof RetryJobPhase)[keyof typeof RetryJobPhase]

--- a/apps/web/src/hooks/use-job-retry-dialog.test.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useJobRetryDialog } from '@/hooks/use-job-retry-dialog'
+
+const { mutateAsyncMock } = vi.hoisted(() => ({
+  mutateAsyncMock: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-queues', () => ({
+  useRetryJobs: () => ({
+    mutateAsync: mutateAsyncMock,
+    isPending: false,
+  }),
+}))
+
+describe('useJobRetryDialog', () => {
+  beforeEach(() => {
+    mutateAsyncMock.mockReset()
+  })
+
+  it('opens dialog and runs retry from openDialog', async () => {
+    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    await waitFor(() => {
+      expect(result.current.open).toBe(true)
+    })
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      queueName: 'emails',
+      jobIds: ['job-123'],
+    })
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('success')
+    })
+  })
+
+  it('sets error phase when retry fails', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      success: 0,
+      failed: 1,
+      errors: [{ jobId: 'job-123', error: 'Job is locked' }],
+    })
+
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('error')
+      expect(result.current.errorMessage).toBe('Job is locked')
+    })
+  })
+
+  it('resets state when dialog closes', async () => {
+    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('success')
+    })
+
+    await act(() => {
+      result.current.setOpen(false)
+    })
+
+    await waitFor(() => {
+      expect(result.current.open).toBe(false)
+    })
+    expect(result.current.phase).toBe('retrying')
+    expect(result.current.errorMessage).toBeNull()
+  })
+})

--- a/apps/web/src/hooks/use-job-retry-dialog.test.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { RetryJobPhase } from '@/components/retry-job-dialog'
+import { RetryJobPhase } from '@/components/retry-job-phase'
 import { useJobRetryDialog } from '@/hooks/use-job-retry-dialog'
 
 const { mutateAsyncMock, trackEventMock } = vi.hoisted(() => ({

--- a/apps/web/src/hooks/use-job-retry-dialog.test.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.test.ts
@@ -1,9 +1,27 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RetryJobPhase } from '@/components/retry-job-dialog'
 import { useJobRetryDialog } from '@/hooks/use-job-retry-dialog'
 
-const { mutateAsyncMock } = vi.hoisted(() => ({
+const { mutateAsyncMock, trackEventMock } = vi.hoisted(() => ({
   mutateAsyncMock: vi.fn(),
+  trackEventMock: vi.fn(),
+}))
+
+vi.mock('@durabull/analytics/browser', () => ({
+  trackEvent: trackEventMock,
+}))
+
+vi.mock('@durabull/analytics/events', () => ({
+  AnalyticsEvents: {
+    DIALOG_OPENED: 'DIALOG_OPENED',
+  },
+  AnalyticsProperties: {
+    DIALOG_TYPE: 'dialog_type',
+  },
+  DialogType: {
+    RETRY_JOB: 'retry_job',
+  },
 }))
 
 vi.mock('@/hooks/use-queues', () => ({
@@ -16,6 +34,7 @@ vi.mock('@/hooks/use-queues', () => ({
 describe('useJobRetryDialog', () => {
   beforeEach(() => {
     mutateAsyncMock.mockReset()
+    trackEventMock.mockReset()
   })
 
   it('opens dialog and runs retry from openDialog', async () => {
@@ -36,7 +55,21 @@ describe('useJobRetryDialog', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.phase).toBe('success')
+      expect(result.current.phase).toBe(RetryJobPhase.SUCCESS)
+    })
+  })
+
+  it('tracks dialog opened analytics from openDialog', async () => {
+    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    expect(trackEventMock).toHaveBeenCalledWith('DIALOG_OPENED', {
+      dialog_type: 'retry_job',
     })
   })
 
@@ -54,7 +87,7 @@ describe('useJobRetryDialog', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.phase).toBe('error')
+      expect(result.current.phase).toBe(RetryJobPhase.ERROR)
       expect(result.current.errorMessage).toBe('Job is locked')
     })
   })
@@ -69,7 +102,7 @@ describe('useJobRetryDialog', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.phase).toBe('success')
+      expect(result.current.phase).toBe(RetryJobPhase.SUCCESS)
     })
 
     await act(() => {
@@ -79,7 +112,7 @@ describe('useJobRetryDialog', () => {
     await waitFor(() => {
       expect(result.current.open).toBe(false)
     })
-    expect(result.current.phase).toBe('retrying')
+    expect(result.current.phase).toBe(RetryJobPhase.RETRYING)
     expect(result.current.errorMessage).toBeNull()
   })
 })

--- a/apps/web/src/hooks/use-job-retry-dialog.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.ts
@@ -1,7 +1,7 @@
 import { trackEvent } from '@durabull/analytics/browser'
 import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { useCallback, useState } from 'react'
-import { RetryJobPhase } from '@/components/retry-job-dialog'
+import { RetryJobPhase } from '@/components/retry-job-phase'
 import { useRetryJobs } from '@/hooks/use-queues'
 
 interface JobRetryDialogState {

--- a/apps/web/src/hooks/use-job-retry-dialog.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.ts
@@ -1,0 +1,81 @@
+import { useCallback, useState } from 'react'
+import type { RetryJobPhase } from '@/components/retry-job-dialog'
+import { useRetryJobs } from '@/hooks/use-queues'
+
+interface JobRetryDialogState {
+  open: boolean
+  phase: RetryJobPhase
+  errorMessage: string | null
+}
+
+const initialState: JobRetryDialogState = {
+  open: false,
+  phase: 'retrying',
+  errorMessage: null,
+}
+
+export function useJobRetryDialog(queueName: string, jobId: string) {
+  const [state, setState] = useState(initialState)
+  const { mutateAsync: retryJobs } = useRetryJobs()
+
+  const runRetry = useCallback(async () => {
+    setState((current) => ({
+      ...current,
+      phase: 'retrying',
+      errorMessage: null,
+    }))
+
+    try {
+      const result = await retryJobs({
+        queueName,
+        jobIds: [jobId],
+      })
+
+      if (result.success > 0 && result.failed === 0) {
+        setState((current) => ({ ...current, phase: 'success' }))
+        return
+      }
+
+      const apiError =
+        result.errors.find((entry) => entry.jobId === jobId)?.error ??
+        (result.failed > 0
+          ? 'The job could not be retried.'
+          : 'The job was not in a failed state and could not be retried.')
+
+      setState((current) => ({
+        ...current,
+        phase: 'error',
+        errorMessage: apiError,
+      }))
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        phase: 'error',
+        errorMessage:
+          error instanceof Error ? error.message : 'An unexpected error occurred while retrying.',
+      }))
+    }
+  }, [jobId, queueName, retryJobs])
+
+  const openDialog = useCallback(() => {
+    setState({ ...initialState, open: true })
+    void runRetry()
+  }, [runRetry])
+
+  const setOpen = useCallback((open: boolean) => {
+    setState((current) =>
+      open
+        ? { ...current, open: true }
+        : { ...initialState }
+    )
+  }, [])
+
+  return {
+    open: state.open,
+    phase: state.phase,
+    errorMessage: state.errorMessage,
+    openDialog,
+    setOpen,
+    runRetry,
+  }
+}

--- a/apps/web/src/hooks/use-job-retry-dialog.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.ts
@@ -1,5 +1,7 @@
+import { trackEvent } from '@durabull/analytics/browser'
+import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { useCallback, useState } from 'react'
-import type { RetryJobPhase } from '@/components/retry-job-dialog'
+import { RetryJobPhase } from '@/components/retry-job-dialog'
 import { useRetryJobs } from '@/hooks/use-queues'
 
 interface JobRetryDialogState {
@@ -10,7 +12,7 @@ interface JobRetryDialogState {
 
 const initialState: JobRetryDialogState = {
   open: false,
-  phase: 'retrying',
+  phase: RetryJobPhase.RETRYING,
   errorMessage: null,
 }
 
@@ -21,7 +23,7 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
   const runRetry = useCallback(async () => {
     setState((current) => ({
       ...current,
-      phase: 'retrying',
+      phase: RetryJobPhase.RETRYING,
       errorMessage: null,
     }))
 
@@ -32,7 +34,7 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
       })
 
       if (result.success > 0 && result.failed === 0) {
-        setState((current) => ({ ...current, phase: 'success' }))
+        setState((current) => ({ ...current, phase: RetryJobPhase.SUCCESS }))
         return
       }
 
@@ -44,13 +46,13 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
 
       setState((current) => ({
         ...current,
-        phase: 'error',
+        phase: RetryJobPhase.ERROR,
         errorMessage: apiError,
       }))
     } catch (error) {
       setState((current) => ({
         ...current,
-        phase: 'error',
+        phase: RetryJobPhase.ERROR,
         errorMessage:
           error instanceof Error ? error.message : 'An unexpected error occurred while retrying.',
       }))
@@ -59,6 +61,9 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
 
   const openDialog = useCallback(() => {
     setState({ ...initialState, open: true })
+    trackEvent(AnalyticsEvents.DIALOG_OPENED, {
+      [AnalyticsProperties.DIALOG_TYPE]: DialogType.RETRY_JOB,
+    })
     void runRetry()
   }, [runRetry])
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -37,7 +37,7 @@ import { JobRemoveButton } from '@/components/job-remove-button'
 import { JsonViewer } from '@/components/json-viewer'
 import { QueueNameTag } from '@/components/queue-name-tag'
 import { RetryCountdown } from '@/components/retry-countdown'
-import { RetryJobDialog, type RetryJobPhase } from '@/components/retry-job-dialog'
+import { RetryJobDialog } from '@/components/retry-job-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -47,7 +47,8 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useConnectionAlertEvents } from '@/hooks/use-alerts'
-import { useJob, useJobLogs, useRemoveJobs, useRetryJobs } from '@/hooks/use-queues'
+import { useJobRetryDialog } from '@/hooks/use-job-retry-dialog'
+import { useJob, useJobLogs, useRemoveJobs } from '@/hooks/use-queues'
 import { cn, formatDate, formatDuration, getTimezoneAbbreviation } from '@/lib/utils'
 
 const jobSearchSchema = z.object({
@@ -76,9 +77,7 @@ function JobDetailPage() {
   const navigate = useNavigate()
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const [invokeDialogOpen, setInvokeDialogOpen] = useState(false)
-  const [retryDialogOpen, setRetryDialogOpen] = useState(false)
-  const [retryPhase, setRetryPhase] = useState<RetryJobPhase>('retrying')
-  const [retryErrorMessage, setRetryErrorMessage] = useState<string | null>(null)
+  const retryDialog = useJobRetryDialog(queueName, jobId)
 
   const { data: job, isLoading, error } = useJob(queueName, jobId)
   const { data: logsData } = useJobLogs(queueName, jobId)
@@ -89,7 +88,6 @@ function JobDetailPage() {
   })
 
   const removeMutation = useRemoveJobs()
-  const { mutateAsync: retryJobs } = useRetryJobs()
 
   // Track job view when job data is loaded
   useEffect(() => {
@@ -122,50 +120,6 @@ function JobDetailPage() {
 
   const hasFailedAttempts = (job?.stacktraceCount ?? 0) > 0
   const hasFailed = job?.status === 'failed'
-
-  const runJobRetry = useCallback(async () => {
-    setRetryPhase('retrying')
-    setRetryErrorMessage(null)
-
-    try {
-      const result = await retryJobs({
-        queueName,
-        jobIds: [jobId],
-      })
-
-      if (result.success > 0 && result.failed === 0) {
-        setRetryPhase('success')
-        return
-      }
-
-      const apiError =
-        result.errors.find((entry) => entry.jobId === jobId)?.error ??
-        (result.failed > 0
-          ? 'The job could not be retried.'
-          : 'The job was not in a failed state and could not be retried.')
-
-      setRetryErrorMessage(apiError)
-      setRetryPhase('error')
-    } catch (error) {
-      setRetryErrorMessage(
-        error instanceof Error ? error.message : 'An unexpected error occurred while retrying.'
-      )
-      setRetryPhase('error')
-    }
-  }, [jobId, queueName, retryJobs])
-
-  const handleOpenRetryDialog = useCallback(() => {
-    setRetryDialogOpen(true)
-    void runJobRetry()
-  }, [runJobRetry])
-
-  const handleRetryDialogOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setRetryPhase('retrying')
-      setRetryErrorMessage(null)
-    }
-    setRetryDialogOpen(open)
-  }, [])
 
   const isScheduledJob = jobId.startsWith('repeat:')
 
@@ -258,7 +212,7 @@ function JobDetailPage() {
             <Button
               variant="outline"
               size="xs"
-              onClick={handleOpenRetryDialog}
+              onClick={retryDialog.openDialog}
               className="border-status-success/30 text-status-success hover:bg-status-success/10 hover:text-status-success"
             >
               <RefreshCw className="mr-2 h-4 w-4" />
@@ -292,7 +246,7 @@ function JobDetailPage() {
       mobileActions: (
         <>
           {job?.status === 'failed' && (
-            <DropdownMenuItem onClick={handleOpenRetryDialog}>
+            <DropdownMenuItem onClick={retryDialog.openDialog}>
               <RefreshCw className="mr-2 h-4 w-4" />
               Retry Job
             </DropdownMenuItem>
@@ -333,7 +287,7 @@ function JobDetailPage() {
     [
       connectionId,
       handleRemove,
-      handleOpenRetryDialog,
+      retryDialog.openDialog,
       isLoading,
       job,
       orgSlug,
@@ -644,14 +598,14 @@ function JobDetailPage() {
       {/* Retry Job Dialog */}
       {job && job.status === 'failed' && (
         <RetryJobDialog
-          open={retryDialogOpen}
-          onOpenChange={handleRetryDialogOpenChange}
+          open={retryDialog.open}
+          onOpenChange={retryDialog.setOpen}
           queueName={queueName}
           jobId={job.id}
           jobName={job.name}
-          phase={retryPhase}
-          errorMessage={retryErrorMessage}
-          onRetry={() => void runJobRetry()}
+          phase={retryDialog.phase}
+          errorMessage={retryDialog.errorMessage}
+          onRetry={() => void retryDialog.runRetry()}
         />
       )}
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -37,7 +37,7 @@ import { JobRemoveButton } from '@/components/job-remove-button'
 import { JsonViewer } from '@/components/json-viewer'
 import { QueueNameTag } from '@/components/queue-name-tag'
 import { RetryCountdown } from '@/components/retry-countdown'
-import { RetryJobDialog } from '@/components/retry-job-dialog'
+import { RetryJobDialog, type RetryJobPhase } from '@/components/retry-job-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -47,7 +47,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useConnectionAlertEvents } from '@/hooks/use-alerts'
-import { useJob, useJobLogs, useRemoveJobs } from '@/hooks/use-queues'
+import { useJob, useJobLogs, useRemoveJobs, useRetryJobs } from '@/hooks/use-queues'
 import { cn, formatDate, formatDuration, getTimezoneAbbreviation } from '@/lib/utils'
 
 const jobSearchSchema = z.object({
@@ -77,6 +77,8 @@ function JobDetailPage() {
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const [invokeDialogOpen, setInvokeDialogOpen] = useState(false)
   const [retryDialogOpen, setRetryDialogOpen] = useState(false)
+  const [retryPhase, setRetryPhase] = useState<RetryJobPhase>('retrying')
+  const [retryErrorMessage, setRetryErrorMessage] = useState<string | null>(null)
 
   const { data: job, isLoading, error } = useJob(queueName, jobId)
   const { data: logsData } = useJobLogs(queueName, jobId)
@@ -87,6 +89,7 @@ function JobDetailPage() {
   })
 
   const removeMutation = useRemoveJobs()
+  const { mutateAsync: retryJobs } = useRetryJobs()
 
   // Track job view when job data is loaded
   useEffect(() => {
@@ -120,8 +123,48 @@ function JobDetailPage() {
   const hasFailedAttempts = (job?.stacktraceCount ?? 0) > 0
   const hasFailed = job?.status === 'failed'
 
+  const runJobRetry = useCallback(async () => {
+    setRetryPhase('retrying')
+    setRetryErrorMessage(null)
+
+    try {
+      const result = await retryJobs({
+        queueName,
+        jobIds: [jobId],
+      })
+
+      if (result.success > 0 && result.failed === 0) {
+        setRetryPhase('success')
+        return
+      }
+
+      const apiError =
+        result.errors.find((entry) => entry.jobId === jobId)?.error ??
+        (result.failed > 0
+          ? 'The job could not be retried.'
+          : 'The job was not in a failed state and could not be retried.')
+
+      setRetryErrorMessage(apiError)
+      setRetryPhase('error')
+    } catch (error) {
+      setRetryErrorMessage(
+        error instanceof Error ? error.message : 'An unexpected error occurred while retrying.'
+      )
+      setRetryPhase('error')
+    }
+  }, [jobId, queueName, retryJobs])
+
   const handleOpenRetryDialog = useCallback(() => {
     setRetryDialogOpen(true)
+    void runJobRetry()
+  }, [runJobRetry])
+
+  const handleRetryDialogOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setRetryPhase('retrying')
+      setRetryErrorMessage(null)
+    }
+    setRetryDialogOpen(open)
   }, [])
 
   const isScheduledJob = jobId.startsWith('repeat:')
@@ -602,10 +645,13 @@ function JobDetailPage() {
       {job && job.status === 'failed' && (
         <RetryJobDialog
           open={retryDialogOpen}
-          onOpenChange={setRetryDialogOpen}
+          onOpenChange={handleRetryDialogOpenChange}
           queueName={queueName}
           jobId={job.id}
           jobName={job.name}
+          phase={retryPhase}
+          errorMessage={retryErrorMessage}
+          onRetry={() => void runJobRetry()}
         />
       )}
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -37,6 +37,7 @@ import { JobRemoveButton } from '@/components/job-remove-button'
 import { JsonViewer } from '@/components/json-viewer'
 import { QueueNameTag } from '@/components/queue-name-tag'
 import { RetryCountdown } from '@/components/retry-countdown'
+import { RetryJobDialog } from '@/components/retry-job-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -46,7 +47,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useConnectionAlertEvents } from '@/hooks/use-alerts'
-import { useJob, useJobLogs, useRemoveJobs, useRetryJobs } from '@/hooks/use-queues'
+import { useJob, useJobLogs, useRemoveJobs } from '@/hooks/use-queues'
 import { cn, formatDate, formatDuration, getTimezoneAbbreviation } from '@/lib/utils'
 
 const jobSearchSchema = z.object({
@@ -75,6 +76,7 @@ function JobDetailPage() {
   const navigate = useNavigate()
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const [invokeDialogOpen, setInvokeDialogOpen] = useState(false)
+  const [retryDialogOpen, setRetryDialogOpen] = useState(false)
 
   const { data: job, isLoading, error } = useJob(queueName, jobId)
   const { data: logsData } = useJobLogs(queueName, jobId)
@@ -84,7 +86,6 @@ function JobDetailPage() {
     limit: 20,
   })
 
-  const retryMutation = useRetryJobs()
   const removeMutation = useRemoveJobs()
 
   // Track job view when job data is loaded
@@ -119,20 +120,9 @@ function JobDetailPage() {
   const hasFailedAttempts = (job?.stacktraceCount ?? 0) > 0
   const hasFailed = job?.status === 'failed'
 
-  const handleRetry = useCallback(() => {
-    retryMutation.mutate(
-      { queueName, jobIds: [jobId] },
-      {
-        onSuccess: () => {
-          navigate({
-            to: '/$orgSlug/c/$connectionId/queues/$queueName',
-            params: { orgSlug, connectionId, queueName },
-            search: {},
-          })
-        },
-      }
-    )
-  }, [connectionId, jobId, navigate, orgSlug, queueName, retryMutation])
+  const handleOpenRetryDialog = useCallback(() => {
+    setRetryDialogOpen(true)
+  }, [])
 
   const isScheduledJob = jobId.startsWith('repeat:')
 
@@ -225,8 +215,7 @@ function JobDetailPage() {
             <Button
               variant="outline"
               size="xs"
-              onClick={handleRetry}
-              disabled={retryMutation.isPending}
+              onClick={handleOpenRetryDialog}
               className="border-status-success/30 text-status-success hover:bg-status-success/10 hover:text-status-success"
             >
               <RefreshCw className="mr-2 h-4 w-4" />
@@ -260,7 +249,7 @@ function JobDetailPage() {
       mobileActions: (
         <>
           {job?.status === 'failed' && (
-            <DropdownMenuItem onClick={handleRetry} disabled={retryMutation.isPending}>
+            <DropdownMenuItem onClick={handleOpenRetryDialog}>
               <RefreshCw className="mr-2 h-4 w-4" />
               Retry Job
             </DropdownMenuItem>
@@ -301,13 +290,12 @@ function JobDetailPage() {
     [
       connectionId,
       handleRemove,
-      handleRetry,
+      handleOpenRetryDialog,
       isLoading,
       job,
       orgSlug,
       queueName,
       removeMutation.isPending,
-      retryMutation.isPending,
       isScheduledJob,
     ]
   )
@@ -607,6 +595,17 @@ function JobDetailPage() {
               search: {},
             })
           }}
+        />
+      )}
+
+      {/* Retry Job Dialog */}
+      {job && job.status === 'failed' && (
+        <RetryJobDialog
+          open={retryDialogOpen}
+          onOpenChange={setRetryDialogOpen}
+          queueName={queueName}
+          jobId={job.id}
+          jobName={job.name}
         />
       )}
 

--- a/apps/web/src/routes/job-detail-remove.test.tsx
+++ b/apps/web/src/routes/job-detail-remove.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { routeState, topBarState, navigateMock, removeMutateMock, retryMutateMock, trackEventMock } =
+const { routeState, topBarState, navigateMock, removeMutateMock, trackEventMock } =
   vi.hoisted(() => ({
     routeState: {
       params: {
@@ -16,7 +16,6 @@ const { routeState, topBarState, navigateMock, removeMutateMock, retryMutateMock
     topBarState: { config: null as null | { actions?: React.ReactNode } },
     navigateMock: vi.fn(),
     removeMutateMock: vi.fn(),
-    retryMutateMock: vi.fn(),
     trackEventMock: vi.fn(),
   }))
 
@@ -75,6 +74,10 @@ vi.mock('@/components/retry-countdown', () => ({
   RetryCountdown: () => null,
 }))
 
+vi.mock('@/components/retry-job-dialog', () => ({
+  RetryJobDialog: () => null,
+}))
+
 vi.mock('@/hooks/use-alerts', () => ({
   useConnectionAlertEvents: () => ({
     data: { events: [] },
@@ -116,10 +119,6 @@ vi.mock('@/hooks/use-queues', () => ({
     mutate: removeMutateMock,
     isPending: false,
   }),
-  useRetryJobs: () => ({
-    mutate: retryMutateMock,
-    isPending: false,
-  }),
 }))
 
 import { Route } from '@/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId'
@@ -131,7 +130,6 @@ describe('job detail scheduled removal', () => {
     topBarState.config = null
     navigateMock.mockReset()
     removeMutateMock.mockReset()
-    retryMutateMock.mockReset()
     trackEventMock.mockReset()
   })
 

--- a/apps/web/src/routes/job-detail-remove.test.tsx
+++ b/apps/web/src/routes/job-detail-remove.test.tsx
@@ -119,6 +119,10 @@ vi.mock('@/hooks/use-queues', () => ({
     mutate: removeMutateMock,
     isPending: false,
   }),
+  useRetryJobs: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
 }))
 
 import { Route } from '@/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId'

--- a/apps/web/src/routes/job-detail-remove.test.tsx
+++ b/apps/web/src/routes/job-detail-remove.test.tsx
@@ -85,6 +85,17 @@ vi.mock('@/hooks/use-alerts', () => ({
   }),
 }))
 
+vi.mock('@/hooks/use-job-retry-dialog', () => ({
+  useJobRetryDialog: () => ({
+    open: false,
+    phase: 'retrying',
+    errorMessage: null,
+    openDialog: vi.fn(),
+    setOpen: vi.fn(),
+    runRetry: vi.fn(),
+  }),
+}))
+
 vi.mock('@/hooks/use-queues', () => ({
   useJob: () => ({
     data: {

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -245,6 +245,7 @@ export const DialogType = {
   UNLINK_ACCOUNT: 'unlink_account',
   DELETE_REDIS_KEY: 'delete_redis_key',
   INVOKE_JOB: 'invoke_job',
+  RETRY_JOB: 'retry_job',
   DUPLICATE_JOB: 'duplicate_job',
   ADD_JOB: 'add_job',
   ADD_SCHEDULED_JOB: 'add_scheduled_job',


### PR DESCRIPTION
## Summary
- Add a `RetryJobDialog` that shows retry progress and clear success or failure feedback
- Keep users on the job detail page after retry instead of navigating back to the queue list
- Update e2e and unit tests for the new flow

## Test plan
- [x] Unit tests pass for `RetryJobDialog` and job detail page
- [ ] Click "Retry Job" on a failed job and confirm the modal shows loading, then success
- [ ] Simulate a retry failure and confirm the error state with "Try Again" works
- [ ] Confirm job status updates on the detail page after a successful retry


Made with [Cursor](https://cursor.com)

## Related issue

Closes #136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated retry dialog for failed jobs, showing clear retry, success, and error states.
  * Users can now retry a failed job from the job details page and see progress feedback during the action.

* **Bug Fixes**
  * Improved retry flow so successful retries confirm completion before returning to the job view.
  * Error states now surface clearer messaging and let users try again or close the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->