### PR TITLE
Fix sidebar nav highlighting on nested alerts routes

### DIFF
--- a/apps/web/src/lib/nav-link-active.test.ts
+++ b/apps/web/src/lib/nav-link-active.test.ts
@@ -1,25 +1,36 @@
 import { describe, expect, it } from 'vitest'
 import { isNavLinkActive } from './nav-link-active'
 
+const base = '/acme/c/conn_1'
+
 describe('isNavLinkActive', () => {
   it('returns true for exact path matches', () => {
     expect(isNavLinkActive('/acme/settings', '/acme/settings')).toBe(true)
   })
 
-  it('treats nested routes as active for section match mode', () => {
-    expect(isNavLinkActive('/acme/settings/connections', '/acme/settings', 'section')).toBe(true)
+  it('treats nested routes as active', () => {
+    expect(isNavLinkActive('/acme/settings/connections', '/acme/settings')).toBe(true)
+    expect(isNavLinkActive(`${base}/alerts/rules`, `${base}/alerts`)).toBe(true)
+    expect(isNavLinkActive(`${base}/alerts/rules/rule_1`, `${base}/alerts`)).toBe(true)
   })
 
-  it('does not match direct child routes in default mode', () => {
-    expect(isNavLinkActive('/acme/settings/connections', '/acme/settings')).toBe(false)
+  it('does not match sibling sections', () => {
+    expect(isNavLinkActive(`${base}/alerts`, `${base}/analytics`)).toBe(false)
   })
 
-  it('matches deeper descendants in default mode', () => {
-    expect(
-      isNavLinkActive(
-        '/acme/settings/connections/connection_123/insights',
-        '/acme/settings/connections',
-      ),
-    ).toBe(true)
+  describe('with a matchPath override (Queues link)', () => {
+    it('matches the exact `to` path', () => {
+      expect(isNavLinkActive(base, base, `${base}/queues`)).toBe(true)
+    })
+
+    it('matches within the matchPath section', () => {
+      expect(isNavLinkActive(`${base}/queues/emails`, base, `${base}/queues`)).toBe(true)
+    })
+
+    it('does not match other sections under `to`', () => {
+      expect(isNavLinkActive(`${base}/alerts`, base, `${base}/queues`)).toBe(false)
+      expect(isNavLinkActive(`${base}/alerts/rules`, base, `${base}/queues`)).toBe(false)
+      expect(isNavLinkActive(`${base}/alerts/rules/rule_1`, base, `${base}/queues`)).toBe(false)
+    })
   })
 })

--- a/apps/web/src/lib/nav-link-active.ts
+++ b/apps/web/src/lib/nav-link-active.ts
@@ -1,11 +1,9 @@
-export type NavMatchMode = 'default' | 'section'
-
-export function isNavLinkActive(pathname: string, to: string, matchMode: NavMatchMode = 'default') {
-  if (pathname === to) return true
-  if (!pathname.startsWith(`${to}/`)) return false
-  if (matchMode === 'section') return true
-
-  const parentPath = pathname.replace(/\/[^/]+$/, '')
-  const isDirectChild = parentPath === to
-  return !isDirectChild
+/**
+ * A nav link is active on an exact match of `to`, or anywhere within its
+ * section. `matchPath` overrides the section prefix for links whose `to`
+ * differs from the section they own (e.g. Queues links to the connection
+ * root but owns the `/queues` subtree).
+ */
+export function isNavLinkActive(pathname: string, to: string, matchPath: string = to) {
+  return pathname === to || pathname === matchPath || pathname.startsWith(`${matchPath}/`)
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -46,7 +46,7 @@ import { type Organization, useOrganizations } from '@/hooks/use-organization'
 import { usePageViewTracking } from '@/hooks/use-page-view-tracking'
 import { type UseQueuesOptions, useQueues } from '@/hooks/use-queues'
 import { APP_BUILD_INFO } from '@/lib/app-version'
-import { type NavMatchMode, isNavLinkActive } from '@/lib/nav-link-active'
+import { isNavLinkActive } from '@/lib/nav-link-active'
 import { SESSION_KEYS, type SessionWithActiveOrganization } from '@/lib/session-keys'
 import { cn, formatCompactNumber } from '@/lib/utils'
 
@@ -398,7 +398,12 @@ function SidebarNav() {
   return (
     <nav className="min-h-0 flex-1 space-y-1 overflow-y-auto p-3">
       <div className="eyebrow mb-2 px-2">Platform</div>
-      <NavLink to={basePath} icon={Layers} badgeLabel={failedJobsBadgeLabel}>
+      <NavLink
+        to={basePath}
+        matchPath={`${basePath}/queues`}
+        icon={Layers}
+        badgeLabel={failedJobsBadgeLabel}
+      >
         Queues
       </NavLink>
       <NavLink to={`${basePath}/alerts`} icon={BellRing} badge={openAlertsBadgeCount}>
@@ -416,11 +421,7 @@ function SidebarNav() {
       <NavLink to={`${basePath}/redis-keys`} icon={Database}>
         KV Explorer
       </NavLink>
-      <NavLink
-        to={orgSlug ? `/${orgSlug}/settings` : '/settings'}
-        icon={Settings}
-        matchMode="section"
-      >
+      <NavLink to={orgSlug ? `/${orgSlug}/settings` : '/settings'} icon={Settings}>
         Settings
       </NavLink>
     </nav>
@@ -449,6 +450,7 @@ function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
       <div className="eyebrow mb-2 px-2">Platform</div>
       <MobileNavLink
         to={basePath}
+        matchPath={`${basePath}/queues`}
         icon={Layers}
         onNavigate={onNavigate}
         badgeLabel={failedJobsBadgeLabel}
@@ -479,7 +481,6 @@ function MobileSidebarNav({ onNavigate }: { onNavigate: () => void }) {
         to={orgSlug ? `/${orgSlug}/settings` : '/settings'}
         icon={Settings}
         onNavigate={onNavigate}
-        matchMode="section"
       >
         Settings
       </MobileNavLink>
@@ -494,7 +495,7 @@ function MobileNavLink({
   onNavigate,
   badge,
   badgeLabel,
-  matchMode = 'default',
+  matchPath,
 }: {
   to: string
   icon: React.ComponentType<{ className?: string }>
@@ -502,11 +503,11 @@ function MobileNavLink({
   onNavigate: () => void
   badge?: number
   badgeLabel?: string
-  matchMode?: NavMatchMode
+  matchPath?: string
 }) {
   const location = useLocation()
 
-  const isActive = isNavLinkActive(location.pathname, to, matchMode)
+  const isActive = isNavLinkActive(location.pathname, to, matchPath)
 
   return (
     <Link
@@ -538,18 +539,18 @@ function NavLink({
   children,
   badge,
   badgeLabel,
-  matchMode = 'default',
+  matchPath,
 }: {
   to: string
   icon: React.ComponentType<{ className?: string }>
   children: React.ReactNode
   badge?: number
   badgeLabel?: string
-  matchMode?: NavMatchMode
+  matchPath?: string
 }) {
   const location = useLocation()
 
-  const isActive = isNavLinkActive(location.pathname, to, matchMode)
+  const isActive = isNavLinkActive(location.pathname, to, matchPath)
 
   return (
     <Link


### PR DESCRIPTION
## Summary
- Fixes the sidebar highlighting Queues on `/alerts/rules`, and both Queues and Alerts on rule detail pages
- Replaces the direct-child/descendant heuristic in `isNavLinkActive` with simple section matching (exact `to` or under a section prefix)
- Queues link now passes an explicit `matchPath` of `{basePath}/queues` so it stays active on the queues list and queue detail pages only

## Test plan
- [x] Unit tests updated in `nav-link-active.test.ts` (6 passing)
- [x] Typecheck passes
- [ ] Manually verify Alerts stays highlighted on Rules tab and rule detail pages

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar link highlighting so links now stay active for the correct section and exact destination.
  * Updated navigation behavior for nested pages, including better matching for “Queues” and “Settings” links.
* **New Features**
  * Added support for customizable active-link matching paths in navigation, giving more precise control over when links appear active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->