### PR TITLE
Tighten alerts incidents table into compact row-actions UI

### DIFF
--- a/apps/web/src/components/alerts/alert-event-details-dialog.tsx
+++ b/apps/web/src/components/alerts/alert-event-details-dialog.tsx
@@ -5,6 +5,7 @@ import {
   AlertTypeBadge,
   formatAlertDate,
   getAlertEventDisplayStatus,
+  getSuppressedCount,
 } from '@/components/alerts/alert-primitives'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -65,8 +66,7 @@ function AlertEventDetails({ event }: { event: AlertEventRecord }) {
   const retryMutation = useRetryAlertDelivery()
   const contextEntries = formatContextEntries(event.context)
   const displayStatus = getAlertEventDisplayStatus(event)
-  const suppressedCount =
-    typeof event.context.suppressedCount === 'number' ? event.context.suppressedCount : 0
+  const suppressedCount = getSuppressedCount(event)
 
   async function handleRetry(delivery: AlertDeliveryRecord) {
     try {

--- a/apps/web/src/components/alerts/alert-event-details-dialog.tsx
+++ b/apps/web/src/components/alerts/alert-event-details-dialog.tsx
@@ -1,11 +1,11 @@
 import { ArrowUpRight, Loader2, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
+import { getSuppressedCount } from '@/components/alerts/alert-event-helpers'
 import {
   AlertStatusBadge,
   AlertTypeBadge,
   formatAlertDate,
   getAlertEventDisplayStatus,
-  getSuppressedCount,
 } from '@/components/alerts/alert-primitives'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'

--- a/apps/web/src/components/alerts/alert-event-helpers.ts
+++ b/apps/web/src/components/alerts/alert-event-helpers.ts
@@ -1,0 +1,7 @@
+import type { AlertEventRecord } from '@/hooks/use-alerts'
+
+/** Coalesced-incident count recorded in event context by the suppression pipeline. */
+export function getSuppressedCount(event: Pick<AlertEventRecord, 'context'>): number {
+  const count = event.context.suppressedCount
+  return typeof count === 'number' ? count : 0
+}

--- a/apps/web/src/components/alerts/alert-events-table.test.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.test.tsx
@@ -1,6 +1,7 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactNode } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { AlertEventsTable } from '@/components/alerts/alert-events-table'
 import type { AlertEventRecord } from '@/hooks/use-alerts'
@@ -42,9 +43,24 @@ function createEvent(overrides: Partial<AlertEventRecord> = {}): AlertEventRecor
   }
 }
 
+async function openRowActionsMenu(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Incident actions' }))
+  return screen.findByRole('menu')
+}
+
+// The details dialog mounts a react-query mutation hook when opened.
+function renderTable(ui: ReactElement) {
+  const queryClient = new QueryClient()
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  })
+}
+
 describe('AlertEventsTable', () => {
   it('renders the empty state when no events are present', () => {
-    render(
+    renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[]}
@@ -57,11 +73,11 @@ describe('AlertEventsTable', () => {
     expect(screen.getByText('Everything is quiet.')).toBeInTheDocument()
   })
 
-  it('calls onResolve for firing events and shows the resolving state', async () => {
+  it('calls onResolve from the row menu and shows the resolving state', async () => {
     const user = userEvent.setup()
     const onResolve = vi.fn()
 
-    const { rerender } = render(
+    const { rerender } = renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[createEvent()]}
@@ -86,16 +102,19 @@ describe('AlertEventsTable', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /resolve/i }))
+    await openRowActionsMenu(user)
+    await user.click(screen.getByRole('menuitem', { name: /resolve/i }))
 
     expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({ id: 'event-1' }))
+    // Selecting a menu action must not also trigger the row's details dialog.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('acknowledges firing events and shows rule names when provided', async () => {
     const user = userEvent.setup()
     const onAcknowledge = vi.fn()
 
-    render(
+    renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[createEvent()]}
@@ -109,13 +128,16 @@ describe('AlertEventsTable', () => {
 
     expect(screen.getByText('Delivery failures')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /acknowledge/i }))
+    await openRowActionsMenu(user)
+    await user.click(screen.getByRole('menuitem', { name: /acknowledge/i }))
 
     expect(onAcknowledge).toHaveBeenCalledWith('event-1')
   })
 
-  it('renders acknowledged rows with a warning badge, ack provenance, and no acknowledge action', () => {
-    render(
+  it('renders acknowledged rows with a warning badge, ack provenance, and no acknowledge action', async () => {
+    const user = userEvent.setup()
+
+    renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[
@@ -134,12 +156,16 @@ describe('AlertEventsTable', () => {
 
     expect(screen.getByText('Acknowledged')).toBeInTheDocument()
     expect(screen.getByText(/Ack'd by Sam Operator/)).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /acknowledge/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /resolve/i })).toBeInTheDocument()
+
+    await openRowActionsMenu(user)
+    expect(screen.queryByRole('menuitem', { name: /acknowledge/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /resolve/i })).toBeInTheDocument()
   })
 
-  it('renders suppressed rows subdued with a coalesced count and no actions', () => {
-    render(
+  it('renders suppressed rows subdued with a coalesced count and no actions', async () => {
+    const user = userEvent.setup()
+
+    renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[
@@ -158,13 +184,17 @@ describe('AlertEventsTable', () => {
 
     expect(screen.getByText('suppressed')).toBeInTheDocument()
     expect(screen.getByText('×4')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /acknowledge/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /resolve/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument()
+
+    await openRowActionsMenu(user)
+    expect(screen.queryByRole('menuitem', { name: /acknowledge/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /resolve/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'View details' })).toBeInTheDocument()
   })
 
-  it('exposes a details action for non-firing events', () => {
-    render(
+  it('opens the details dialog from the row menu and shows the resolved subline', async () => {
+    const user = userEvent.setup()
+
+    renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[
@@ -181,6 +211,11 @@ describe('AlertEventsTable', () => {
     )
 
     expect(screen.getByText('Delivered')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument()
+    expect(screen.getByText(/^Resolved /)).toBeInTheDocument()
+
+    await openRowActionsMenu(user)
+    await user.click(screen.getByRole('menuitem', { name: 'View details' }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/alerts/alert-events-table.test.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.test.tsx
@@ -44,13 +44,16 @@ function createEvent(overrides: Partial<AlertEventRecord> = {}): AlertEventRecor
 }
 
 async function openRowActionsMenu(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(screen.getByRole('button', { name: 'Incident actions' }))
+  const trigger = await screen.findByRole('button', { name: 'Incident actions' })
+  await user.click(trigger)
   return screen.findByRole('menu')
 }
 
 // The details dialog mounts a react-query mutation hook when opened.
 function renderTable(ui: ReactElement) {
-  const queryClient = new QueryClient()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
   return render(ui, {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -73,25 +76,27 @@ describe('AlertEventsTable', () => {
     expect(screen.getByText('Everything is quiet.')).toBeInTheDocument()
   })
 
-  it('calls onResolve from the row menu and shows the resolving state', async () => {
-    const user = userEvent.setup()
-    const onResolve = vi.fn()
-
-    const { rerender } = renderTable(
+  it('shows the resolving state on the actions trigger', () => {
+    renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[createEvent()]}
         emptyTitle="No incidents"
         emptyCopy="Everything is quiet."
-        onResolve={onResolve}
+        onResolve={vi.fn()}
         resolvingEventId="event-1"
       />
     )
 
     expect(screen.getByRole('button', { name: /resolving/i })).toBeDisabled()
     expect(screen.getByText('Not sent')).toBeInTheDocument()
+  })
 
-    rerender(
+  it('calls onResolve from the row menu without opening details', async () => {
+    const user = userEvent.setup()
+    const onResolve = vi.fn()
+
+    renderTable(
       <AlertEventsTable
         orgSlug="acme"
         events={[createEvent()]}
@@ -103,7 +108,7 @@ describe('AlertEventsTable', () => {
     )
 
     await openRowActionsMenu(user)
-    await user.click(screen.getByRole('menuitem', { name: /resolve/i }))
+    await user.click(await screen.findByRole('menuitem', { name: /resolve/i }))
 
     expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({ id: 'event-1' }))
     // Selecting a menu action must not also trigger the row's details dialog.
@@ -217,5 +222,22 @@ describe('AlertEventsTable', () => {
     await user.click(screen.getByRole('menuitem', { name: 'View details' }))
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('does not open details when activating the fired-time tooltip trigger', async () => {
+    const user = userEvent.setup()
+
+    renderTable(
+      <AlertEventsTable
+        orgSlug="acme"
+        events={[createEvent()]}
+        emptyTitle="No incidents"
+        emptyCopy="Everything is quiet."
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /ago$/i }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/alerts/alert-events-table.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.tsx
@@ -228,6 +228,7 @@ function AlertEventRow({
             <button
               type="button"
               className="cursor-default rounded-sm text-xs tabular-nums text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              onClick={(clickEvent) => clickEvent.stopPropagation()}
             >
               {formatRelativeAlertTime(event.firedAt)}
             </button>

--- a/apps/web/src/components/alerts/alert-events-table.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.tsx
@@ -1,16 +1,24 @@
 import { Link } from '@tanstack/react-router'
-import { ArrowUpRight, CheckCheck, Loader2, UserCheck } from 'lucide-react'
+import { ArrowUpRight, CheckCheck, Eye, Loader2, MoreHorizontal, UserCheck } from 'lucide-react'
 import { useState } from 'react'
 import { AlertEventDetailsDialog } from '@/components/alerts/alert-event-details-dialog'
 import {
   AlertStatusBadge,
-  AlertTypeBadge,
   formatAlertDate,
   formatRelativeAlertTime,
   getAlertEventDisplayStatus,
+  getAlertTypeMeta,
+  getSuppressedCount,
 } from '@/components/alerts/alert-primitives'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -19,6 +27,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { AlertEventRecord } from '@/hooks/use-alerts'
 import { cn } from '@/lib/utils'
 
@@ -34,6 +43,14 @@ interface AlertEventsTableProps {
   resolvingEventId?: string | null
   onAcknowledge?: (eventId: string) => void
   acknowledgingEventId?: string | null
+}
+
+interface IncidentRowActions {
+  openDetails: () => void
+  resolve?: (event: AlertEventRecord) => void
+  acknowledge?: (eventId: string) => void
+  isResolving: boolean
+  isAcknowledging: boolean
 }
 
 export function AlertEventsTable({
@@ -63,177 +80,217 @@ export function AlertEventsTable({
   const selectedEvent = events.find((event) => event.id === selectedEventId) ?? null
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-border/70 bg-background/70">
-      <AlertEventDetailsDialog
-        event={selectedEvent}
-        open={selectedEvent !== null}
-        onOpenChange={(open) => {
-          if (!open) setSelectedEventId(null)
-        }}
-      />
-      <Table>
-        <TableHeader>
-          <TableRow className="hover:bg-transparent">
-            {showConnectionColumn ? <TableHead>Connection</TableHead> : null}
-            <TableHead>Status</TableHead>
-            <TableHead>Rule</TableHead>
-            <TableHead>Queue</TableHead>
-            <TableHead>Summary</TableHead>
-            <TableHead className="hidden md:table-cell">Delivery</TableHead>
-            <TableHead className="hidden md:table-cell">Fired</TableHead>
-            <TableHead className="w-[140px] text-right">Action</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {events.map((event) => {
-            const isResolving = resolvingEventId === event.id
-            const isAcknowledging = acknowledgingEventId === event.id
-            const displayStatus = getAlertEventDisplayStatus(event)
-            const ruleName = getRuleName?.(event)
-            const suppressedCount =
-              typeof event.context.suppressedCount === 'number' ? event.context.suppressedCount : 0
-
-            return (
-              <TableRow
+    <TooltipProvider delayDuration={200}>
+      <div className="overflow-hidden rounded-2xl border border-border/70 bg-background/70">
+        <AlertEventDetailsDialog
+          event={selectedEvent}
+          open={selectedEvent !== null}
+          onOpenChange={(open) => {
+            if (!open) setSelectedEventId(null)
+          }}
+        />
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              {showConnectionColumn ? <TableHead>Connection</TableHead> : null}
+              <TableHead className="w-[120px]">Status</TableHead>
+              <TableHead className="hidden md:table-cell">Rule</TableHead>
+              <TableHead>Queue</TableHead>
+              <TableHead className="w-full">Summary</TableHead>
+              <TableHead className="hidden md:table-cell">Delivery</TableHead>
+              <TableHead className="hidden text-right md:table-cell">Fired</TableHead>
+              <TableHead className="w-12">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {events.map((event) => (
+              <AlertEventRow
                 key={event.id}
-                className={cn(
-                  'cursor-pointer',
-                  displayStatus === 'firing' && 'border-l-2 border-l-destructive/60',
-                  displayStatus === 'suppressed' && 'opacity-60'
-                )}
-                onClick={() => setSelectedEventId(event.id)}
-              >
-                {showConnectionColumn ? (
-                  <TableCell className="text-sm font-medium">
-                    {connectionNameForEvent?.(event) ?? 'Unknown connection'}
-                  </TableCell>
-                ) : null}
-                <TableCell>
-                  <div className="flex items-center gap-1.5">
-                    <AlertStatusBadge
-                      status={event.status}
-                      acknowledged={displayStatus === 'acknowledged'}
-                      emphasize={displayStatus === 'firing'}
-                    />
-                    {displayStatus === 'suppressed' && suppressedCount > 1 ? (
-                      <Badge variant="secondary">×{suppressedCount}</Badge>
-                    ) : null}
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <div className="space-y-1">
-                    {ruleName ? (
-                      <div className="max-w-[200px] truncate text-sm font-medium">{ruleName}</div>
-                    ) : null}
-                    <AlertTypeBadge type={event.type} compact />
-                  </div>
-                </TableCell>
-                <TableCell className="max-w-[220px]">
-                  <Link
-                    to="/$orgSlug/c/$connectionId/queues/$queueName"
-                    params={{
-                      orgSlug,
-                      connectionId: event.connectionId,
-                      queueName: event.queueName,
-                    }}
-                    className="inline-flex items-center gap-1.5 truncate font-medium hover:text-primary"
-                    onClick={(clickEvent) => clickEvent.stopPropagation()}
-                  >
-                    <span className="truncate">{event.queueName}</span>
-                    <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
-                  </Link>
-                </TableCell>
-                <TableCell className="max-w-[520px]">
-                  <div className="space-y-1">
-                    <p className="line-clamp-2 text-sm font-medium">{event.summary}</p>
-                    {displayStatus === 'acknowledged' ? (
-                      <p className="text-xs text-muted-foreground">
-                        Ack'd by {event.acknowledgedByName ?? 'a teammate'} ·{' '}
-                        {formatRelativeAlertTime(event.acknowledgedAt)}
-                      </p>
-                    ) : null}
-                    {event.resolvedAt && event.status === 'resolved' ? (
-                      <p className="text-xs text-muted-foreground">
-                        Resolved {formatAlertDate(event.resolvedAt)}
-                      </p>
-                    ) : null}
-                  </div>
-                </TableCell>
-                <TableCell className="hidden md:table-cell">
-                  <DeliverySummary event={event} />
-                </TableCell>
-                <TableCell className="hidden text-xs text-muted-foreground md:table-cell">
-                  {formatAlertDate(event.firedAt)}
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex flex-wrap items-center justify-end gap-2">
-                    <Button
-                      type="button"
-                      size="xs"
-                      variant="ghost"
-                      onClick={(clickEvent) => {
-                        clickEvent.stopPropagation()
-                        setSelectedEventId(event.id)
-                      }}
-                    >
-                      Details
-                    </Button>
-                    {displayStatus === 'firing' && onAcknowledge ? (
-                      <Button
-                        type="button"
-                        size="xs"
-                        variant="outline"
-                        onClick={(clickEvent) => {
-                          clickEvent.stopPropagation()
-                          onAcknowledge(event.id)
-                        }}
-                        disabled={isAcknowledging}
-                      >
-                        {isAcknowledging ? (
-                          <>
-                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                            Acknowledging
-                          </>
-                        ) : (
-                          <>
-                            <UserCheck className="mr-1.5 h-3.5 w-3.5" />
-                            Acknowledge
-                          </>
-                        )}
-                      </Button>
-                    ) : null}
-                    {event.status === 'firing' && onResolve ? (
-                      <Button
-                        type="button"
-                        size="xs"
-                        variant="outline"
-                        onClick={(clickEvent) => {
-                          clickEvent.stopPropagation()
-                          onResolve(event)
-                        }}
-                        disabled={isResolving}
-                      >
-                        {isResolving ? (
-                          <>
-                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                            Resolving
-                          </>
-                        ) : (
-                          <>
-                            <CheckCheck className="mr-1.5 h-3.5 w-3.5" />
-                            Resolve
-                          </>
-                        )}
-                      </Button>
-                    ) : null}
-                  </div>
-                </TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                orgSlug={orgSlug}
+                event={event}
+                showConnectionColumn={showConnectionColumn}
+                connectionName={connectionNameForEvent?.(event)}
+                ruleName={getRuleName?.(event)}
+                actions={{
+                  openDetails: () => setSelectedEventId(event.id),
+                  resolve: onResolve,
+                  acknowledge: onAcknowledge,
+                  isResolving: resolvingEventId === event.id,
+                  isAcknowledging: acknowledgingEventId === event.id,
+                }}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function AlertEventRow({
+  orgSlug,
+  event,
+  showConnectionColumn,
+  connectionName,
+  ruleName,
+  actions,
+}: {
+  orgSlug: string
+  event: AlertEventRecord
+  showConnectionColumn: boolean
+  connectionName?: string
+  ruleName?: string
+  actions: IncidentRowActions
+}) {
+  const displayStatus = getAlertEventDisplayStatus(event)
+  const suppressedCount = getSuppressedCount(event)
+  const canAcknowledge = displayStatus === 'firing' && Boolean(actions.acknowledge)
+  const canResolve = event.status === 'firing' && Boolean(actions.resolve)
+  const isActing = actions.isResolving || actions.isAcknowledging
+
+  return (
+    <TableRow
+      className={cn(
+        'group cursor-pointer',
+        displayStatus === 'firing' && 'border-l-2 border-l-destructive/60',
+        displayStatus === 'suppressed' && 'opacity-60'
+      )}
+      onClick={actions.openDetails}
+    >
+      {showConnectionColumn ? (
+        <TableCell className="whitespace-nowrap text-sm font-medium">
+          {connectionName ?? 'Unknown connection'}
+        </TableCell>
+      ) : null}
+      <TableCell className="whitespace-nowrap">
+        <div className="flex items-center gap-1.5">
+          <AlertStatusBadge
+            status={event.status}
+            acknowledged={displayStatus === 'acknowledged'}
+            emphasize={displayStatus === 'firing'}
+          />
+          {displayStatus === 'suppressed' && suppressedCount > 1 ? (
+            <Badge variant="secondary">×{suppressedCount}</Badge>
+          ) : null}
+        </div>
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        {ruleName ? (
+          <span className="block max-w-[180px] truncate text-sm font-medium" title={ruleName}>
+            {ruleName}
+          </span>
+        ) : (
+          <span className="block max-w-[180px] truncate text-sm text-muted-foreground">
+            {getAlertTypeMeta(event.type).label}
+          </span>
+        )}
+      </TableCell>
+      <TableCell className="whitespace-nowrap">
+        <Link
+          to="/$orgSlug/c/$connectionId/queues/$queueName"
+          params={{
+            orgSlug,
+            connectionId: event.connectionId,
+            queueName: event.queueName,
+          }}
+          className="inline-flex max-w-[200px] items-center gap-1 font-medium hover:text-primary"
+          onClick={(clickEvent) => clickEvent.stopPropagation()}
+        >
+          <span className="truncate">{event.queueName}</span>
+          <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </Link>
+      </TableCell>
+      <TableCell className="max-w-0">
+        <p className="truncate text-sm" title={event.summary}>
+          {event.summary}
+        </p>
+        {displayStatus === 'acknowledged' ? (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            Ack'd by {event.acknowledgedByName ?? 'a teammate'} ·{' '}
+            {formatRelativeAlertTime(event.acknowledgedAt)}
+          </p>
+        ) : null}
+        {displayStatus === 'resolved' && event.resolvedAt ? (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            Resolved {formatRelativeAlertTime(event.resolvedAt)}
+          </p>
+        ) : null}
+      </TableCell>
+      <TableCell className="hidden max-w-[180px] md:table-cell">
+        <DeliverySummary event={event} />
+      </TableCell>
+      <TableCell className="hidden whitespace-nowrap text-right md:table-cell">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {/* A real button so keyboard focus reveals the absolute timestamp. */}
+            <button
+              type="button"
+              className="cursor-default rounded-sm text-xs tabular-nums text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            >
+              {formatRelativeAlertTime(event.firedAt)}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">{formatAlertDate(event.firedAt)}</TooltipContent>
+        </Tooltip>
+      </TableCell>
+      <TableCell className="pr-3">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                'h-8 w-8 transition-opacity data-[state=open]:opacity-100',
+                // Hover-reveal only where hovering exists; stay visible on touch devices.
+                isActing
+                  ? 'opacity-100'
+                  : 'opacity-0 focus-visible:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100'
+              )}
+              disabled={isActing}
+              onClick={(clickEvent) => clickEvent.stopPropagation()}
+            >
+              {isActing ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <MoreHorizontal className="h-4 w-4" />
+              )}
+              <span className="sr-only">
+                {actions.isResolving
+                  ? 'Resolving incident'
+                  : actions.isAcknowledging
+                    ? 'Acknowledging incident'
+                    : 'Incident actions'}
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="w-44"
+            onClick={(clickEvent) => clickEvent.stopPropagation()}
+          >
+            <DropdownMenuItem onClick={actions.openDetails}>
+              <Eye className="mr-2 h-4 w-4" />
+              View details
+            </DropdownMenuItem>
+            {canAcknowledge || canResolve ? <DropdownMenuSeparator /> : null}
+            {canAcknowledge ? (
+              <DropdownMenuItem onClick={() => actions.acknowledge?.(event.id)}>
+                <UserCheck className="mr-2 h-4 w-4" />
+                Acknowledge
+              </DropdownMenuItem>
+            ) : null}
+            {canResolve ? (
+              <DropdownMenuItem onClick={() => actions.resolve?.(event)}>
+                <CheckCheck className="mr-2 h-4 w-4" />
+                Resolve
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
   )
 }
 
@@ -245,7 +302,7 @@ function DeliverySummary({ event }: { event: AlertEventRecord }) {
         href={linearDelivery.externalUrl}
         target="_blank"
         rel="noreferrer"
-        className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        className="inline-flex items-center gap-1 whitespace-nowrap text-xs font-medium text-primary hover:underline"
         onClick={(clickEvent) => clickEvent.stopPropagation()}
       >
         {linearDelivery.externalIdentifier ?? 'Linear issue'}
@@ -255,7 +312,10 @@ function DeliverySummary({ event }: { event: AlertEventRecord }) {
   }
   if (linearDelivery?.status === 'failed') {
     return (
-      <span className="text-xs text-destructive">
+      <span
+        className="block truncate text-xs text-destructive"
+        title={linearDelivery.lastError ?? undefined}
+      >
         Linear failed{linearDelivery.lastError ? `: ${linearDelivery.lastError}` : ''}
       </span>
     )
@@ -266,36 +326,39 @@ function DeliverySummary({ event }: { event: AlertEventRecord }) {
     const httpStatus = webhookDelivery.providerMetadata?.httpStatus
     if (webhookDelivery.status === 'delivered') {
       return (
-        <span className="text-xs text-muted-foreground">
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
           Webhook {typeof httpStatus === 'number' ? `HTTP ${httpStatus}` : 'delivered'}
         </span>
       )
     }
     if (webhookDelivery.status === 'failed') {
       return (
-        <span className="text-xs text-destructive">
+        <span
+          className="block truncate text-xs text-destructive"
+          title={webhookDelivery.lastError ?? undefined}
+        >
           Webhook failed{webhookDelivery.lastError ? `: ${webhookDelivery.lastError}` : ''}
         </span>
       )
     }
-    return <span className="text-xs text-muted-foreground">Webhook pending</span>
+    return <span className="whitespace-nowrap text-xs text-muted-foreground">Webhook pending</span>
   }
 
   if (linearDelivery) {
-    return <span className="text-xs text-muted-foreground">Linear pending</span>
+    return <span className="whitespace-nowrap text-xs text-muted-foreground">Linear pending</span>
   }
 
   if (event.deliveries.length > 0) {
     const delivered = event.deliveries.filter((delivery) => delivery.status === 'delivered').length
     return (
-      <span className="text-xs text-muted-foreground">
+      <span className="whitespace-nowrap text-xs text-muted-foreground">
         {delivered}/{event.deliveries.length} delivered
       </span>
     )
   }
 
   return (
-    <span className="text-xs text-muted-foreground">
+    <span className="whitespace-nowrap text-xs text-muted-foreground">
       {event.notificationSentAt ? 'Delivered' : 'Not sent'}
     </span>
   )

--- a/apps/web/src/components/alerts/alert-events-table.tsx
+++ b/apps/web/src/components/alerts/alert-events-table.tsx
@@ -2,13 +2,13 @@ import { Link } from '@tanstack/react-router'
 import { ArrowUpRight, CheckCheck, Eye, Loader2, MoreHorizontal, UserCheck } from 'lucide-react'
 import { useState } from 'react'
 import { AlertEventDetailsDialog } from '@/components/alerts/alert-event-details-dialog'
+import { getSuppressedCount } from '@/components/alerts/alert-event-helpers'
 import {
   AlertStatusBadge,
   formatAlertDate,
   formatRelativeAlertTime,
   getAlertEventDisplayStatus,
   getAlertTypeMeta,
-  getSuppressedCount,
 } from '@/components/alerts/alert-primitives'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'

--- a/apps/web/src/components/alerts/alert-primitives.tsx
+++ b/apps/web/src/components/alerts/alert-primitives.tsx
@@ -67,6 +67,12 @@ export function AlertTypeBadge({
 
 export type AlertEventDisplayStatus = 'firing' | 'acknowledged' | 'resolved' | 'suppressed'
 
+/** Coalesced-incident count recorded in event context by the suppression pipeline. */
+export function getSuppressedCount(event: Pick<AlertEventRecord, 'context'>): number {
+  const count = event.context.suppressedCount
+  return typeof count === 'number' ? count : 0
+}
+
 /** Acknowledged is derived, not a stored status: a firing event with ack provenance. */
 export function getAlertEventDisplayStatus(
   event: Pick<AlertEventRecord, 'status' | 'acknowledgedAt'>

--- a/apps/web/src/components/alerts/alert-primitives.tsx
+++ b/apps/web/src/components/alerts/alert-primitives.tsx
@@ -67,12 +67,6 @@ export function AlertTypeBadge({
 
 export type AlertEventDisplayStatus = 'firing' | 'acknowledged' | 'resolved' | 'suppressed'
 
-/** Coalesced-incident count recorded in event context by the suppression pipeline. */
-export function getSuppressedCount(event: Pick<AlertEventRecord, 'context'>): number {
-  const count = event.context.suppressedCount
-  return typeof count === 'number' ? count : 0
-}
-
 /** Acknowledged is derived, not a stored status: a firing event with ack provenance. */
 export function getAlertEventDisplayStatus(
   event: Pick<AlertEventRecord, 'status' | 'acknowledgedAt'>

--- a/apps/web/src/components/alerts/connection-incidents-view.test.tsx
+++ b/apps/web/src/components/alerts/connection-incidents-view.test.tsx
@@ -150,7 +150,8 @@ describe('ConnectionIncidentsView', () => {
       limit: 100,
     })
 
-    await user.click(screen.getByRole('button', { name: /^resolve$/i }))
+    await user.click(screen.getByRole('button', { name: 'Incident actions' }))
+    await user.click(await screen.findByRole('menuitem', { name: /^resolve$/i }))
 
     await waitFor(() =>
       expect(resolveEventMutateAsyncMock).toHaveBeenCalledWith({
@@ -212,7 +213,8 @@ describe('ConnectionIncidentsView', () => {
 
     expect(screen.getByText('Delivery failures')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /acknowledge/i }))
+    await user.click(screen.getByRole('button', { name: 'Incident actions' }))
+    await user.click(await screen.findByRole('menuitem', { name: /acknowledge/i }))
 
     await waitFor(() => expect(acknowledgeEventMutateAsyncMock).toHaveBeenCalledWith('event-1'))
 

--- a/apps/web/src/components/alerts/org-alerts-feed.test.tsx
+++ b/apps/web/src/components/alerts/org-alerts-feed.test.tsx
@@ -200,8 +200,9 @@ describe('OrgAlertsFeed', () => {
 
     render(<OrgAlertsFeed orgSlug="acme" status="open" onFiltersChange={vi.fn()} />)
 
-    const acknowledgeButtons = screen.getAllByRole('button', { name: /acknowledge/i })
-    await user.click(acknowledgeButtons[0]!)
+    const actionTriggers = screen.getAllByRole('button', { name: 'Incident actions' })
+    await user.click(actionTriggers[0]!)
+    await user.click(await screen.findByRole('menuitem', { name: /acknowledge/i }))
 
     await waitFor(() =>
       expect(acknowledgeEventMutateAsyncMock).toHaveBeenCalledWith({
@@ -219,8 +220,9 @@ describe('OrgAlertsFeed', () => {
 
     render(<OrgAlertsFeed orgSlug="acme" status="open" onFiltersChange={vi.fn()} />)
 
-    const resolveButtons = screen.getAllByRole('button', { name: /resolve/i })
-    await user.click(resolveButtons[0]!)
+    const actionTriggers = screen.getAllByRole('button', { name: 'Incident actions' })
+    await user.click(actionTriggers[0]!)
+    await user.click(await screen.findByRole('menuitem', { name: /resolve/i }))
 
     await waitFor(() =>
       expect(resolveEventMutateAsyncMock).toHaveBeenCalledWith({

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -5,3 +5,18 @@ import { afterEach } from 'vitest'
 afterEach(() => {
   cleanup()
 })
+
+// jsdom lacks layout APIs that Radix popper-based components (dropdowns,
+// tooltips) require, so stub them to let the real components render in tests.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver
+}
+
+if (typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = () => {}
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -40,6 +40,31 @@
   `connection-alerts-workspace.test.tsx` from incomplete `use-alerts` mocks — confirmed
   failing on baseline with changes stashed.
 
+## Incidents Table shadcn Redesign
+
+- [x] Rework `AlertEventsTable` rows into compact single-line layout: status badge, rule name, queue link, truncated summary, delivery, relative fired time.
+- [x] Replace stacked Details/Acknowledge/Resolve buttons with a `⋯` dropdown row-actions menu (matches `queue-table.tsx` pattern); row click keeps opening details.
+- [x] Show absolute fired timestamp via tooltip; relative time in the cell.
+- [x] Update `alert-events-table.test.tsx` for the new action menu.
+- [x] Verify: focused tests + typecheck.
+
+### Review
+
+- Rows went from ~110px (three stacked buttons) to a single ~40px line; summary truncates with a title tooltip, fired time is relative ("19m ago") with an absolute-timestamp tooltip.
+- Row actions consolidated into a hover-revealed `⋯` dropdown (View details / Acknowledge / Resolve), same pattern as `queue-table.tsx`; the trigger swaps to a spinner while a mutation is in flight.
+- Verification: 22 tests across the three alert test files pass, `tsc --noEmit` clean, biome clean on changed files; verified live in browser (menu opens, Acknowledge mutation works, ack'd row shows provenance subline).
+
+### Code-review remediation
+
+- [x] Touch reachability: `⋯` trigger stays visible on coarse pointers (`pointer-coarse:opacity-100`); hover-reveal kept for mouse users.
+- [x] Keyboard a11y: fired-time tooltip trigger is now a real button, so Tab focus reveals the absolute timestamp.
+- [x] Restored the `Resolved {time}` subline on resolved rows (was silently dropped in the redesign).
+- [x] Rule column now shows from `md` (was `lg`), so the org feed keeps rule/type info alongside Delivery/Fired.
+- [x] Data clump: `AlertEventRow`'s five action props bundled into one `IncidentRowActions` object.
+- [x] Primitive obsession/duplication: `getSuppressedCount()` helper in `alert-primitives.tsx`, used by table + details dialog.
+- [x] Removed all three duplicated `dropdown-menu` test mocks; tests now drive the real Radix menu (jsdom `ResizeObserver`/`scrollIntoView` stubs added to `src/test/setup.ts`), including menu open, item visibility per status, the click-propagation guard, and dialog open from the menu.
+- [x] Verify: full web suite 238/238 passing, `tsc --noEmit` clean, biome clean on changed files (14 pre-existing errors elsewhere confirmed on baseline via stash).
+
 ## Queue Failed Count Navigation Badge
 
 - [x] Add compact count formatting for failed queue totals.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -61,7 +61,7 @@
 - [x] Restored the `Resolved {time}` subline on resolved rows (was silently dropped in the redesign).
 - [x] Rule column now shows from `md` (was `lg`), so the org feed keeps rule/type info alongside Delivery/Fired.
 - [x] Data clump: `AlertEventRow`'s five action props bundled into one `IncidentRowActions` object.
-- [x] Primitive obsession/duplication: `getSuppressedCount()` helper in `alert-primitives.tsx`, used by table + details dialog.
+- [x] Primitive obsession/duplication: `getSuppressedCount()` helper in `alert-event-helpers.ts`, used by table + details dialog (kept out of `alert-primitives.tsx` for Fast Refresh).
 - [x] Removed all three duplicated `dropdown-menu` test mocks; tests now drive the real Radix menu (jsdom `ResizeObserver`/`scrollIntoView` stubs added to `src/test/setup.ts`), including menu open, item visibility per status, the click-propagation guard, and dialog open from the menu.
 - [x] Verify: full web suite 238/238 passing, `tsc --noEmit` clean, biome clean on changed files (14 pre-existing errors elsewhere confirmed on baseline via stash).
 


### PR DESCRIPTION
## Summary
- Redesign the Alerts incidents table into single-line rows with a `⋯` dropdown for View details / Acknowledge / Resolve (shadcn pattern, matching queue-table).
- Fix a11y gaps from review: always-visible trigger on coarse pointers, keyboard-focusable fired-time tooltip, restored `Resolved {time}` subline, Rule column from `md`.
- Drop triplicated dropdown mocks; tests drive the real Radix menu (with jsdom stubs) and share `getSuppressedCount` / `IncidentRowActions`.

## Test plan
- [ ] Open connection Alerts → Incidents and confirm rows are single-line with truncated summary
- [ ] On desktop: hover a row → `⋯` appears; open menu and Acknowledge / Resolve a firing incident
- [ ] On touch / narrow viewport: `⋯` stays visible without hover; actions still work
- [ ] Tab to Fired timestamp and confirm absolute time tooltip appears on focus
- [ ] Confirm resolved rows show a `Resolved …` subline under Summary
- [ ] Confirm Rule column is visible at `md` and up
- [ ] `bunx vitest run` in `apps/web` (238 tests) and `tsc --noEmit`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the incidents table with compact rows and a three-dot actions menu.
  * Added relative fired times with tooltips showing exact timestamps.
  * Enabled row-click access to incident details.
  * Improved delivery status display, including error tooltips and external links.
  * Added clearer handling for suppressed incident counts and statuses.

* **Bug Fixes**
  * Restricted incident actions based on event status.
  * Improved loading and disabled states while acknowledging or resolving incidents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->