### PR TITLE
Add macOS download checksum verification

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -54,6 +54,29 @@ jobs:
         if: github.event_name == 'push'
         run: bun run dist:desktop
 
+      - name: Generate macOS SHA256 verification file
+        if: github.event_name == 'push' && runner.os == 'macOS'
+        shell: bash
+        run: |
+          shopt -s nullglob
+          dmg_assets=(apps/desktop/release/Durabull-*-arm64.dmg)
+
+          if [ ${#dmg_assets[@]} -ne 1 ]; then
+            echo "Expected one macOS arm64 DMG, found ${#dmg_assets[@]}." >&2
+            printf '%s\n' "${dmg_assets[@]}" >&2
+            exit 1
+          fi
+
+          dmg="${dmg_assets[0]}"
+          checksum_file="apps/desktop/release/durabull-macos-arm64.sha256"
+
+          (
+            cd "$(dirname "$dmg")"
+            shasum -a 256 "$(basename "$dmg")" > "$(basename "$checksum_file")"
+          )
+
+          echo "Wrote $checksum_file"
+
       - name: Wait for GitHub release
         if: github.event_name == 'push'
         shell: bash
@@ -83,6 +106,7 @@ jobs:
             apps/desktop/release/*.zip
             apps/desktop/release/*.exe
             apps/desktop/release/*.blockmap
+            apps/desktop/release/*.sha256
           )
 
           if [ ${#assets[@]} -eq 0 ]; then
@@ -107,4 +131,5 @@ jobs:
             apps/desktop/release/*.zip
             apps/desktop/release/*.exe
             apps/desktop/release/*.blockmap
+            apps/desktop/release/*.sha256
           if-no-files-found: error

--- a/apps/docs/app/docs/page.tsx
+++ b/apps/docs/app/docs/page.tsx
@@ -49,7 +49,7 @@ export default function DocsPage() {
             items: [
               'Direct Apple Silicon macOS download',
               'Windows installer and zip options',
-              'Homebrew cask command and verification steps',
+              'Visible macOS SHA-256 verification steps',
             ],
           },
           {

--- a/apps/docs/content/documentation/getting-started/desktop-apps.mdx
+++ b/apps/docs/content/documentation/getting-started/desktop-apps.mdx
@@ -13,10 +13,23 @@ If you want to self-host Durabull instead, start with
 
 | Platform | Recommended path | Notes |
 | --- | --- | --- |
-| Apple Silicon macOS | [Download the macOS app](https://github.com/durabullhq/durabull/releases/latest) | Latest GitHub release for the current arm64 macOS build. |
+| Apple Silicon macOS | [Download the macOS app](https://github.com/durabullhq/durabull/releases/latest) | Latest GitHub release for the current arm64 macOS build. Verify the download with the SHA-256 step below before opening. |
 | Windows | [Download the Windows installer](https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull.Setup.1.3.0.exe) | Best choice for standard workstation installs. |
 | Windows (portable) | [Download the Windows zip](https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull-1.3.0-win.zip) | Useful when you prefer a portable archive. |
 | Homebrew (Apple Silicon macOS) | `brew install --cask durabullhq/tap/durabull` | Good for repeatable rollout on managed Apple Silicon Mac fleets. |
+
+## Verify the macOS Download
+
+After downloading the Apple Silicon `.dmg`, download the published SHA-256 file into the
+same folder and verify it before opening the app:
+
+```bash
+curl -fsSLO https://github.com/durabullhq/durabull/releases/latest/download/durabull-macos-arm64.sha256
+shasum -a 256 -c durabull-macos-arm64.sha256
+```
+
+The command should print `OK` for the downloaded `Durabull-*-arm64.dmg`. If it does not,
+delete the file and download it again from the latest release.
 
 ## Homebrew Install
 
@@ -25,18 +38,21 @@ brew install --cask durabullhq/tap/durabull
 ```
 
 Homebrew is the cleanest option when you want a scripted or repeatable Apple Silicon macOS install
-path across a team.
+path across a team. Homebrew verifies the same DMG checksum through the Durabull cask before
+installing.
 
 ## First Launch Checklist
 
-1. Launch Durabull from your Applications folder on Apple Silicon macOS or from the Start menu on Windows.
-2. Add or select the Redis connection you want to inspect.
-3. Open **Queues Dashboard** and confirm queues load successfully.
-4. Open a queue detail or failed job view to verify the desktop app can inspect live data.
+1. On Apple Silicon macOS, mount the verified `.dmg`, drag Durabull to Applications, and run
+   `xattr -cr /Applications/Durabull.app` once if macOS blocks first launch.
+2. Launch Durabull from your Applications folder on Apple Silicon macOS or from the Start menu on Windows.
+3. Add or select the Redis connection you want to inspect.
+4. Open **Queues Dashboard** and confirm queues load successfully.
+5. Open a queue detail or failed job view to verify the desktop app can inspect live data.
 
 ## Need the Full Release Notes?
 
-For checksums, additional assets, and future release notes, see the
+For additional assets and future release notes, see the
 [latest Durabull release](https://github.com/durabullhq/durabull/releases/latest).
 
 ## Next Steps

--- a/apps/docs/src/components/v2/deploy.tsx
+++ b/apps/docs/src/components/v2/deploy.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { motion, useReducedMotion } from 'framer-motion'
-import { Check, Cloud, Laptop, Lock, Server } from 'lucide-react'
+import { Check, Cloud, Laptop, Lock, Server, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useRef } from 'react'
-import { GITHUB_RELEASE_URL, WEB_APP_URL } from '@/lib/config'
+import { GITHUB_RELEASE_URL, MAC_CHECKSUM_URL, WEB_APP_URL } from '@/lib/config'
 import { EmberField } from './ember-field'
 import { Eyebrow, Reveal } from './reveal'
 
@@ -55,7 +55,16 @@ function TiltCard({ featured, children }: { featured?: boolean; children: React.
 
 /* ---------------- deploy your way ---------------- */
 
-const modes = [
+type DeployMode = {
+  icon: LucideIcon
+  title: string
+  body: string
+  cta: { label: string; href: string }
+  featured?: boolean
+  verification?: { label: string; href: string }
+}
+
+const modes: DeployMode[] = [
   {
     icon: Cloud,
     title: 'Durabull Cloud',
@@ -74,6 +83,7 @@ const modes = [
     title: 'Desktop app',
     body: 'Native on Apple Silicon macOS and Windows. Local-first with encrypted saved connections.',
     cta: { label: 'Download', href: GITHUB_RELEASE_URL },
+    verification: { label: 'Verify macOS DMG SHA-256', href: MAC_CHECKSUM_URL },
   },
   {
     icon: Lock,
@@ -132,6 +142,14 @@ export function V2Deploy() {
                 >
                   {mode.cta.label}
                 </Link>
+                {mode.verification ? (
+                  <Link
+                    href={mode.verification.href}
+                    className="v2-mono mt-3 text-[11px] text-[var(--v2-faint)] underline decoration-[var(--v2-line-strong)] underline-offset-4 transition-colors hover:text-[var(--v2-fg)]"
+                  >
+                    {mode.verification.label}
+                  </Link>
+                ) : null}
               </TiltCard>
             </Reveal>
           ))}

--- a/apps/docs/src/components/v2/features.tsx
+++ b/apps/docs/src/components/v2/features.tsx
@@ -3,7 +3,7 @@
 import { motion, useInView, useReducedMotion } from 'framer-motion'
 import { Check, Copy, Terminal } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { HOMEBREW_INSTALL_COMMAND } from '@/lib/config'
+import { HOMEBREW_INSTALL_COMMAND, MAC_VERIFY_DOWNLOAD_COMMAND } from '@/lib/config'
 import { CornerMarks, Eyebrow, Reveal } from './reveal'
 
 /* ---------------- getting started / install ---------------- */
@@ -122,6 +122,7 @@ export function V2GettingStarted() {
           </Reveal>
           <Reveal delay={0.12} className="space-y-3">
             <CommandBlock label="macOS (Homebrew)" command={HOMEBREW_INSTALL_COMMAND} />
+            <CommandBlock label="Verify macOS DMG" command={MAC_VERIFY_DOWNLOAD_COMMAND} />
             <CommandBlock
               label="Self-hosted (Docker)"
               command="docker run -p 3000:3000 durabullhq/durabull"

--- a/apps/docs/src/components/v2/features.tsx
+++ b/apps/docs/src/components/v2/features.tsx
@@ -3,7 +3,7 @@
 import { motion, useInView, useReducedMotion } from 'framer-motion'
 import { Check, Copy, Terminal } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { HOMEBREW_INSTALL_COMMAND, MAC_VERIFY_DOWNLOAD_COMMAND } from '@/lib/config'
+import { HOMEBREW_INSTALL_COMMAND } from '@/lib/config'
 import { CornerMarks, Eyebrow, Reveal } from './reveal'
 
 /* ---------------- getting started / install ---------------- */
@@ -122,7 +122,6 @@ export function V2GettingStarted() {
           </Reveal>
           <Reveal delay={0.12} className="space-y-3">
             <CommandBlock label="macOS (Homebrew)" command={HOMEBREW_INSTALL_COMMAND} />
-            <CommandBlock label="Verify macOS DMG" command={MAC_VERIFY_DOWNLOAD_COMMAND} />
             <CommandBlock
               label="Self-hosted (Docker)"
               command="docker run -p 3000:3000 durabullhq/durabull"

--- a/apps/docs/src/lib/config.ts
+++ b/apps/docs/src/lib/config.ts
@@ -11,8 +11,11 @@ export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://durabull.io
 // Desktop distribution and release links
 export const GITHUB_RELEASE_URL = 'https://github.com/durabullhq/durabull/releases/latest'
 export const MAC_DOWNLOAD_URL = GITHUB_RELEASE_URL
+export const MAC_CHECKSUM_URL =
+  'https://github.com/durabullhq/durabull/releases/latest/download/durabull-macos-arm64.sha256'
 export const WINDOWS_DOWNLOAD_URL =
   'https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull.Setup.1.3.0.exe'
 export const WINDOWS_ZIP_DOWNLOAD_URL =
   'https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull-1.3.0-win.zip'
 export const HOMEBREW_INSTALL_COMMAND = 'brew install --cask durabullhq/tap/durabull'
+export const MAC_VERIFY_DOWNLOAD_COMMAND = `curl -fsSLO ${MAC_CHECKSUM_URL} && shasum -a 256 -c durabull-macos-arm64.sha256`

--- a/apps/docs/src/lib/config.ts
+++ b/apps/docs/src/lib/config.ts
@@ -18,4 +18,3 @@ export const WINDOWS_DOWNLOAD_URL =
 export const WINDOWS_ZIP_DOWNLOAD_URL =
   'https://github.com/durabullhq/durabull/releases/download/v1.3.0/Durabull-1.3.0-win.zip'
 export const HOMEBREW_INSTALL_COMMAND = 'brew install --cask durabullhq/tap/durabull'
-export const MAC_VERIFY_DOWNLOAD_COMMAND = `curl -fsSLO ${MAC_CHECKSUM_URL} && shasum -a 256 -c durabull-macos-arm64.sha256`


### PR DESCRIPTION
## Summary
- Publish a macOS SHA-256 sidecar during tagged desktop release builds.
- Surface macOS DMG verification on the landing page and Desktop Apps docs.
- Link the checksum asset from the desktop download card and document first-launch macOS handling.

## Test plan
- [x] `bun run --filter @durabull/docs typecheck`
- [x] `bun run --filter @durabull/docs lint`
- [x] `git diff --check`
- [x] Local `shasum -a 256 -c` checksum format smoke test

Closes #137

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS download verification for the desktop app, including a published SHA-256 checksum file and step-by-step verification instructions.
  * Added a visible verification link and command guidance in the desktop app docs and marketing sections.
* **Bug Fixes**
  * Improved the macOS install flow by clarifying the one-time launch workaround for Apple Silicon users after installation.
* **Documentation**
  * Updated desktop app installation guidance to highlight checksum verification, Homebrew rollout, and where to find the latest release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->