### PR TITLE
Show failed job count in Queues nav

### DIFF
--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { formatCompactNumber } from '@/lib/utils'
+
+describe('formatCompactNumber', () => {
+  it('formats queue nav counts with compact lowercase suffixes', () => {
+    expect(formatCompactNumber(5)).toBe('5')
+    expect(formatCompactNumber(30)).toBe('30')
+    expect(formatCompactNumber(350)).toBe('350')
+    expect(formatCompactNumber(1500)).toBe('1.5k')
+    expect(formatCompactNumber(10000)).toBe('10k')
+  })
+})

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -63,3 +63,12 @@ export function formatDuration(ms: number): string {
 export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num)
 }
+
+export function formatCompactNumber(num: number): string {
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  })
+    .format(num)
+    .toLowerCase()
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -44,10 +44,11 @@ import { useAuth } from '@/hooks/use-auth'
 import { useIsElectronShell } from '@/hooks/use-electron-shell'
 import { type Organization, useOrganizations } from '@/hooks/use-organization'
 import { usePageViewTracking } from '@/hooks/use-page-view-tracking'
+import { type UseQueuesOptions, useQueues } from '@/hooks/use-queues'
 import { APP_BUILD_INFO } from '@/lib/app-version'
 import { type NavMatchMode, isNavLinkActive } from '@/lib/nav-link-active'
 import { SESSION_KEYS, type SessionWithActiveOrganization } from '@/lib/session-keys'
-import { cn } from '@/lib/utils'
+import { cn, formatCompactNumber } from '@/lib/utils'
 
 /**
  * Hook to get the current organization slug.
@@ -76,6 +77,7 @@ function useCurrentOrgSlug(): string | undefined {
 }
 
 const USE_DEVTOOLS = false
+const NAV_QUEUE_COUNT_OPTIONS: UseQueuesOptions = { pageSize: 1 }
 
 // Public routes that don't require authentication (auth-related only)
 // Marketing/landing pages are now in the separate docs app
@@ -377,6 +379,7 @@ function RootLayout() {
 function SidebarNav() {
   const { currentConnection } = useConnection()
   const { data: alertSummary } = useAlertSummary()
+  const { data: queuesData } = useQueues(NAV_QUEUE_COUNT_OPTIONS)
   const params = useParams({ strict: false }) as { connectionId?: string }
   const connectionId = currentConnection?.id
   // Get orgSlug from route params or fall back to active organization
@@ -385,6 +388,7 @@ function SidebarNav() {
     () => getOpenAlertCount(alertSummary?.connections, params.connectionId),
     [alertSummary?.connections, params.connectionId]
   )
+  const failedJobsBadgeLabel = formatFailedJobsBadgeLabel(queuesData?.totalJobCounts.failed)
 
   // If no connection or org is selected, we can still show nav but links won't work
   // The index page will handle redirecting to a connection
@@ -394,7 +398,7 @@ function SidebarNav() {
   return (
     <nav className="min-h-0 flex-1 space-y-1 overflow-y-auto p-3">
       <div className="eyebrow mb-2 px-2">Platform</div>
-      <NavLink to={basePath} icon={Layers}>
+      <NavLink to={basePath} icon={Layers} badgeLabel={failedJobsBadgeLabel}>
         Queues
       </NavLink>
       <NavLink to={`${basePath}/alerts`} icon={BellRing} badge={openAlertsBadgeCount}>
@@ -426,6 +430,7 @@ function SidebarNav() {
 function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
   const { currentConnection } = useConnection()
   const { data: alertSummary } = useAlertSummary()
+  const { data: queuesData } = useQueues(NAV_QUEUE_COUNT_OPTIONS)
   const params = useParams({ strict: false }) as { connectionId?: string }
   const connectionId = currentConnection?.id
   // Get orgSlug from route params or fall back to active organization
@@ -434,6 +439,7 @@ function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
     () => getOpenAlertCount(alertSummary?.connections, params.connectionId),
     [alertSummary?.connections, params.connectionId]
   )
+  const failedJobsBadgeLabel = formatFailedJobsBadgeLabel(queuesData?.totalJobCounts.failed)
 
   const basePath =
     orgSlug && connectionId ? `/${orgSlug}/c/${connectionId}` : orgSlug ? `/${orgSlug}` : '/'
@@ -441,7 +447,12 @@ function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
   return (
     <nav className="min-h-0 flex-1 space-y-1 overflow-y-auto p-3">
       <div className="eyebrow mb-2 px-2">Platform</div>
-      <MobileNavLink to={basePath} icon={Layers} onNavigate={onNavigate}>
+      <MobileNavLink
+        to={basePath}
+        icon={Layers}
+        onNavigate={onNavigate}
+        badgeLabel={failedJobsBadgeLabel}
+      >
         Queues
       </MobileNavLink>
       <MobileNavLink
@@ -482,6 +493,7 @@ function MobileNavLink({
   children,
   onNavigate,
   badge,
+  badgeLabel,
   matchMode = 'default',
 }: {
   to: string
@@ -489,6 +501,7 @@ function MobileNavLink({
   children: React.ReactNode
   onNavigate: () => void
   badge?: number
+  badgeLabel?: string
   matchMode?: NavMatchMode
 }) {
   const location = useLocation()
@@ -512,6 +525,9 @@ function MobileNavLink({
           {badge}
         </Badge>
       ) : null}
+      {badgeLabel ? (
+        <span className="font-mono text-xs tabular-nums text-status-danger">{badgeLabel}</span>
+      ) : null}
     </Link>
   )
 }
@@ -521,12 +537,14 @@ function NavLink({
   icon: Icon,
   children,
   badge,
+  badgeLabel,
   matchMode = 'default',
 }: {
   to: string
   icon: React.ComponentType<{ className?: string }>
   children: React.ReactNode
   badge?: number
+  badgeLabel?: string
   matchMode?: NavMatchMode
 }) {
   const location = useLocation()
@@ -549,6 +567,14 @@ function NavLink({
           {badge}
         </Badge>
       ) : null}
+      {badgeLabel ? (
+        <span className="font-mono text-xs tabular-nums text-status-danger">{badgeLabel}</span>
+      ) : null}
     </Link>
   )
+}
+
+function formatFailedJobsBadgeLabel(failedJobs: number | undefined): string | undefined {
+  if (!failedJobs || failedJobs <= 0) return undefined
+  return `(${formatCompactNumber(failedJobs)})`
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -33,3 +33,15 @@ status palette.
 - Pre-existing (not introduced): 4 unit test failures in `settings.test.tsx` and
   `connection-alerts-workspace.test.tsx` from incomplete `use-alerts` mocks — confirmed
   failing on baseline with changes stashed.
+
+## Queue Failed Count Navigation Badge
+
+- [x] Add compact count formatting for failed queue totals.
+- [x] Wire the Platform > Queues nav item to connection-wide failed job totals.
+- [x] Verify formatting examples and type safety.
+
+### Review
+
+- Desktop and mobile Platform navigation now show `Queues (n)` when the selected connection has failed jobs, using connection-wide `totalJobCounts.failed`.
+- Compact formatting matches the requested examples: `5`, `30`, `350`, `1.5k`, `10k`.
+- Verification: focused `utils` unit test passed, web typecheck passed, web lint exited 0 with unrelated existing warnings.


### PR DESCRIPTION
## Summary
- Show the connection-wide failed job total next to Queues in desktop and mobile Platform nav.
- Add reusable compact number formatting for counts like 1.5k and 10k.
- Cover the requested compact formatting examples with a focused unit test.

## Test plan
- bun run --filter @durabull/web test:unit -- src/lib/utils.test.ts
- bun run --filter @durabull/web typecheck
- bun run --filter @durabull/web lint

Linear: none provided.

Made with [Cursor](https://cursor.com)