### PR TITLE
Fix retry job modal live feedback

### DIFF
--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -22,6 +22,18 @@ const CLEAR_RETENTION_SCHEMA = z.object({
   keepMostRecent: z.number().int().min(0).default(0),
 })
 
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function parseNonNegativeInt(value: string | undefined): number | null {
+  if (value === undefined) return null
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -388,16 +400,34 @@ const app = new Hono()
     const jobId = c.req.param('jobId')
     const pageStr = c.req.query('page')
     const pageSizeStr = c.req.query('pageSize')
+    const startStr = c.req.query('start')
 
-    const page = pageStr ? parseInt(pageStr, 10) : 1
-    const pageSize = Math.min(
-      pageSizeStr ? parseInt(pageSizeStr, 10) : DEFAULT_PAGE_SIZE,
-      MAX_PAGE_SIZE
-    )
+    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
+
+    // Offset-tail mode: return up to MAX_PAGE_SIZE lines from an absolute
+    // index, used by the retry dialog to stream lines appended after a retry.
+    if (startStr !== undefined) {
+      const startOffset = parseNonNegativeInt(startStr)
+      if (startOffset === null) {
+        return c.json({ error: 'start must be a non-negative integer' }, 400)
+      }
+
+      const logs = await queue.getJobLogs(jobId, startOffset, startOffset + MAX_PAGE_SIZE - 1)
+      const count = logs.count ?? 0
+
+      return c.json({
+        logs: logs.logs ?? [],
+        count,
+        start: startOffset,
+        hasMore: startOffset + (logs.logs?.length ?? 0) < count,
+      })
+    }
+
+    const page = parsePositiveInt(pageStr, 1)
+    const pageSize = Math.min(parsePositiveInt(pageSizeStr, DEFAULT_PAGE_SIZE), MAX_PAGE_SIZE)
     const start = (page - 1) * pageSize
     const end = start + pageSize - 1
 
-    const queue = await getQueue(connectionId, connectionUrl, queueName, connectionPrefix, redisOptions)
     // BullMQ getJobLogs accepts start and end parameters for pagination
     const logs = await queue.getJobLogs(jobId, start, end)
 

--- a/apps/web/e2e/pages.spec.ts
+++ b/apps/web/e2e/pages.spec.ts
@@ -291,7 +291,7 @@ test.describe("Pages", () => {
     ).toBeVisible();
   });
 
-  test("failed job retry shows success modal and requeues job", async ({ page }) => {
+  test("failed job retry streams status in modal and requeues job", async ({ page }) => {
     const { connectionId } = await getConnectionAndQueue(page);
     const failedJob = await findJobByStatus(page, connectionId, "failed");
 
@@ -302,12 +302,24 @@ test.describe("Pages", () => {
     await expect(retryButton).toBeVisible();
     await retryButton.click();
 
-    await expect(page.getByRole("heading", { name: "Job Retried" })).toBeVisible({
-      timeout: 10000,
-    });
-    await expect(page.getByText(/Retry succeeded/i)).toBeVisible();
+    // The modal requeues the job and starts polling status + logs. Depending
+    // on whether a worker picks the job up, it shows the live running phase
+    // or jumps straight to a terminal phase - all of them render the log
+    // stream pane.
+    await expect(
+      page.getByRole("heading", {
+        name: /Job Running|Waiting for Retry|Job Completed|Job Failed/,
+      })
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("retry-log-stream")).toBeVisible();
 
-    await page.getByRole("button", { name: "Done" }).click();
+    // The modal is closable at any point; the job keeps running server-side.
+    const dialog = page.getByRole("dialog");
+    await dialog
+      .getByRole("button", { name: /^(Close|Done)$/ })
+      .first()
+      .click();
+    await expect(dialog).not.toBeVisible();
     await expect(page).toHaveURL(
       new RegExp(
         `/${TEST_ORG_SLUG}/c/${connectionId}/queues/${failedJob.queueName}/jobs/${failedJob.jobId}`

--- a/apps/web/src/components/retry-job-dialog.test.tsx
+++ b/apps/web/src/components/retry-job-dialog.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RetryJobDialog } from '@/components/retry-job-dialog'
-import { RetryJobPhase } from '@/components/retry-job-phase'
+import { RetryJobRequestState, type useJobRetryDialog } from '@/hooks/use-job-retry-dialog'
+import type { GetJobResponse } from '@/hooks/use-queues'
 
 const { trackEventMock } = vi.hoisted(() => ({
   trackEventMock: vi.fn(),
@@ -25,74 +26,283 @@ vi.mock('@durabull/analytics/events', () => ({
   },
 }))
 
+const delayedJob = {
+  id: 'job-123',
+  name: 'send-email',
+  status: 'delayed',
+  attemptsMade: 1,
+  maxAttempts: 3,
+  processedOn: Date.now() - 1_000,
+  timestamp: Date.now() - 5_000,
+  delay: 0,
+  opts: { backoff: { type: 'fixed', delay: 30_000 } },
+} as unknown as GetJobResponse
+
+const completedJob = {
+  ...delayedJob,
+  status: 'completed',
+  failedReason: undefined,
+} as unknown as GetJobResponse
+
+const failedJob = {
+  ...delayedJob,
+  status: 'failed',
+  failedReason: 'Timeout after 30s',
+} as unknown as GetJobResponse
+
+type RetryController = ReturnType<typeof useJobRetryDialog>
+
+function makeRetryController(overrides: Partial<RetryController> = {}): RetryController {
+  return {
+    open: true,
+    requestState: RetryJobRequestState.RETRYING,
+    errorMessage: null,
+    logLines: [],
+    stillRunning: false,
+    job: null,
+    jobStatus: undefined,
+    watchError: null,
+    isWatching: false,
+    isTerminal: false,
+    openDialog: vi.fn(),
+    setOpen: vi.fn(),
+    runRetry: vi.fn(),
+    ...overrides,
+  }
+}
+
 const defaultProps = {
-  open: true,
-  onOpenChange: vi.fn(),
   queueName: 'emails',
   jobId: 'job-123',
   jobName: 'send-email',
-  phase: RetryJobPhase.RETRYING,
-  errorMessage: null,
-  onRetry: vi.fn(),
+  retry: makeRetryController(),
 }
 
 describe('RetryJobDialog', () => {
   beforeEach(() => {
     trackEventMock.mockReset()
-    defaultProps.onOpenChange.mockReset()
-    defaultProps.onRetry.mockReset()
+  })
+
+  it('shows retrying state without a log pane', () => {
+    render(<RetryJobDialog {...defaultProps} retry={makeRetryController()} />)
+
+    expect(screen.getByText('Retrying Job')).toBeInTheDocument()
+    expect(screen.queryByTestId('retry-log-stream')).not.toBeInTheDocument()
+  })
+
+  it('streams log lines while running', () => {
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          jobStatus: 'active',
+          logLines: ['processing item 1', 'processing item 2'],
+        })}
+      />
+    )
+
+    expect(screen.getByText('Job Running')).toBeInTheDocument()
+    expect(screen.getByText('processing item 1')).toBeInTheDocument()
+    expect(screen.getByText('processing item 2')).toBeInTheDocument()
+  })
+
+  it('shows waiting placeholder when no logs have arrived', () => {
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          jobStatus: 'active',
+        })}
+      />
+    )
+
+    expect(screen.getByText('Waiting for logs...')).toBeInTheDocument()
+  })
+
+  it('shows the still-running notice after the timeout', () => {
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          jobStatus: 'active',
+          stillRunning: true,
+        })}
+      />
+    )
+
+    expect(screen.getByText(/safe to close this dialog/i)).toBeInTheDocument()
+  })
+
+  it('shows the delayed state with a backoff countdown', () => {
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          job: delayedJob,
+          jobStatus: 'delayed',
+        })}
+      />
+    )
+
+    expect(screen.getByText('Waiting for Retry')).toBeInTheDocument()
+    expect(screen.getByText(/Next retry in/i)).toBeInTheDocument()
   })
 
   it('shows success state', () => {
-    render(<RetryJobDialog {...defaultProps} phase={RetryJobPhase.SUCCESS} />)
-
-    expect(screen.getByText('Job Retried')).toBeInTheDocument()
-    expect(screen.getByText(/Retry succeeded/i)).toBeInTheDocument()
-  })
-
-  it('shows error state with message', () => {
     render(
-      <RetryJobDialog {...defaultProps} phase={RetryJobPhase.ERROR} errorMessage="Job is locked" />
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          isTerminal: true,
+          job: completedJob,
+          jobStatus: 'completed',
+        })}
+      />
     )
 
-    expect(screen.getByText('Retry Failed')).toBeInTheDocument()
-    expect(screen.getByText('Job is locked')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument()
+    expect(screen.getByText('Job Completed')).toBeInTheDocument()
+    expect(screen.getByText('The job completed successfully.')).toBeInTheDocument()
+    expect(screen.queryByText('Waiting for logs...')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('retry-log-stream')).not.toBeInTheDocument()
   })
 
-  it('calls onRetry when Try Again is clicked', async () => {
+  it('hides the log stream on terminal success when no new logs arrived', () => {
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          isTerminal: true,
+          job: completedJob,
+          jobStatus: 'completed',
+          logLines: [],
+        })}
+      />
+    )
+
+    expect(screen.queryByTestId('retry-log-stream')).not.toBeInTheDocument()
+  })
+
+  it('still shows streamed logs on terminal success when present', () => {
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          isTerminal: true,
+          job: completedJob,
+          jobStatus: 'completed',
+          logLines: ['done processing'],
+        })}
+      />
+    )
+
+    expect(screen.getByTestId('retry-log-stream')).toBeInTheDocument()
+    expect(screen.getByText('done processing')).toBeInTheDocument()
+  })
+
+  it('shows failed run with reason and Retry Again', async () => {
     const user = userEvent.setup()
     const onRetry = vi.fn()
 
     render(
       <RetryJobDialog
         {...defaultProps}
-        phase={RetryJobPhase.ERROR}
-        errorMessage="Temporary failure"
-        onRetry={onRetry}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          isTerminal: true,
+          job: failedJob,
+          jobStatus: 'failed',
+          logLines: ['starting...', 'error: timeout'],
+          runRetry: onRetry,
+        })}
       />
     )
 
-    await user.click(screen.getByRole('button', { name: 'Try Again' }))
+    expect(screen.getByText('Job Failed')).toBeInTheDocument()
+    expect(screen.getByText('Timeout after 30s')).toBeInTheDocument()
+    expect(screen.getByText('error: timeout')).toBeInTheDocument()
 
+    await user.click(screen.getByRole('button', { name: 'Retry Again' }))
     expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows error state with Try Again', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.ERROR,
+          errorMessage: 'Job is locked',
+          runRetry: onRetry,
+        })}
+      />
+    )
+
+    expect(screen.getByText('Retry Failed')).toBeInTheDocument()
+    expect(screen.getByText('Job is locked')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Try Again' }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('is closable while the job is running', async () => {
+    const user = userEvent.setup()
+    const setOpen = vi.fn()
+
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          jobStatus: 'active',
+          setOpen,
+        })}
+      />
+    )
+
+    // Two "Close" buttons exist: the footer button and Radix's X icon button.
+    const [footerClose] = screen.getAllByRole('button', { name: 'Close' })
+    await user.click(footerClose)
+    expect(setOpen).toHaveBeenCalledWith(false)
   })
 
   it('closes when Done is clicked after success', async () => {
     const user = userEvent.setup()
-    const onOpenChange = vi.fn()
+    const setOpen = vi.fn()
 
-    render(<RetryJobDialog {...defaultProps} phase={RetryJobPhase.SUCCESS} onOpenChange={onOpenChange} />)
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          isTerminal: true,
+          job: completedJob,
+          jobStatus: 'completed',
+          setOpen,
+        })}
+      />
+    )
 
     await user.click(screen.getByRole('button', { name: 'Done' }))
-
-    expect(onOpenChange).toHaveBeenCalledWith(false)
-  })
-
-  it('shows retrying state while in progress', () => {
-    render(<RetryJobDialog {...defaultProps} phase={RetryJobPhase.RETRYING} />)
-
-    expect(screen.getByText('Retrying Job')).toBeInTheDocument()
-    expect(screen.getByText('Retry in progress...')).toBeInTheDocument()
+    expect(setOpen).toHaveBeenCalledWith(false)
   })
 })

--- a/apps/web/src/components/retry-job-dialog.test.tsx
+++ b/apps/web/src/components/retry-job-dialog.test.tsx
@@ -57,7 +57,7 @@ function makeRetryController(overrides: Partial<RetryController> = {}): RetryCon
     open: true,
     requestState: RetryJobRequestState.RETRYING,
     errorMessage: null,
-    logLines: [],
+    logEntries: [],
     stillRunning: false,
     job: null,
     jobStatus: undefined,
@@ -98,7 +98,10 @@ describe('RetryJobDialog', () => {
           requestState: RetryJobRequestState.WATCHING,
           isWatching: true,
           jobStatus: 'active',
-          logLines: ['processing item 1', 'processing item 2'],
+          logEntries: [
+            { id: 10, line: 'processing item 1' },
+            { id: 11, line: 'processing item 2' },
+          ],
         })}
       />
     )
@@ -186,7 +189,7 @@ describe('RetryJobDialog', () => {
           isTerminal: true,
           job: completedJob,
           jobStatus: 'completed',
-          logLines: [],
+          logEntries: [],
         })}
       />
     )
@@ -204,7 +207,7 @@ describe('RetryJobDialog', () => {
           isTerminal: true,
           job: completedJob,
           jobStatus: 'completed',
-          logLines: ['done processing'],
+          logEntries: [{ id: 20, line: 'done processing' }],
         })}
       />
     )
@@ -226,7 +229,10 @@ describe('RetryJobDialog', () => {
           isTerminal: true,
           job: failedJob,
           jobStatus: 'failed',
-          logLines: ['starting...', 'error: timeout'],
+          logEntries: [
+            { id: 30, line: 'starting...' },
+            { id: 31, line: 'error: timeout' },
+          ],
           runRetry: onRetry,
         })}
       />
@@ -282,6 +288,24 @@ describe('RetryJobDialog', () => {
     const [footerClose] = screen.getAllByRole('button', { name: 'Close' })
     await user.click(footerClose)
     expect(setOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('does not show still-running copy while a delayed job is waiting for backoff', () => {
+    render(
+      <RetryJobDialog
+        {...defaultProps}
+        retry={makeRetryController({
+          requestState: RetryJobRequestState.WATCHING,
+          isWatching: true,
+          job: delayedJob,
+          jobStatus: 'delayed',
+          stillRunning: true,
+        })}
+      />
+    )
+
+    expect(screen.getByText('Waiting for Retry')).toBeInTheDocument()
+    expect(screen.queryByText(/still running/i)).not.toBeInTheDocument()
   })
 
   it('closes when Done is clicked after success', async () => {

--- a/apps/web/src/components/retry-job-dialog.tsx
+++ b/apps/web/src/components/retry-job-dialog.tsx
@@ -15,6 +15,7 @@ import {
 import {
   RetryJobRequestState,
   isTerminalJobStatus,
+  type RetryJobLogEntry,
   type useJobRetryDialog,
 } from '@/hooks/use-job-retry-dialog'
 import type { GetJobResponse } from '@/hooks/use-queues'
@@ -93,16 +94,18 @@ function getDialogCopy({
   }
 }
 
-function LogStream({ lines, inFlight }: { lines: string[]; inFlight: boolean }) {
+function LogStream({ entries, inFlight }: { entries: RetryJobLogEntry[]; inFlight: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const entryCount = entries.length
 
-  // Pin the scroll position to the newest line whenever the stream renders.
+  // Pin the scroll position to the newest line only when new content arrives.
   useEffect(() => {
+    if (entryCount === 0) return
     const node = containerRef.current
     if (node) {
       node.scrollTop = node.scrollHeight
     }
-  })
+  }, [entryCount])
 
   return (
     <div
@@ -110,13 +113,12 @@ function LogStream({ lines, inFlight }: { lines: string[]; inFlight: boolean }) 
       data-testid="retry-log-stream"
       className="max-h-48 overflow-y-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs"
     >
-      {lines.length === 0 && inFlight ? (
+      {entries.length === 0 && inFlight ? (
         <p className="text-muted-foreground">Waiting for logs...</p>
       ) : (
-        lines.map((line, index) => (
-          // Index keys are safe here: the stream is append-only.
-          <p key={index} className="whitespace-pre-wrap break-all leading-5">
-            {line}
+        entries.map((entry) => (
+          <p key={entry.id} className="whitespace-pre-wrap break-all leading-5">
+            {entry.line}
           </p>
         ))
       )}
@@ -137,7 +139,7 @@ export function RetryJobDialog({
     retry.setOpen(nextOpen)
   }
 
-  const { requestState, jobStatus, logLines, stillRunning, job, watchError } = retry
+  const { requestState, jobStatus, logEntries, stillRunning, job, watchError } = retry
   const { title, description } = getDialogCopy({ requestState, jobStatus })
   const terminal = isTerminalJobStatus(jobStatus)
   const inFlight = requestState === RetryJobRequestState.RETRYING || (retry.isWatching && !terminal)
@@ -145,7 +147,7 @@ export function RetryJobDialog({
   const showLogs =
     retry.isWatching &&
     requestState !== RetryJobRequestState.ERROR &&
-    (inFlight || logLines.length > 0)
+    (inFlight || logEntries.length > 0)
 
   return (
     <Dialog open={retry.open} onOpenChange={handleOpenChange}>
@@ -190,11 +192,11 @@ export function RetryJobDialog({
             />
           )}
 
-          {showLogs && (inFlight || logLines.length > 0) && (
-            <LogStream lines={logLines} inFlight={inFlight} />
+          {showLogs && (inFlight || logEntries.length > 0) && (
+            <LogStream entries={logEntries} inFlight={inFlight} />
           )}
 
-          {inFlight && stillRunning && (
+          {inFlight && stillRunning && jobStatus !== JOB_STATUS.DELAYED && (
             <div className="flex items-start gap-3 rounded-lg border border-status-delayed/30 bg-status-delayed/10 px-4 py-3">
               <Info className="mt-0.5 h-4 w-4 shrink-0 text-status-delayed" />
               <p className="text-sm text-status-delayed">

--- a/apps/web/src/components/retry-job-dialog.tsx
+++ b/apps/web/src/components/retry-job-dialog.tsx
@@ -1,7 +1,8 @@
 import { trackEvent } from '@durabull/analytics/browser'
 import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
-import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react'
-import { RetryJobPhase } from '@/components/retry-job-phase'
+import { AlertCircle, CheckCircle2, Info, Loader2, RefreshCw } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { RetryCountdown } from '@/components/retry-countdown'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,63 +12,149 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  RetryJobRequestState,
+  isTerminalJobStatus,
+  type useJobRetryDialog,
+} from '@/hooks/use-job-retry-dialog'
+import type { GetJobResponse } from '@/hooks/use-queues'
+import { JOB_STATUS } from '@/lib/constants'
+
+type RetryJobDialogController = ReturnType<typeof useJobRetryDialog>
 
 interface RetryJobDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
   queueName: string
   jobId: string
   jobName: string
-  phase: RetryJobPhase
-  errorMessage: string | null
-  onRetry: () => void
+  retry: RetryJobDialogController
+}
+
+interface RetryBackoffConfig {
+  type?: 'fixed' | 'exponential'
+  delay?: number
+}
+
+function getRetryBackoff(opts: GetJobResponse['opts'] | undefined): RetryBackoffConfig | undefined {
+  const backoff = opts?.backoff
+  if (!backoff || typeof backoff !== 'object') return undefined
+
+  const record = backoff as Record<string, unknown>
+  return {
+    type: record.type === 'fixed' || record.type === 'exponential' ? record.type : undefined,
+    delay: typeof record.delay === 'number' ? record.delay : undefined,
+  }
+}
+
+function getDialogCopy({
+  requestState,
+  jobStatus,
+}: {
+  requestState: RetryJobDialogController['requestState']
+  jobStatus: RetryJobDialogController['jobStatus']
+}) {
+  if (requestState === RetryJobRequestState.RETRYING) {
+    return {
+      title: 'Retrying Job',
+      description: 'Sending this job back to the queue...',
+    }
+  }
+
+  if (requestState === RetryJobRequestState.ERROR) {
+    return {
+      title: 'Retry Failed',
+      description: 'We could not retry this job. Review the details below and try again if needed.',
+    }
+  }
+
+  if (jobStatus === JOB_STATUS.COMPLETED) {
+    return {
+      title: 'Job Completed',
+      description: 'The retried job finished successfully.',
+    }
+  }
+
+  if (jobStatus === JOB_STATUS.FAILED) {
+    return {
+      title: 'Job Failed',
+      description: 'The retried job ran but finished in a failed state.',
+    }
+  }
+
+  if (jobStatus === JOB_STATUS.DELAYED) {
+    return {
+      title: 'Waiting for Retry',
+      description: 'The attempt failed and the job is waiting for its automatic retry backoff.',
+    }
+  }
+
+  return {
+    title: 'Job Running',
+    description: 'The job was requeued. Watching status and logs until it finishes.',
+  }
+}
+
+function LogStream({ lines, inFlight }: { lines: string[]; inFlight: boolean }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Pin the scroll position to the newest line whenever the stream renders.
+  useEffect(() => {
+    const node = containerRef.current
+    if (node) {
+      node.scrollTop = node.scrollHeight
+    }
+  })
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="retry-log-stream"
+      className="max-h-48 overflow-y-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs"
+    >
+      {lines.length === 0 && inFlight ? (
+        <p className="text-muted-foreground">Waiting for logs...</p>
+      ) : (
+        lines.map((line, index) => (
+          // Index keys are safe here: the stream is append-only.
+          <p key={index} className="whitespace-pre-wrap break-all leading-5">
+            {line}
+          </p>
+        ))
+      )}
+    </div>
+  )
 }
 
 export function RetryJobDialog({
-  open,
-  onOpenChange,
   queueName,
   jobId,
   jobName,
-  phase,
-  errorMessage,
-  onRetry,
+  retry,
 }: RetryJobDialogProps) {
   const handleOpenChange = (nextOpen: boolean) => {
     trackEvent(nextOpen ? AnalyticsEvents.DIALOG_OPENED : AnalyticsEvents.DIALOG_CLOSED, {
       [AnalyticsProperties.DIALOG_TYPE]: DialogType.RETRY_JOB,
     })
-    onOpenChange(nextOpen)
+    retry.setOpen(nextOpen)
   }
 
-  const title =
-    phase === RetryJobPhase.RETRYING
-      ? 'Retrying Job'
-      : phase === RetryJobPhase.SUCCESS
-        ? 'Job Retried'
-        : 'Retry Failed'
-
-  const description =
-    phase === RetryJobPhase.RETRYING
-      ? 'Sending this job back to the queue. This usually takes just a moment.'
-      : phase === RetryJobPhase.SUCCESS
-        ? 'The job was requeued successfully and should start processing again soon.'
-        : 'We could not retry this job. Review the details below and try again if needed.'
+  const { requestState, jobStatus, logLines, stillRunning, job, watchError } = retry
+  const { title, description } = getDialogCopy({ requestState, jobStatus })
+  const terminal = isTerminalJobStatus(jobStatus)
+  const inFlight = requestState === RetryJobRequestState.RETRYING || (retry.isWatching && !terminal)
+  const failedReason = jobStatus === JOB_STATUS.FAILED ? (job?.failedReason ?? null) : null
+  const showLogs =
+    retry.isWatching &&
+    requestState !== RetryJobRequestState.ERROR &&
+    (inFlight || logLines.length > 0)
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen && phase === RetryJobPhase.RETRYING) return
-        handleOpenChange(nextOpen)
-      }}
-    >
-      <DialogContent className="sm:max-w-[480px]">
+    <Dialog open={retry.open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            {phase === RetryJobPhase.RETRYING ? (
+            {inFlight ? (
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-            ) : phase === RetryJobPhase.SUCCESS ? (
+            ) : jobStatus === JOB_STATUS.COMPLETED ? (
               <CheckCircle2 className="h-5 w-5 text-status-success" />
             ) : (
               <AlertCircle className="h-5 w-5 text-status-danger" />
@@ -90,45 +177,79 @@ export function RetryJobDialog({
             </div>
           </div>
 
-          {phase === RetryJobPhase.RETRYING && (
-            <div className="flex items-center gap-3 rounded-lg border border-border/70 bg-background/60 px-4 py-3">
-              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">Retry in progress...</p>
-            </div>
+          {jobStatus === JOB_STATUS.DELAYED && job && (
+            <RetryCountdown
+              processedOn={job.processedOn ?? undefined}
+              finishedOn={job.finishedOn ?? undefined}
+              attemptsMade={job.attemptsMade}
+              maxAttempts={job.maxAttempts}
+              backoff={getRetryBackoff(job.opts)}
+              status={job.status}
+              timestamp={job.timestamp}
+              delay={job.delay}
+            />
           )}
 
-          {phase === RetryJobPhase.SUCCESS && (
-            <div className="rounded-lg border border-status-success/30 bg-status-success/10 px-4 py-3">
-              <p className="text-sm text-status-success">
-                Retry succeeded. The job status on this page will update shortly.
+          {showLogs && (inFlight || logLines.length > 0) && (
+            <LogStream lines={logLines} inFlight={inFlight} />
+          )}
+
+          {inFlight && stillRunning && (
+            <div className="flex items-start gap-3 rounded-lg border border-status-delayed/30 bg-status-delayed/10 px-4 py-3">
+              <Info className="mt-0.5 h-4 w-4 shrink-0 text-status-delayed" />
+              <p className="text-sm text-status-delayed">
+                This job is still running. It's safe to close this dialog — the job will keep
+                running in the background.
               </p>
             </div>
           )}
 
-          {phase === RetryJobPhase.ERROR && errorMessage && (
+          {watchError && (
             <div className="rounded-lg border border-status-danger/30 bg-status-danger/10 px-4 py-3">
-              <p className="text-sm text-status-danger">{errorMessage}</p>
+              <p className="text-sm text-status-danger">
+                Could not refresh this job yet. Retrying automatically...
+              </p>
+            </div>
+          )}
+
+          {jobStatus === JOB_STATUS.COMPLETED && (
+            <div className="rounded-lg border border-status-success/30 bg-status-success/10 px-4 py-3">
+              <p className="text-sm text-status-success">The job completed successfully.</p>
+            </div>
+          )}
+
+          {jobStatus === JOB_STATUS.FAILED && (
+            <div className="rounded-lg border border-status-danger/30 bg-status-danger/10 px-4 py-3">
+              <p className="text-sm font-medium text-status-danger mb-1">The job failed again.</p>
+              {failedReason && (
+                <p className="font-mono text-xs text-status-danger break-all whitespace-pre-wrap">
+                  {failedReason}
+                </p>
+              )}
+            </div>
+          )}
+
+          {requestState === RetryJobRequestState.ERROR && retry.errorMessage && (
+            <div className="rounded-lg border border-status-danger/30 bg-status-danger/10 px-4 py-3">
+              <p className="text-sm text-status-danger">{retry.errorMessage}</p>
             </div>
           )}
         </div>
 
         <DialogFooter>
-          {phase === RetryJobPhase.RETRYING ? (
-            <Button variant="outline" disabled>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Retrying...
-            </Button>
-          ) : phase === RetryJobPhase.SUCCESS ? (
+          {jobStatus === JOB_STATUS.COMPLETED ? (
             <Button onClick={() => handleOpenChange(false)}>Done</Button>
           ) : (
             <>
               <Button variant="outline" onClick={() => handleOpenChange(false)}>
                 Close
               </Button>
-              <Button onClick={onRetry}>
-                <RefreshCw className="mr-2 h-4 w-4" />
-                Try Again
-              </Button>
+              {(jobStatus === JOB_STATUS.FAILED || requestState === RetryJobRequestState.ERROR) && (
+                <Button onClick={() => void retry.runRetry()}>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  {jobStatus === JOB_STATUS.FAILED ? 'Retry Again' : 'Try Again'}
+                </Button>
+              )}
             </>
           )}
         </DialogFooter>

--- a/apps/web/src/components/retry-job-phase.ts
+++ b/apps/web/src/components/retry-job-phase.ts
@@ -1,7 +1,0 @@
-export const RetryJobPhase = {
-  RETRYING: 'retrying',
-  SUCCESS: 'success',
-  ERROR: 'error',
-} as const
-
-export type RetryJobPhase = (typeof RetryJobPhase)[keyof typeof RetryJobPhase]

--- a/apps/web/src/hooks/use-job-retry-dialog.test.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.test.ts
@@ -157,6 +157,29 @@ describe('useJobRetryDialog', () => {
     })
   })
 
+  it('still submits the retry when the auxiliary log snapshot fails', async () => {
+    fetchQueryMock.mockRejectedValue(new Error('logs unavailable'))
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      queueName: 'emails',
+      jobIds: ['job-123'],
+    })
+    await waitFor(() => {
+      expect(result.current.requestState).toBe(RetryJobRequestState.WATCHING)
+      expect(useJobLogTailMock).toHaveBeenLastCalledWith(
+        'emails',
+        'job-123',
+        0,
+        expect.objectContaining({ enabled: true, refetchInterval: 1000 })
+      )
+    })
+  })
+
   it('derives status from the polled job query instead of mirroring phases', async () => {
     const { result, rerender } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
     await act(async () => {
@@ -180,7 +203,10 @@ describe('useJobRetryDialog', () => {
     rerender()
 
     await waitFor(() => {
-      expect(result.current.logLines).toEqual(['line 1', 'line 2'])
+      expect(result.current.logEntries).toEqual([
+        { id: 2, line: 'line 1' },
+        { id: 3, line: 'line 2' },
+      ])
     })
     expect(useJobLogTailMock).toHaveBeenLastCalledWith(
       'emails',
@@ -250,8 +276,34 @@ describe('useJobRetryDialog', () => {
 
     expect(result.current.open).toBe(false)
     expect(result.current.requestState).toBe(RetryJobRequestState.IDLE)
-    expect(result.current.logLines).toEqual([])
+    expect(result.current.logEntries).toEqual([])
     expect(invalidateQueriesMock).toHaveBeenCalled()
+  })
+
+  it('ignores stale retry completions after the dialog closes', async () => {
+    let resolveSnapshot: (value: { logs: string[]; count: number; start: number; hasMore: boolean }) => void
+    fetchQueryMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSnapshot = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+
+    act(() => {
+      result.current.openDialog()
+    })
+    await act(() => {
+      result.current.setOpen(false)
+    })
+    await act(async () => {
+      resolveSnapshot({ logs: [], count: 2, start: 0, hasMore: false })
+      await Promise.resolve()
+    })
+
+    expect(mutateAsyncMock).not.toHaveBeenCalled()
+    expect(result.current.open).toBe(false)
+    expect(result.current.requestState).toBe(RetryJobRequestState.IDLE)
   })
 
   it('tracks dialog opened analytics from openDialog', async () => {

--- a/apps/web/src/hooks/use-job-retry-dialog.test.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.test.ts
@@ -1,11 +1,25 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { RetryJobPhase } from '@/components/retry-job-phase'
-import { useJobRetryDialog } from '@/hooks/use-job-retry-dialog'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RetryJobRequestState, useJobRetryDialog } from '@/hooks/use-job-retry-dialog'
 
-const { mutateAsyncMock, trackEventMock } = vi.hoisted(() => ({
+const {
+  mutateAsyncMock,
+  trackEventMock,
+  fetchQueryMock,
+  invalidateQueriesMock,
+  useJobMock,
+  useJobLogTailMock,
+  fetchJobLogTailMock,
+  logTailRefetchMock,
+} = vi.hoisted(() => ({
   mutateAsyncMock: vi.fn(),
   trackEventMock: vi.fn(),
+  fetchQueryMock: vi.fn(),
+  invalidateQueriesMock: vi.fn(),
+  useJobMock: vi.fn(),
+  useJobLogTailMock: vi.fn(),
+  fetchJobLogTailMock: vi.fn(),
+  logTailRefetchMock: vi.fn(),
 }))
 
 vi.mock('@durabull/analytics/browser', () => ({
@@ -24,46 +38,224 @@ vi.mock('@durabull/analytics/events', () => ({
   },
 }))
 
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    fetchQuery: fetchQueryMock,
+    invalidateQueries: invalidateQueriesMock,
+  }),
+}))
+
 vi.mock('@/hooks/use-queues', () => ({
+  fetchJobLogTail: fetchJobLogTailMock,
+  useJob: useJobMock,
+  useJobLogTail: useJobLogTailMock,
   useRetryJobs: () => ({
     mutateAsync: mutateAsyncMock,
     isPending: false,
   }),
+  useConnectionIdFromContextOrRoute: () => 'conn-1',
+  queryKeys: {
+    job: (connectionId: string, queueName: string, jobId: string) => [
+      'job',
+      connectionId,
+      queueName,
+      jobId,
+    ],
+    jobLogs: (connectionId: string, queueName: string, jobId: string) => [
+      'job',
+      connectionId,
+      queueName,
+      jobId,
+      'logs',
+    ],
+    jobLogTail: (connectionId: string, queueName: string, jobId: string, start: number) => [
+      'job',
+      connectionId,
+      queueName,
+      jobId,
+      'logs',
+      'tail',
+      start,
+    ],
+    queue: (connectionId: string, queueName: string) => ['queue', connectionId, queueName],
+  },
 }))
+
+function makeJob(status: string, extra: Record<string, unknown> = {}) {
+  return {
+    id: 'job-123',
+    name: 'send-email',
+    status,
+    attemptsMade: 1,
+    maxAttempts: 3,
+    timestamp: Date.now(),
+    delay: 0,
+    ...extra,
+  }
+}
+
+let jobData: ReturnType<typeof makeJob> | null
+let jobError: Error | null
+let logTailData: { logs: string[]; count: number; start: number; hasMore: boolean } | undefined
+let logTailError: Error | null
 
 describe('useJobRetryDialog', () => {
   beforeEach(() => {
     mutateAsyncMock.mockReset()
     trackEventMock.mockReset()
+    fetchQueryMock.mockReset()
+    invalidateQueriesMock.mockReset()
+    useJobMock.mockReset()
+    useJobLogTailMock.mockReset()
+    fetchJobLogTailMock.mockReset()
+    logTailRefetchMock.mockReset()
+    jobData = null
+    jobError = null
+    logTailData = undefined
+    logTailError = null
+    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+    fetchQueryMock.mockResolvedValue({ logs: [], count: 2, start: 0, hasMore: false })
+    fetchJobLogTailMock.mockResolvedValue({ logs: [], count: 2, start: 0, hasMore: false })
+    logTailRefetchMock.mockResolvedValue({ data: { logs: [], count: 2, start: 2, hasMore: false } })
+    useJobMock.mockImplementation(() => ({ data: jobData, error: jobError }))
+    useJobLogTailMock.mockImplementation(() => ({
+      data: logTailData,
+      error: logTailError,
+      refetch: logTailRefetchMock,
+    }))
   })
 
-  it('opens dialog and runs retry from openDialog', async () => {
-    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
 
+  it('opens, snapshots log count, retries, and enters watching state', async () => {
     const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
 
     await act(async () => {
       result.current.openDialog()
     })
 
-    await waitFor(() => {
-      expect(result.current.open).toBe(true)
-    })
+    expect(result.current.open).toBe(true)
+    expect(fetchQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['job', 'conn-1', 'emails', 'job-123', 'logs', 'tail', 0],
+      })
+    )
     expect(mutateAsyncMock).toHaveBeenCalledWith({
       queueName: 'emails',
       jobIds: ['job-123'],
     })
-
     await waitFor(() => {
-      expect(result.current.phase).toBe(RetryJobPhase.SUCCESS)
+      expect(result.current.requestState).toBe(RetryJobRequestState.WATCHING)
+      expect(useJobLogTailMock).toHaveBeenLastCalledWith(
+        'emails',
+        'job-123',
+        2,
+        expect.objectContaining({ enabled: true, refetchInterval: 1000 })
+      )
     })
   })
 
-  it('tracks dialog opened analytics from openDialog', async () => {
-    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+  it('derives status from the polled job query instead of mirroring phases', async () => {
+    const { result, rerender } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    jobData = makeJob('active')
+    rerender()
+
+    expect(result.current.jobStatus).toBe('active')
+    expect(result.current.isTerminal).toBe(false)
+  })
+
+  it('appends tail logs and advances the next tail offset', async () => {
+    const { result, rerender } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    logTailData = { logs: ['line 1', 'line 2'], count: 4, start: 2, hasMore: false }
+    rerender()
+
+    await waitFor(() => {
+      expect(result.current.logLines).toEqual(['line 1', 'line 2'])
+    })
+    expect(useJobLogTailMock).toHaveBeenLastCalledWith(
+      'emails',
+      'job-123',
+      4,
+      expect.objectContaining({ enabled: true, refetchInterval: 1000 })
+    )
+  })
+
+  it('sets stillRunning after 60s of non-terminal polling', async () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+    await act(async () => {
+      await result.current.runRetry()
+    })
+    expect(result.current.requestState).toBe(RetryJobRequestState.WATCHING)
+
+    expect(result.current.stillRunning).toBe(false)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(result.current.stillRunning).toBe(true)
+    expect(result.current.requestState).toBe(RetryJobRequestState.WATCHING)
+    vi.useRealTimers()
+  })
+
+  it('sets error phase when the retry request fails', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      success: 0,
+      failed: 1,
+      errors: [{ jobId: 'job-123', error: 'Job is locked' }],
+    })
 
     const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+    await act(async () => {
+      result.current.openDialog()
+    })
 
+    await waitFor(() => {
+      expect(result.current.requestState).toBe(RetryJobRequestState.ERROR)
+      expect(result.current.errorMessage).toBe('Job is locked')
+    })
+  })
+
+  it('surfaces polling errors without retrying the mutation or deleting anything', async () => {
+    const { result, rerender } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    jobError = new Error('poll failed')
+    rerender()
+
+    expect(result.current.watchError).toBe('poll failed')
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops polling, invalidates, and resets state when dialog closes', async () => {
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
+    await act(async () => {
+      result.current.openDialog()
+    })
+
+    await act(() => {
+      result.current.setOpen(false)
+    })
+
+    expect(result.current.open).toBe(false)
+    expect(result.current.requestState).toBe(RetryJobRequestState.IDLE)
+    expect(result.current.logLines).toEqual([])
+    expect(invalidateQueriesMock).toHaveBeenCalled()
+  })
+
+  it('tracks dialog opened analytics from openDialog', async () => {
+    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
     await act(async () => {
       result.current.openDialog()
     })
@@ -73,46 +265,19 @@ describe('useJobRetryDialog', () => {
     })
   })
 
-  it('sets error phase when retry fails', async () => {
-    mutateAsyncMock.mockResolvedValue({
-      success: 0,
-      failed: 1,
-      errors: [{ jobId: 'job-123', error: 'Job is locked' }],
-    })
-
-    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
-
+  it('refetches final logs and invalidates cache when the watched job becomes terminal', async () => {
+    const { result, rerender } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
     await act(async () => {
       result.current.openDialog()
     })
 
+    jobData = makeJob('completed')
+    rerender()
+
+    expect(result.current.isTerminal).toBe(true)
+    expect(logTailRefetchMock).toHaveBeenCalled()
     await waitFor(() => {
-      expect(result.current.phase).toBe(RetryJobPhase.ERROR)
-      expect(result.current.errorMessage).toBe('Job is locked')
+      expect(invalidateQueriesMock).toHaveBeenCalled()
     })
-  })
-
-  it('resets state when dialog closes', async () => {
-    mutateAsyncMock.mockResolvedValue({ success: 1, failed: 0, errors: [] })
-
-    const { result } = renderHook(() => useJobRetryDialog('emails', 'job-123'))
-
-    await act(async () => {
-      result.current.openDialog()
-    })
-
-    await waitFor(() => {
-      expect(result.current.phase).toBe(RetryJobPhase.SUCCESS)
-    })
-
-    await act(() => {
-      result.current.setOpen(false)
-    })
-
-    await waitFor(() => {
-      expect(result.current.open).toBe(false)
-    })
-    expect(result.current.phase).toBe(RetryJobPhase.RETRYING)
-    expect(result.current.errorMessage).toBeNull()
   })
 })

--- a/apps/web/src/hooks/use-job-retry-dialog.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.ts
@@ -1,7 +1,7 @@
 import { trackEvent } from '@durabull/analytics/browser'
 import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
 import { useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   fetchJobLogTail,
   type JobLogTailResponse,
@@ -15,6 +15,11 @@ import { JOB_STATUS, type JobStatus } from '@/lib/constants'
 
 const POLL_INTERVAL_MS = 1_000
 const STILL_RUNNING_AFTER_MS = 60_000
+
+export interface RetryJobLogEntry {
+  id: number
+  line: string
+}
 
 export const RetryJobRequestState = {
   IDLE: 'idle',
@@ -31,7 +36,7 @@ interface JobRetryDialogState {
   requestState: RetryJobRequestState
   errorMessage: string | null
   logStart: number | null
-  logLines: string[]
+  logEntries: RetryJobLogEntry[]
   stillRunning: boolean
 }
 
@@ -40,7 +45,7 @@ const initialState: JobRetryDialogState = {
   requestState: RetryJobRequestState.IDLE,
   errorMessage: null,
   logStart: null,
-  logLines: [],
+  logEntries: [],
   stillRunning: false,
 }
 
@@ -60,9 +65,18 @@ function getRetryErrorMessage(
   )
 }
 
-function appendUniqueLogLines(current: string[], tail: JobLogTailResponse | undefined): string[] {
+function appendLogEntries(
+  current: RetryJobLogEntry[],
+  tail: JobLogTailResponse | undefined
+): RetryJobLogEntry[] {
   if (!tail?.logs.length) return current
-  return [...current, ...tail.logs]
+  return [
+    ...current,
+    ...tail.logs.map((line, index) => ({
+      id: tail.start + index,
+      line,
+    })),
+  ]
 }
 
 export function useJobRetryDialog(queueName: string, jobId: string) {
@@ -70,8 +84,9 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
   const { mutateAsync: retryJobs } = useRetryJobs()
   const queryClient = useQueryClient()
   const connectionId = useConnectionIdFromContextOrRoute()
+  const retryRunIdRef = useRef(0)
   const isWatching = state.requestState === RetryJobRequestState.WATCHING
-  const logOffset = state.logStart == null ? null : state.logStart + state.logLines.length
+  const logOffset = state.logStart == null ? null : state.logStart + state.logEntries.length
 
   const jobQuery = useJob(queueName, jobId, {
     enabled: isWatching,
@@ -93,6 +108,9 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
   }, [connectionId, jobId, queryClient, queueName])
 
   const runRetry = useCallback(async () => {
+    const retryRunId = retryRunIdRef.current + 1
+    retryRunIdRef.current = retryRunId
+
     setState((current) => ({
       ...initialState,
       open: current.open,
@@ -104,21 +122,32 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
         throw new Error('Connection is still loading. Try again in a moment.')
       }
 
-      const snapshot = await queryClient.fetchQuery({
-        queryKey: queryKeys.jobLogTail(connectionId ?? '', queueName, jobId, 0),
-        queryFn: () => fetchJobLogTail({ connectionId, queueName, jobId, start: 0 }),
-      })
+      let logStart = 0
+      try {
+        const snapshot = await queryClient.fetchQuery({
+          queryKey: queryKeys.jobLogTail(connectionId, queueName, jobId, 0),
+          queryFn: () => fetchJobLogTail({ connectionId, queueName, jobId, start: 0 }),
+        })
+        logStart = snapshot.count
+      } catch {
+        // Log history is auxiliary; a transient log read failure must not
+        // prevent the actual retry request from being submitted.
+      }
+
+      if (retryRunIdRef.current !== retryRunId) return
 
       const result = await retryJobs({
         queueName,
         jobIds: [jobId],
       })
 
+      if (retryRunIdRef.current !== retryRunId) return
+
       if (result.success > 0 && result.failed === 0) {
         setState((current) => ({
           ...current,
           requestState: RetryJobRequestState.WATCHING,
-          logStart: snapshot.count,
+          logStart,
         }))
         return
       }
@@ -129,6 +158,8 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
         errorMessage: getRetryErrorMessage(result, jobId),
       }))
     } catch (error) {
+      if (retryRunIdRef.current !== retryRunId) return
+
       setState((current) => ({
         ...current,
         requestState: RetryJobRequestState.ERROR,
@@ -153,6 +184,7 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
         return
       }
       // Closing never cancels the job; it keeps running server-side.
+      retryRunIdRef.current += 1
       invalidateJobQueries()
       setState({ ...initialState })
     },
@@ -174,11 +206,11 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
     setState((current) => {
       if (current.requestState !== RetryJobRequestState.WATCHING) return current
       const currentOffset =
-        current.logStart == null ? null : current.logStart + current.logLines.length
+        current.logStart == null ? null : current.logStart + current.logEntries.length
       if (currentOffset !== logTailQuery.data.start) return current
       return {
         ...current,
-        logLines: appendUniqueLogLines(current.logLines, logTailQuery.data),
+        logEntries: appendLogEntries(current.logEntries, logTailQuery.data),
       }
     })
   }, [logOffset, logTailQuery.data])
@@ -201,7 +233,7 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
     open: state.open,
     requestState: state.requestState,
     errorMessage: state.errorMessage,
-    logLines: state.logLines,
+    logEntries: state.logEntries,
     stillRunning: state.stillRunning,
     job,
     jobStatus,

--- a/apps/web/src/hooks/use-job-retry-dialog.ts
+++ b/apps/web/src/hooks/use-job-retry-dialog.ts
@@ -1,63 +1,142 @@
 import { trackEvent } from '@durabull/analytics/browser'
 import { AnalyticsEvents, AnalyticsProperties, DialogType } from '@durabull/analytics/events'
-import { useCallback, useState } from 'react'
-import { RetryJobPhase } from '@/components/retry-job-phase'
-import { useRetryJobs } from '@/hooks/use-queues'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  fetchJobLogTail,
+  type JobLogTailResponse,
+  queryKeys,
+  useJob,
+  useJobLogTail,
+  useConnectionIdFromContextOrRoute,
+  useRetryJobs,
+} from '@/hooks/use-queues'
+import { JOB_STATUS, type JobStatus } from '@/lib/constants'
+
+const POLL_INTERVAL_MS = 1_000
+const STILL_RUNNING_AFTER_MS = 60_000
+
+export const RetryJobRequestState = {
+  IDLE: 'idle',
+  RETRYING: 'retrying',
+  WATCHING: 'watching',
+  ERROR: 'error',
+} as const
+
+export type RetryJobRequestState =
+  (typeof RetryJobRequestState)[keyof typeof RetryJobRequestState]
 
 interface JobRetryDialogState {
   open: boolean
-  phase: RetryJobPhase
+  requestState: RetryJobRequestState
   errorMessage: string | null
+  logStart: number | null
+  logLines: string[]
+  stillRunning: boolean
 }
 
 const initialState: JobRetryDialogState = {
   open: false,
-  phase: RetryJobPhase.RETRYING,
+  requestState: RetryJobRequestState.IDLE,
   errorMessage: null,
+  logStart: null,
+  logLines: [],
+  stillRunning: false,
+}
+
+export function isTerminalJobStatus(status: string | undefined): boolean {
+  return status === JOB_STATUS.COMPLETED || status === JOB_STATUS.FAILED
+}
+
+function getRetryErrorMessage(
+  result: { failed: number; errors: Array<{ jobId: string; error: string }> },
+  jobId: string
+): string {
+  return (
+    result.errors.find((entry) => entry.jobId === jobId)?.error ??
+    (result.failed > 0
+      ? 'The job could not be retried.'
+      : 'The job was not in a failed state and could not be retried.')
+  )
+}
+
+function appendUniqueLogLines(current: string[], tail: JobLogTailResponse | undefined): string[] {
+  if (!tail?.logs.length) return current
+  return [...current, ...tail.logs]
 }
 
 export function useJobRetryDialog(queueName: string, jobId: string) {
   const [state, setState] = useState(initialState)
   const { mutateAsync: retryJobs } = useRetryJobs()
+  const queryClient = useQueryClient()
+  const connectionId = useConnectionIdFromContextOrRoute()
+  const isWatching = state.requestState === RetryJobRequestState.WATCHING
+  const logOffset = state.logStart == null ? null : state.logStart + state.logLines.length
+
+  const jobQuery = useJob(queueName, jobId, {
+    enabled: isWatching,
+    refetchInterval: isWatching ? POLL_INTERVAL_MS : false,
+  })
+  const job = jobQuery.data ?? null
+  const terminal = isTerminalJobStatus(job?.status)
+  const logTailQuery = useJobLogTail(queueName, jobId, logOffset, {
+    enabled: isWatching,
+    refetchInterval: isWatching && !terminal ? POLL_INTERVAL_MS : false,
+  })
+
+  const invalidateJobQueries = useCallback(() => {
+    if (!connectionId) return
+    queryClient.invalidateQueries({ queryKey: queryKeys.job(connectionId, queueName, jobId) })
+    queryClient.invalidateQueries({ queryKey: queryKeys.jobLogs(connectionId, queueName, jobId) })
+    queryClient.invalidateQueries({ queryKey: ['jobs', connectionId, queueName] })
+    queryClient.invalidateQueries({ queryKey: queryKeys.queue(connectionId, queueName) })
+  }, [connectionId, jobId, queryClient, queueName])
 
   const runRetry = useCallback(async () => {
     setState((current) => ({
-      ...current,
-      phase: RetryJobPhase.RETRYING,
-      errorMessage: null,
+      ...initialState,
+      open: current.open,
+      requestState: RetryJobRequestState.RETRYING,
     }))
 
     try {
+      if (!connectionId) {
+        throw new Error('Connection is still loading. Try again in a moment.')
+      }
+
+      const snapshot = await queryClient.fetchQuery({
+        queryKey: queryKeys.jobLogTail(connectionId ?? '', queueName, jobId, 0),
+        queryFn: () => fetchJobLogTail({ connectionId, queueName, jobId, start: 0 }),
+      })
+
       const result = await retryJobs({
         queueName,
         jobIds: [jobId],
       })
 
       if (result.success > 0 && result.failed === 0) {
-        setState((current) => ({ ...current, phase: RetryJobPhase.SUCCESS }))
+        setState((current) => ({
+          ...current,
+          requestState: RetryJobRequestState.WATCHING,
+          logStart: snapshot.count,
+        }))
         return
       }
 
-      const apiError =
-        result.errors.find((entry) => entry.jobId === jobId)?.error ??
-        (result.failed > 0
-          ? 'The job could not be retried.'
-          : 'The job was not in a failed state and could not be retried.')
-
       setState((current) => ({
         ...current,
-        phase: RetryJobPhase.ERROR,
-        errorMessage: apiError,
+        requestState: RetryJobRequestState.ERROR,
+        errorMessage: getRetryErrorMessage(result, jobId),
       }))
     } catch (error) {
       setState((current) => ({
         ...current,
-        phase: RetryJobPhase.ERROR,
+        requestState: RetryJobRequestState.ERROR,
         errorMessage:
           error instanceof Error ? error.message : 'An unexpected error occurred while retrying.',
       }))
     }
-  }, [jobId, queueName, retryJobs])
+  }, [connectionId, jobId, queryClient, queueName, retryJobs])
 
   const openDialog = useCallback(() => {
     setState({ ...initialState, open: true })
@@ -67,18 +146,68 @@ export function useJobRetryDialog(queueName: string, jobId: string) {
     void runRetry()
   }, [runRetry])
 
-  const setOpen = useCallback((open: boolean) => {
-    setState((current) =>
-      open
-        ? { ...current, open: true }
-        : { ...initialState }
-    )
-  }, [])
+  const setOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        setState((current) => ({ ...current, open: true }))
+        return
+      }
+      // Closing never cancels the job; it keeps running server-side.
+      invalidateJobQueries()
+      setState({ ...initialState })
+    },
+    [invalidateJobQueries]
+  )
+
+  useEffect(() => {
+    if (!isWatching || terminal) return
+    const timer = setTimeout(() => {
+      setState((current) => ({ ...current, stillRunning: true }))
+    }, STILL_RUNNING_AFTER_MS)
+
+    return () => clearTimeout(timer)
+  }, [isWatching, terminal])
+
+  useEffect(() => {
+    if (!logTailQuery.data || logOffset == null) return
+
+    setState((current) => {
+      if (current.requestState !== RetryJobRequestState.WATCHING) return current
+      const currentOffset =
+        current.logStart == null ? null : current.logStart + current.logLines.length
+      if (currentOffset !== logTailQuery.data.start) return current
+      return {
+        ...current,
+        logLines: appendUniqueLogLines(current.logLines, logTailQuery.data),
+      }
+    })
+  }, [logOffset, logTailQuery.data])
+
+  useEffect(() => {
+    if (!terminal || !isWatching || logOffset == null) return
+
+    void logTailQuery.refetch().finally(() => {
+      invalidateJobQueries()
+    })
+  }, [invalidateJobQueries, isWatching, logOffset, logTailQuery.refetch, terminal])
+
+  const jobStatus = job?.status as JobStatus | undefined
+
+  const logTailError = logTailQuery.error instanceof Error ? logTailQuery.error.message : null
+  const jobPollError = jobQuery.error instanceof Error ? jobQuery.error.message : null
+  const watchError = isWatching ? (jobPollError ?? logTailError) : null
 
   return {
     open: state.open,
-    phase: state.phase,
+    requestState: state.requestState,
     errorMessage: state.errorMessage,
+    logLines: state.logLines,
+    stillRunning: state.stillRunning,
+    job,
+    jobStatus,
+    watchError,
+    isWatching,
+    isTerminal: terminal,
     openDialog,
     setOpen,
     runRetry,

--- a/apps/web/src/hooks/use-queues.ts
+++ b/apps/web/src/hooks/use-queues.ts
@@ -244,6 +244,8 @@ export const queryKeys = {
     ['job', connectionId, queueName, jobId] as const,
   jobLogs: (connectionId: string, queueName: string, jobId: string) =>
     ['job', connectionId, queueName, jobId, 'logs'] as const,
+  jobLogTail: (connectionId: string, queueName: string, jobId: string, start: number) =>
+    ['job', connectionId, queueName, jobId, 'logs', 'tail', start] as const,
   jobStacktraces: (connectionId: string, queueName: string, jobId: string) =>
     ['job', connectionId, queueName, jobId, 'stacktraces'] as const,
   scheduledJobs: (connectionId: string) => ['scheduledJobs', connectionId] as const,
@@ -255,7 +257,7 @@ export const queryKeys = {
   allWorkers: (connectionId: string) => ['workers', connectionId] as const,
 }
 
-function useConnectionIdFromContextOrRoute(): string | undefined {
+export function useConnectionIdFromContextOrRoute(): string | undefined {
   const { currentConnection } = useConnection()
   const { connectionId } = useParams({ strict: false }) as { connectionId?: string }
   return currentConnection?.id ?? connectionId
@@ -438,7 +440,37 @@ export function useJobs(
   })
 }
 
-export function useJob(queueName: string, jobId: string) {
+interface UsePollingQueryOptions {
+  enabled?: boolean
+  refetchInterval?: number | false
+}
+
+export interface JobLogTailResponse {
+  logs: string[]
+  count: number
+  start: number
+  hasMore: boolean
+}
+
+export async function fetchJobLogTail({
+  connectionId,
+  queueName,
+  jobId,
+  start,
+}: {
+  connectionId: string
+  queueName: string
+  jobId: string
+  start: number
+}) {
+  const params = new URLSearchParams()
+  params.set('start', String(start))
+
+  const url = `/api/c/${connectionId}/queues/${encodeURIComponent(queueName)}/jobs/${encodeURIComponent(jobId)}/logs?${params}`
+  return fetchApi<JobLogTailResponse>(url)
+}
+
+export function useJob(queueName: string, jobId: string, options?: UsePollingQueryOptions) {
   const connectionId = useConnectionIdFromContextOrRoute()
 
   return useQuery({
@@ -449,7 +481,8 @@ export function useJob(queueName: string, jobId: string) {
       })
       return handleRes<GetJobResponse>(res)
     },
-    enabled: !!queueName && !!jobId && !!connectionId,
+    enabled: !!queueName && !!jobId && !!connectionId && (options?.enabled ?? true),
+    refetchInterval: options?.refetchInterval ?? false,
   })
 }
 
@@ -476,6 +509,31 @@ export function useJobLogs(queueName: string, jobId: string) {
     getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
     initialPageParam: 1,
     enabled: !!queueName && !!jobId && !!connectionId,
+  })
+}
+
+export function useJobLogTail(
+  queueName: string,
+  jobId: string,
+  start: number | null,
+  options?: UsePollingQueryOptions
+) {
+  const connectionId = useConnectionIdFromContextOrRoute()
+  const enabled =
+    start != null && !!queueName && !!jobId && !!connectionId && (options?.enabled ?? true)
+
+  return useQuery({
+    queryKey: queryKeys.jobLogTail(connectionId ?? '', queueName, jobId, start ?? 0),
+    queryFn: async () => {
+      return fetchJobLogTail({
+        connectionId: connectionId!,
+        queueName,
+        jobId,
+        start: start ?? 0,
+      })
+    },
+    enabled,
+    refetchInterval: options?.refetchInterval ?? false,
   })
 }
 

--- a/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
+++ b/apps/web/src/routes/$orgSlug.c.$connectionId.queues.$queueName_.jobs.$jobId.tsx
@@ -595,17 +595,14 @@ function JobDetailPage() {
         />
       )}
 
-      {/* Retry Job Dialog */}
-      {job && job.status === 'failed' && (
+      {/* Retry Job Dialog - rendered whenever the job exists so it survives
+          the status flipping away from 'failed' once the retry starts */}
+      {job && (
         <RetryJobDialog
-          open={retryDialog.open}
-          onOpenChange={retryDialog.setOpen}
           queueName={queueName}
           jobId={job.id}
           jobName={job.name}
-          phase={retryDialog.phase}
-          errorMessage={retryDialog.errorMessage}
-          onRetry={() => void retryDialog.runRetry()}
+          retry={retryDialog}
         />
       )}
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,35 +1,29 @@
-# UI Redesign — "Signal" ops-console aesthetic
+# Retry Job Modal: live status + streaming logs
 
-Direction: confident, polished, developer-first. Dark-first graphite chrome, hairline
-borders, emerald reserved as the single "signal" accent, Geist Sans + Geist Mono with
-mono discipline for all data (numbers, IDs, keys, eyebrows), sharper radii, tokenized
-status palette.
+## Agreed design (grill-me session)
+- Modal polls job status + logs every 1s until terminal (`completed`/`failed`); `delayed` shows backoff countdown and keeps polling.
+- After 60s non-terminal, show a "still running, safe to close" notice but keep polling.
+- Logs shown are only lines appended after the retry started (snapshot the BullMQ log count before POSTing the retry).
+- Modal closable at any time; job continues server-side.
+- Distinct failure states: retry POST failure (error + Try Again) vs job re-failed (logs + failedReason + Retry Again).
+- Job detail page kept in sync via shared React Query job/log hooks + invalidation on close/terminal.
+- API: add `start` offset mode to `GET .../jobs/:jobId/logs` (BullMQ `getJobLogs(start, end)` native).
+- Scope: single-job modal only; bulk retry dialog untouched.
 
-- [x] Design tokens: rebuild styles.css palette (light + dark), status tokens, radius, fonts, selection/focus/scrollbars
-- [x] Fonts: ship Geist Sans + Geist Mono variable woff2 to public/fonts, @font-face + @theme wiring, preload in index.html
-- [x] Primitives: button, badge, card, input, table, tabs, select, dialog, skeleton polish
-- [x] Shell: sidebar nav (active rail indicator), top bar, eyebrow labels, logo treatment
-- [x] Page headers: replace rainbow gradients with one consistent technical treatment
-- [x] Status colors: tokenize status-badge, queue-table, stat cards, badge success/warning
-- [x] Stragglers: nav-user gradient, theme-color meta, webmanifest
-- [x] Verify: typecheck/lint/build + browser screenshots light & dark
+## Tasks
+- [x] API: `start` query param on logs endpoint (offset tail mode)
+- [x] Web: rework `use-job-retry-dialog.ts` around canonical React Query polling (`useJob` + `useJobLogTail`) instead of custom timers
+- [x] Web: remove redundant retry phase enum; derive running/delayed/success/failed from the actual BullMQ job status
+- [x] Web: rework `retry-job-dialog.tsx` (log stream pane w/ auto-scroll, delayed countdown via RetryCountdown, closable, status-derived footer)
+- [x] Route: render dialog independent of `job.status === 'failed'` so it survives status flips; keep page in sync
+- [x] Rewrite unit tests around request state + polled job status, including log-tail replay guard and no destructive retry side effects
+- [x] Extend E2E: modal shows live phase + log stream pane, closable mid-run
+- [x] Verify: typecheck, unit tests (E2E blocked locally, see review)
 
 ## Review
-
-- 46 files touched, all presentation-layer only (classNames, CSS tokens, fonts, manifest).
-  No business logic, routing, or data-flow changes.
-- New token system in `styles.css`: `--color-status-*` palette (success, active, warning,
-  danger, delayed, priority, neutral), chart palette, `--color-signal` accent, `eyebrow`
-  utility. Light + dark both rebuilt around graphite/paper neutrals.
-- Geist Sans (UI) + Geist Mono (data) self-hosted in `public/fonts`, preloaded in
-  `index.html`; mono + `tabular-nums` applied to all counts, IDs, keys, timestamps.
-- Unified StatCard treatment everywhere: neutral card, colored hairline top accent,
-  eyebrow title, mono semibold value.
-- Page headers consolidated to one technical treatment (icon tile + title), rainbow
-  gradients removed; nav gained an emerald "signal rail" active indicator.
-- Verification: `bun run build` clean; biome format applied to touched files; browser
-  screenshots verified in light and dark across dashboard, queue detail, job detail,
-  workers, analytics, alerts, scheduled jobs, KV explorer, and settings.
-- Pre-existing (not introduced): 4 unit test failures in `settings.test.tsx` and
-  `connection-alerts-workspace.test.tsx` from incomplete `use-alerts` mocks — confirmed
-  failing on baseline with changes stashed.
+- Hook is now a thin retry controller: snapshot log count -> POST retry -> enable `useJob` + `useJobLogTail` with React Query `refetchInterval`. The dialog derives terminal/running/delayed state from the actual BullMQ job status.
+- Page sync uses the canonical job/log query keys and invalidates job, logs, list, and queue summaries on terminal/close. No `setInterval`, manual polling fetches, or duplicated status phase enum remain.
+- Added an offset guard so a replayed log-tail response cannot append duplicate lines; final terminal state triggers one last log-tail refetch to catch logs emitted between ticks.
+- Safety review: retry UI/hook diffs add no `remove`, `delete`, `clean`, `drain`, `discard`, `$delete`, `removeJob`, or `clearLogs` calls. The only mutation remains the existing `useRetryJobs` POST, and the backend retry route still only calls `job.retry()` / `job.retry('completed')`.
+- Verified: web `tsc` clean; focused retry lint clean; 21 focused retry unit tests pass. API touched file lint clean; api `tsc` is still blocked by pre-existing `src/mcp/tools/shared.test.ts` error.
+- E2E: rewrote the retry test but the local env cannot run it — `GET /api/connections` 500s with "Failed to decrypt Redis connection URL" (stale seeded connection encrypted with a different `DURABULL_REDIS_URL_ENCRYPTION_KEY`); fails identically on a clean tree. Baseline "settings page loads" E2E passes. Needs CI (fresh seed) to validate.


### PR DESCRIPTION
## Summary
- Rework the single-job retry modal to watch the retried job through React Query polling and derive UI state from BullMQ job status.
- Add log-tail polling from a snapshot offset so the modal streams only retry-attempt logs and avoids duplicate replayed lines.
- Harden the logs endpoint tail mode and remove the redundant retry phase enum/custom polling loop.

## Test plan
- `cd apps/web && bunx tsc --noEmit`
- `cd apps/web && bunx biome lint src/hooks/use-job-retry-dialog.ts src/hooks/use-queues.ts src/components/retry-job-dialog.tsx src/components/retry-job-dialog.test.tsx src/hooks/use-job-retry-dialog.test.ts`
- `cd apps/web && bunx vitest run src/hooks/use-job-retry-dialog.test.ts src/components/retry-job-dialog.test.tsx --testTimeout=10000`
- `cd apps/api && bunx biome lint src/routes/jobs.ts`

Note: `cd apps/api && bunx tsc --noEmit` is still blocked by an existing unrelated `src/mcp/tools/shared.test.ts` type error.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry Job now shows live status updates and streaming logs in the modal.
  * Added support for viewing log history with smoother pagination while logs are loading.

* **Bug Fixes**
  * Improved retry dialog behavior for delayed, running, success, and failure states.
  * Made job log viewing more reliable by handling invalid pagination values and reducing inconsistent loading states.

* **Tests**
  * Updated automated coverage for the new retry flow and log streaming experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->